### PR TITLE
Update copyright links

### DIFF
--- a/epub33/common/copyright.html
+++ b/epub33/common/copyright.html
@@ -1,5 +1,5 @@
 <p class="copyright">
-	<a href="https://www.w3.org/policies/#copyright">Copyright</a> © 1999-2023 
+	<a href="https://www.w3.org/policies/#copyright">Copyright</a> © 1999-%thisyear%
 	<a href="https://www.idpf.org">International Digital Publishing Forum</a>
 	and
 	<a href="https://www.w3.org/">World Wide Web Consortium</a>. 

--- a/epub33/common/copyright.html
+++ b/epub33/common/copyright.html
@@ -1,11 +1,11 @@
 <p class="copyright">
-	<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-%thisyear%
-	<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+	<a href="https://www.w3.org/policies/#copyright">Copyright</a> © 1999-2023 
+	<a href="https://www.idpf.org">International Digital Publishing Forum</a>
 	and
-	<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-	<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-	<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-	<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-	<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-		title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+	<a href="https://www.w3.org/">World Wide Web Consortium</a>. 
+	<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> 
+	<a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, 
+	<a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and 
+	<a rel="license" href="https://www.w3.org/copyright/software-license-2023/"
+		title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
 </p>

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -8,8 +8,8 @@
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub-wg",
+				group: "pm",
+				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				noRecTrack: true,
 				shortName: "epub-a11y-eaa-mapping",

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -9,8 +9,8 @@
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
-                group: "epub",
-                wgPublicList: "public-epub-wg",
+                group: "pm",
+                wgPublicList: "public-pm-wg",
                 specStatus: "ED",
 				noRecTrack: true,
                 shortName: "epub-aria-authoring-11",

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -9,8 +9,8 @@
 		<script class="remove">
       	// <![CDATA[
           var respecConfig = {
-              group: "epub",
-              wgPublicList: "public-epub-wg",
+              group: "pm",
+              wgPublicList: "public-pm-wg",
               specStatus: "ED",
               noRecTrack: true,
               shortName: "epubcfi",

--- a/epub33/locators/index.html
+++ b/epub33/locators/index.html
@@ -10,8 +10,8 @@
 			//<![CDATA[
             var respecConfig = {
                 format: "markdown",
-                group: "epub",
-                wgPublicList: "public-epub-wg",
+                group: "pm",
+                wgPublicList: "public-pm-wg",
                 specStatus: "ED",
                 shortName: "epub-locators",
                 edDraftURI: "https://w3c.github.io/epub-specs/epub33/locators/",

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -10,8 +10,8 @@
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
-                group: "epub",
-                wgPublicList: "public-epub-wg",
+                group: "pm",
+                wgPublicList: "public-pm-wg",
                 specStatus: "ED",
                 shortName: "epub-multi-rend-11",
                 edDraftURI: "https://w3c.github.io/epub-specs/epub33/multi-rend/",

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -12,8 +12,8 @@
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub-wg",
+				group: "pm",
+				wgPublicList: "public-pm-wg",
 				specStatus: "NOTE",
 				noRecTrack: true,
 				shortName: "epub-overview-33",

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -10,8 +10,8 @@
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub3",
+				group: "pm",
+				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				shortName: "epub-ssv-11",
 				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -10,8 +10,8 @@
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub3",
+				group: "pm",
+				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				shortName: "epub-tts-10",
 				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",


### PR DESCRIPTION
The accessibility guidelines failed to build/deploy because the URLs used in the copyright have changed: https://github.com/w3c/epub-specs/actions/runs/7145045877/job/19459898614#step:3:720

This PR will fix the links, but I'm concerned that because the file is in /common it will trigger all the notes to be republished. Do we just live with that?