### PR TITLE
Clarify nav doc types are defined by structural semantics in their epub:type attributes

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6816,9 +6816,11 @@ No Entry</pre>
 				<section id="sec-nav-toc">
 					<h4>The <code>toc nav</code> element </h4>
 
-					<p>The <code>toc nav</code> element defines the primary navigational hierarchy. It conceptually
-						corresponds to a table of contents in a printed work (i.e., it provides navigation to the major
-						structural sections of the publication).</p>
+					<p>The primary navigational hierarchy of an [=EPUB publication=] is defined in a [^nav^] element
+						[[html]] whose [^/epub:type^] attribute set to the value "<a data-cite="epub-ssv-11#toc-1"
+							>toc</a>" [[epub-ssv-11]] (i.e., the <code>toc nav</code> element). This element
+						conceptually corresponds to a table of contents in a printed work &#8212; it provides navigation
+						to the major structural sections of the publication.</p>
 
 					<p>[=EPUB creators=] SHOULD order the references in the <code>toc nav</code> element such that they
 						reflect both:</p>
@@ -6839,9 +6841,13 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L162,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L168">
 					<h4>The <code>page-list nav</code> element </h4>
 
-					<p>The <code>page-list</code> element provides navigation to static page boundaries in the content.
-						These boundaries may correspond to a statically paginated source such as print or may be defined
-						exclusively for the [=EPUB publication=].</p>
+					<p>The page list provides navigation to static page boundaries in the content. These boundaries may
+						correspond to a statically paginated source such as print or may be defined exclusively for the
+						[=EPUB publication=].</p>
+
+					<p>The page list is defined in a [^nav^] element [[html]] whose [^/epub:type^] attribute is set to
+						the value "<a data-cite="epub-ssv-11#page-list">page-list</a>" [[epub-ssv-11]] (i.e., the
+							<code>page-list nav</code> element).</p>
 
 					<p>The <code>page-list nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT
 						occur more than once.</p>
@@ -6858,9 +6864,13 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L199,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L205,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L213,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L221,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L227">
 					<h4>The <code>landmarks nav</code> element</h4>
 
-					<p>The <code>landmarks nav</code> element identifies fundamental structural components in the
-						content to enable [=reading systems=] to provide the user efficient access to them (e.g.,
-						through a dedicated button in the user interface).</p>
+					<p>Landmarks identify fundamental structural components of the content to enable [=reading systems=]
+						to provide the user efficient access to them (e.g., through a dedicated button in the user
+						interface).</p>
+
+					<p>Landmarks are defined in a [^nav^] element [[html]] whose [^/epub:type^] attribute is set to the
+						value "<a data-cite="epub-ssv-11#landmarks">landmarks</a>" [[epub-ssv-11]] (i.e., the
+							<code>landmarks nav</code> element).</p>
 
 					<p>The <code>landmarks nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT
 						occur more than once.</p>


### PR DESCRIPTION
This pull request just adds some missing context to the element naming for the nav types. It clarifies that the names are coming from the epub:type attribute value for each nav element and formally refers to the structural semantics vocabulary for where the values are defined.

I don't think this rises above a class 2 change since the requirements on the elements and their presence within the navigation document are already spelled out. It's mainly a clarifier change.

Fixes #2623


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2624.html" title="Last updated on May 29, 2024, 4:23 PM UTC (e640b29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2624/df2789d...e640b29.html" title="Last updated on May 29, 2024, 4:23 PM UTC (e640b29)">Diff</a>