### PR TITLE
[FXLA11Y] Adding Reading System Guidance 

### DIFF
--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -675,42 +675,130 @@ a textual description to aid in accessibility.
         <section id="rs-a11y-intro">
             <h3>Introduction</h3>
 
-            <p>An EPUB reading system can take many forms. It might have a visual display area for rendering the content to users, for example, or it might only provide audio playback of the content. Therefore, there is no single set of rules that applies to all reading systems.</p>
+            <p>An EPUB reading system can take many forms. It might have a small or big visual display area for visually rendering the content to users, or it might only provide audio playback or tactile display. It can be dedicated to the EPUB format or handle many formats. It can depend on an operating system ecosystem that includes assistive technologies or be self-sufficient on a dedicated reading device. There is no single set of rules that applies to all reading systems, and this section presents the most important aspects of reading a fixed layout publication to take into consideration.</p>
+
+            <p>This section is composed of three parts:</p>
+
+            <ul>
+                <li>a general statement about information to provide a supported level of accessibility in fixed layout;</li>
+                <li>a description of minimal requirements for accessibility of fixed layout presentation;</li>
+                <li>a description of extended possibilities for proposed alternate renderings of the content to fit most users’ needs.</li>
+            </ul>
+        </section>
+
+        <section id="rs-a11y-info">
+            <h3>Reading system support of fixed layout content</h3>
+
+            <p>As fixed layout files are not fully supported by all reading systems but may be displayed without rendering the content as specified, information about what features are supported should be given to the user. This precaution is important to avoid deception of the user and misunderstandings about the format and its capabilities.</p>
+
+            <p>For example, a user could be informed whether the reading system:</p>
+
+            <ul>
+                <li>Fully supports fixed layout content, including accessibility features</li>
+                <li>Fully supports fixed layout content, but does not support accessibility features</li>
+                <li>Does not fully support fixed layout content, and reading experience may be poor</li>
+                <li>Does not support the rendering of fixed layout content, but will display fallbacks if provided</li>
+            </ul>
         </section>
 
         <section id="rs-a11y-requirements">
             <h3>Reading system accessibility requirements</h3>
 
+            <p>Any reading system must take into consideration the recommendations listed in the <a href="https://www.w3.org/TR/epub-rs-33/#sec-accessibility">Accessibility section</a> of the EPUB Reading Systems 3.3 document [[epub-rs-33]].</p>
+
+            <p>Fixed layout EPUBs are composed of a large variety of EPUB features, often using an extended set in comparison to reflowable EPUBs. To ensure accessibility in the reading system, this list of recommendations should be considered:</p>
+
             <ul>
-                <li>A reading system should support an EPUB's table of contents, page list, and landmarks.</li>
-                <li>A reading system should enable access to the content of each page to assistive technologies.</li>
-                <li>A reading system should support fixed layout SVG pages.</li>
-                <li>A reading system should enable resizing a page up to 200 percent without assistive technology and without losing content or functionality.</li>
-                <li>A reading system should enable the display of an image full screen.</li>
-                <li>A reading system should enable access to alternative text and complex image descriptions.</li>
-                <li>A reading system should support EPUB Media Overlays.</li>
-                <li>A reading system should display the accessibility metadata provided in an EPUB.</li>
+                <li>display the accessibility metadata provided in the EPUB;</li>
+                <li>enable use of assistive technologies;</li>
+                <li>support EPUB navigation;</li>
+                <li>enable resizing a page up to 200 per cent;</li>
+                <li>enable the display of an image full screen;</li>
+                <li>enable access to alternative text and extended descriptions;</li>
+                <li>support EPUB Media Overlays;</li>
+                <li>support DRM formats that do not interfere with accessibility.</li>
             </ul>
+
+            <section id="rs-a11y-requirements-metadata">
+                <h4>Display the accessibility metadata</h4>
+
+                <p>A reading system should provide information on accessibility metadata provided by the EPUB file in the OPF. Guidance for key information and proposed wordings are provided by the W3C Publishing Community Group Accessibility taskforce report: <a href="https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/index.html">User Experience Guide for Displaying Accessibility Metadata 2.0</a>.</p>
+            </section>
+
+            <section id="rs-a11y-requirements-at">
+                <h4>Enable use of assistive technologies</h4>
+
+                <p>Assistive technologies are user agents that help users with specific needs to get access and interact with the content. They are often used in combination with a reading system and an operating system, therefore particular attention must be provided to make sure no blocking happens.</p>
+
+                <p>This support happens through API integration, ensuring that the accessibility tree, including support for roles, states and properties, is exposed to the underlying operating system's accessibility API. This means that users can fully interact with the content when using assistive technologies. Reading system developers also need to integrate the accessibility properties and values provided by the Accessible Rich Internet Applications 1.1 [[wai-aria-1.1]] and Digital Publishing WAI-ARIA 1.1 [[dpub-aria-1.1]] recommendations.</p>
+
+                <p>The User Agent Accessibility Guidelines [[UAAG20]] also provide information on building user agents that integrate with assistive technologies.</p>
+            </section>
+
+            <section id="rs-a11y-requirements-nav">
+                <h4>Support EPUB navigation</h4>
+
+                <p>Navigation within a file provides the reader with the ability to reach portions and points of a document. It is important for every user and becomes crucial when one cannot depend on visual styling to figure out the divisions of a document, like pages, sections or headings.</p>
+
+                <p>The EPUB Reading Systems 3.3 [[epub-rs-33]] recommendation has a dedicated section about Navigation document processing. Regarding fixed layout files, pagination is often the main reference, therefore supporting page lists should not be avoided. Authored tables of content and landmarks are also important as they represent navigation options the publishers consider meaningful.</p>
+            </section>
+
+            <section id="rs-a11y-requirements-resize">
+                <h4>Enable resizing a page</h4>
+
+                <p>As the purpose of fixed layout is often the representation of the printed page, with constraints on viewport and display, a reading system with an accessible fixed layout reading experience must enable zooming of the page. This must be possible without assistive technology and guarantee that no content or functionality is lost.</p>
+
+                <p>Resizing a page should not affect the original proportions, acting like a magnifying glass and should allow the user to zoom in at least 200 percent.</p>
+            </section>
+
+            <section id="rs-a11y-requirements-page">
+                <h4>Enable fullscreen image display</h4>
+
+                <p>Fixed Layout pages are generally composed of one or more images, therefore it should be possible to view each of them fullscreen.</p>
+            </section>
+
+            <section id="rs-a11y-requirements-alt">
+                <h4>Enable access to alternative text and extended descriptions</h4>
+
+                <p>Alternative text is usually hidden from visual reading and exposed to assistive technologies and non-visual reading methods like text to speech. The addition of visual display for those contents should be considered carefully as, in complex layouts including overlapping images, it may lead to overlays masking content.</p>
+
+                <p>Extended descriptions, including long and structured content that cannot be authored as <code>alt</code> attributes, are usually provided as links to appendices or included into foldable elements like <code>details</code>. Even if they are not often present in fixed layout due to the complexity of authoring them, reading systems must make sure that interactions are available.</p>
+            </section>
+
+            <section id="rs-a11y-requirements-mo">
+                <h4>Support EPUB Media Overlays</h4>
+
+                <p>Often used in educational or children's literature context, fixed layout EPUBs can contain synchronized audio narration as defined in <a href="https://www.w3.org/TR/epub-33/#sec-media-overlays">EPUB 3.3 Section 9</a>. Supporting this feature is highly recommended for reading systems.</p>
+
+                <p>Recommendations for media overlay support in reading systems is provided in the EPUB Reading Systems 3.3 <a href="https://www.w3.org/TR/epub-rs-33/#sec-media-overlays">Media Overlay processing</a> section.</p>
+            </section>
+
+            <section id="rs-a11y-requirements-drm">
+                <h4>Support non-breaking content protection methods</h4>
+
+                <p>Despite all efforts provided to ensure that a reading system offers rich accessibility features for  fixed layout content, a file may become inaccessible due to content protection restrictions blocking access to accessibility APIs. Reading system developers must ensure that the protection method used preserves all the accessibility features described in this document.</p>
+
+                <p>If this is not the case, users must be informed of the limitations created by the protection method used to protect the file.</p>
+            </section>
         </section>
 
-        <section id="rs-a11y-display-html">
-            <h3>How to best display HTML content</h3>
-        </section>
+        <section id="rs-a11y-alt-rendering">
+            <h3>Alternative rendering methods</h3>
 
-        <section id="rs-a11y-display-svg">
-            <h3>How to best display SVG content</h3>
-        </section>
+            <p>While fixed layout formatting is often used to represent highly visual content, not all reading systems support visual display, and when visual display is available, screen sizes may be limited. Therefore, many reading systems might avoid supporting fixed layout content due to concerns about a poor reading experience. In addition to concerns about rendering, it must also be considered that many users face difficulties consuming and navigating complex fixed layout content. Alternative rendering methods should be considered as a replacement or addition to fixed layout rendering.</p>
 
-        <section id="rs-a11y-display-image">
-            <h3>How to best display image-based content</h3>
-        </section>
+            <p>If the fixed layout publication does not conform to the recommendations made in this document, or WCAG [[wcag2]], providing alternate renderings of the content may result in an unusable or poor reading experience.Content that is not formatted in conformance with WCAG may result in output that has an incorrect reading order, broken sentences, or choppy pronounciation. The user should be informed if the content does not have accessibility metadata that would provide clarity on whether alternate renderings are supported, such as <code>dcterms:conformsTo</code> with a value for WCAG, <code>readingOrder</code>, or <code>ttsMarkup</code>.</p>
 
-        <section id="rs-a11y-features">
-            <h3>Accessibility features for reading systems</h3>
-        </section>
+            <section id="rs-a11y-alt-rendering-tts">
+                <h4>TTS rendering of the content</h4>
 
-        <section id="rs-a11y-scripting">
-            <h3>Scripting</h3>
+                <p>Not all reading systems are built on an operating system providing assistive technology and not all readers with specific needs related to reading impairments are comfortable with using complex assistive technologies. Therefore text to speech (TTS) functionality is a strong requirement for a reading system claiming to provide fixed layout accessibility support.</p>
+
+                <p>How a reading system implements TTS will depend on multiple factors, including platform, underlying operating system, or technical feasbility. There are a variety of TTS APIs and speech engines available. An example is the <a href="https://wicg.github.io/speech-api/">Web Speech API</a> from W3C Web Platform Incubator Community Group. Reading system developers can test their support of TTS with Epubtest.org's <a href="https://epubtest.org/test-books/read-aloud">Fundamental Accessibility Tests Read Aloud</a>.</p>
+
+                <p>The <a href="https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te">Accessible Name and Description Computation</a> draft specification is another useful reference in implementing a text to speech experience.</p>
+            </section>
+            
         </section>
     </section>
 </body>

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -794,11 +794,11 @@ a textual description to aid in accessibility.
 
                 <p>Not all reading systems are built on an operating system providing assistive technology and not all readers with specific needs related to reading impairments are comfortable with using complex assistive technologies. Therefore text to speech (TTS) functionality is a strong requirement for a reading system claiming to provide fixed layout accessibility support.</p>
 
-                <p>How a reading system implements TTS will depend on multiple factors, including platform, underlying operating system, or technical feasbility. There are a variety of TTS APIs and speech engines available. An example is the <a href="https://wicg.github.io/speech-api/">Web Speech API</a> from W3C Web Platform Incubator Community Group. Reading system developers can test their support of TTS with Epubtest.org's <a href="https://epubtest.org/test-books/read-aloud">Fundamental Accessibility Tests Read Aloud</a>.</p>
+                <p>How a reading system implements TTS will depend on multiple factors, including platform, underlying operating system, or technical feasibility. There are a variety of TTS APIs and speech engines available. An example is the <a href="https://wicg.github.io/speech-api/">Web Speech API</a> from W3C Web Platform Incubator Community Group. Reading system developers can test their support of TTS with Epubtest.org's <a href="https://epubtest.org/test-books/read-aloud">Fundamental Accessibility Tests Read Aloud</a>.</p>
 
                 <p>The <a href="https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te">Accessible Name and Description Computation</a> draft specification is another useful reference in implementing a text to speech experience.</p>
             </section>
-            
+
         </section>
     </section>
 </body>

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -716,7 +716,8 @@ a textual description to aid in accessibility.
                 <li>enable the display of an image full screen;</li>
                 <li>enable access to alternative text and extended descriptions;</li>
                 <li>support EPUB Media Overlays;</li>
-                <li>support DRM formats that do not interfere with accessibility.</li>
+                <li>support DRM formats that do not interfere with accessibility;</li>
+                <li>support fallbacks.</li>
             </ul>
 
             <section id="rs-a11y-requirements-metadata">
@@ -741,6 +742,15 @@ a textual description to aid in accessibility.
                 <p>Navigation within a file provides the reader with the ability to reach portions and points of a document. It is important for every user and becomes crucial when one cannot depend on visual styling to figure out the divisions of a document, like pages, sections or headings.</p>
 
                 <p>The EPUB Reading Systems 3.3 [[epub-rs-33]] recommendation has a dedicated section about Navigation document processing. Regarding fixed layout files, pagination is often the main reference, therefore supporting page lists should not be avoided. Authored tables of content and landmarks are also important as they represent navigation options the publishers consider meaningful.</p>
+
+                <p>WCAG [[wcag2]] has several success criteria relating to navigation:</p>
+
+                <ul>
+                    <li>1.3.1 Info and Relationships (A)</li>
+                    <li>2.4.4 Link Purpose (In Context) (A)</li>
+                    <li>2.5.3 Label in Name (A)</li>
+                    <li>3.2.3 Consistent Navigation (AA)</li>
+                </ul>
             </section>
 
             <section id="rs-a11y-requirements-resize">
@@ -749,12 +759,19 @@ a textual description to aid in accessibility.
                 <p>As the purpose of fixed layout is often the representation of the printed page, with constraints on viewport and display, a reading system with an accessible fixed layout reading experience must enable zooming of the page. This must be possible without assistive technology and guarantee that no content or functionality is lost.</p>
 
                 <p>Resizing a page should not affect the original proportions, acting like a magnifying glass and should allow the user to zoom in at least 200 percent.</p>
+
+                <p>The following Success Criteria relate to the visual adjustability of content:</p>
+
+                <ul>
+                    <li>1.3.4 Orientation (AA)</li>
+                    <li>1.4.4 Resize Text (AA)</li>
+                </ul>
             </section>
 
             <section id="rs-a11y-requirements-page">
                 <h4>Enable fullscreen image display</h4>
 
-                <p>Fixed Layout pages are generally composed of one or more images, therefore it should be possible to view each of them fullscreen.</p>
+                <p>Fixed Layout pages generally include one or more images, therefore it should be possible to view each of them fullscreen.</p>
             </section>
 
             <section id="rs-a11y-requirements-alt">
@@ -763,6 +780,15 @@ a textual description to aid in accessibility.
                 <p>Alternative text is usually hidden from visual reading and exposed to assistive technologies and non-visual reading methods like text to speech. The addition of visual display for those contents should be considered carefully as, in complex layouts including overlapping images, it may lead to overlays masking content.</p>
 
                 <p>Extended descriptions, including long and structured content that cannot be authored as <code>alt</code> attributes, are usually provided as links to appendices or included into foldable elements like <code>details</code>. Even if they are not often present in fixed layout due to the complexity of authoring them, reading systems must make sure that interactions are available.</p>
+
+                <p>WCAG [[wcag2]] has several success criteria that apply to the presentation and accessibility of images:</p>
+
+                <ul>
+                    <li>1.1.1 Non-text Content (A)</li>
+                    <li>1.4.1 Use of Color (A)</li>
+                    <li>1.4.5 Images of Text (AA)</li>
+                    <li>1.4.11 Non-text Contrast (AA)</li>
+                </ul>
             </section>
 
             <section id="rs-a11y-requirements-mo">
@@ -780,6 +806,12 @@ a textual description to aid in accessibility.
 
                 <p>If this is not the case, users must be informed of the limitations created by the protection method used to protect the file.</p>
             </section>
+
+            <section id="rs-a11y-requirements-fallbacks">
+                <h4>Support fallbacks</h4>
+
+                <p>In cases where the EPUB creator has included fallbacks for potentially unsupported content (e.g. MathML, audio, video), the reading system should support fallbacks. EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section.</p>
+            </section>
         </section>
 
         <section id="rs-a11y-alt-rendering">
@@ -787,7 +819,7 @@ a textual description to aid in accessibility.
 
             <p>While fixed layout formatting is often used to represent highly visual content, not all reading systems support visual display, and when visual display is available, screen sizes may be limited. Therefore, many reading systems might avoid supporting fixed layout content due to concerns about a poor reading experience. In addition to concerns about rendering, it must also be considered that many users face difficulties consuming and navigating complex fixed layout content. Alternative rendering methods should be considered as a replacement or addition to fixed layout rendering.</p>
 
-            <p>If the fixed layout publication does not conform to the recommendations made in this document, or WCAG [[wcag2]], providing alternate renderings of the content may result in an unusable or poor reading experience.Content that is not formatted in conformance with WCAG may result in output that has an incorrect reading order, broken sentences, or choppy pronounciation. The user should be informed if the content does not have accessibility metadata that would provide clarity on whether alternate renderings are supported, such as <code>dcterms:conformsTo</code> with a value for WCAG, <code>readingOrder</code>, or <code>ttsMarkup</code>.</p>
+            <p>If the fixed layout publication does not conform to the recommendations made in this document, or WCAG [[wcag2]], providing alternate renderings of the content may result in an unusable or poor reading experience. Content that is not formatted in conformance with WCAG may result in output that has an incorrect reading order, broken sentences, or choppy pronounciation. The user should be informed if the content does not have accessibility metadata that would provide clarity on whether alternate renderings are supported, such as <code>dcterms:conformsTo</code> with a value for WCAG, or metadata values that conform to properties like <a href="https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/#supports-nonvisual-reading">Supports nonvisual reading</a> from the <a href="https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/">User Experience Guide for Displaying Accessibility Metadata</a>.</p>
 
             <section id="rs-a11y-alt-rendering-tts">
                 <h4>TTS rendering of the content</h4>


### PR DESCRIPTION
Adding Gautier's section on reading system guidance. I made some editorial changes, and have opted not to include some sections that were in the original document. 

I think for now we need to avoid mentioning features that don't yet exist (converting FXL to reflow), as I don't want to confuse publishers or any other readers (like the EU commission). I do think the ideas and concepts mentioned are worth keeping and exploring elsewhere. 

Open to discussing it though! 