### PR TITLE
Minor edit to remote resources definition

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -572,8 +572,8 @@
 						<dfn class="export">remote resource</dfn>
 					</dt>
 					<dd>
-						<p>A [=publication resource=] that is located outside of the [=EPUB container=], typically, but
-							not necessarily, on the web.</p>
+						<p>A [=publication resource=] that is located outside of the [=EPUB container=], typically on
+							the web.</p>
 						<p>Publication resources within the EPUB container are referred to as [=container
 							resources=].</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for media type specific rules for resource


### PR DESCRIPTION
Removes the redundant "but not necessarily" from the definition.

Fixes #2610


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2616.html" title="Last updated on Apr 30, 2024, 1:44 PM UTC (0347a74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2616/a171b4a...0347a74.html" title="Last updated on Apr 30, 2024, 1:44 PM UTC (0347a74)">Diff</a>