### PR TITLE
Fix example 47 description

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4761,7 +4761,8 @@ XHTML:
 							href="#record">linked metadata records</a>.</p>
 
 					<aside class="example" title="Specifying linked records">
-						<p>In this example, linked ONIX and JSON-LD records are included in the EPUB container.</p>
+						<p>In this example, an ONIX record is hosted remotely while a JSON-LD record is included in the
+							EPUB container.</p>
 
 						<pre>&lt;metadata …&gt;
    &lt;link rel="record"


### PR DESCRIPTION
Corrects the description to note that the onix record is hosted remotely.

Fixes #2614


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2615.html" title="Last updated on Apr 30, 2024, 1:36 PM UTC (b536a69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2615/a171b4a...b536a69.html" title="Last updated on Apr 30, 2024, 1:36 PM UTC (b536a69)">Diff</a>