### PR TITLE
Removed Luc as editor for the eu mapping

### DIFF
--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -16,7 +16,21 @@
 				edDraftURI: "https://w3c.github.io/epub-specs/epub33/epub-a11y-eaa-mapping/",
 				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
                 copyrightStart: "2021",
-				editors:[
+				editors: [
+					{
+						name: "Cristina Mussinelli",
+						company: "Fondazione LIA",
+						companyURL: "https://www.fondazionelia.org",
+						w3cid: 66100
+					},
+					{
+						name: "Gregorio Pellegrino",
+						company: "Fondazione LIA",
+						companyURL: "https://www.fondazionelia.org",
+						w3cid: 97111
+					}
+				],
+				authors:[
 					{
 						name: "Cristina Mussinelli",
 						company: "Fondazione LIA",

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -30,23 +30,11 @@
 						w3cid: 97111
 					}
 				],
-				authors:[
-					{
-						name: "Cristina Mussinelli",
-						company: "Fondazione LIA",
-						companyURL: "https://www.fondazionelia.org",
-						w3cid: 66100
-					},
+				formerEditors :[
 					{
 						name: "Luc Audrain",
 						company: "Invited Expert",
 						w3cid: 65303
-					},
-					{
-						name: "Gregorio Pellegrino",
-						company: "Fondazione LIA",
-						companyURL: "https://www.fondazionelia.org",
-						w3cid: 97111
 					}
 				],
 				includePermalinks: true,


### PR DESCRIPTION
The republication of the Note was rejected, because each editor must be member of the WG. To get the publication through this Thursday, I have created a new field for "authors", with Cristina, Luc, and Gregorio, and the "editors" field only refers to Cristina and Gregorio.

We can modify this later if we want, keeping the publication constraint in mind. But this setup reflects the re-publication of the Note under the PM WG's auspices. 