### PR TITLE
Updated techniques

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -14,7 +14,7 @@
 				shortName: "epub-a11y-tech-11",
 				noRecTrack: true,
 				edDraftURI: "https://w3c.github.io/epub-specs/epub33/a11y-tech/",
-                previousPublishDate: "2021-07-12",
+                previousPublishDate: "2024-04-12",
 				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
                 previousMaturity: "NOTE",
                 copyrightStart: "2017",
@@ -77,6 +77,13 @@
 						"href": "http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
 						"date": "04 September 2010",
 						"publisher": "IDPF"
+					},
+					"page-source-id": {
+						"title": "Page Source Identification",
+						"href": "https://www.w3.org/publishing/a11y/page-source-id/",
+						"editors": [
+							"Matt Garrish"
+						]
 					},
 					"svg": {
 						"title": "SVG",
@@ -176,7 +183,8 @@
 		<section id="sec-discovery">
 			<h2>Discovery metadata techniques</h2>
 
-			<section id="meta-001">
+			<section id="accessMode">
+				<span id="meta-001"></span>
 				<h3>Identify primary access modes</h3>
 
 				<p>An access mode is defined as a "human sense perceptual system or cognitive faculty through which a
@@ -232,20 +240,22 @@
 
 				<p>Note that the access modes of the content do not reflect any adaptations that have been provided. For
 					example, if a comic book also includes alternative text for each image, it does not have a textual
-					access mode. See the following section on <a href="#meta-002">sufficient access modes</a> for how to
-					indicate that the available adaptations allow the content to be consumed in another mode.</p>
+					access mode. See the following section on <a href="#accessModeSufficient">sufficient access
+						modes</a> for how to indicate that the available adaptations allow the content to be consumed in
+					another mode.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode">The
 							<code>accessMode</code> Property</a> [[a11y-discov-vocab]] for more information about this
 					property and its values.</p>
 			</section>
 
-			<section id="meta-002">
+			<section id="accessModeSufficient">
+				<span id="meta-002"></span>
 				<h3>Identify sufficient access modes</h3>
 
 				<p>The access modes sufficient to consume an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication"
 						>EPUB publication</a> express a broader picture of the potential usability than do the <a
-						href="#meta-001">basic access modes</a>. Where the basic access modes identify the default
+						href="#accessMode">basic access modes</a>. Where the basic access modes identify the default
 					nature of the media used in the publication, sufficient access modes identify all the individual
 					modes, and sets of modes, that allow a user to read a publication. Sufficient access modes account
 					for the affordances and adaptations that the EPUB creators have provided, allowing users to
@@ -373,7 +383,8 @@
 				</div>
 			</section>
 
-			<section id="meta-access-modes-sync-audio">
+			<section id="accessMode-sync">
+				<span id="meta-access-modes-sync-audio"></span>
 				<h3>Setting access modes for synchronized text-audio</h3>
 
 				<p>Setting the correct access modes and sufficient access modes for EPUB 3 publications that contain
@@ -386,9 +397,9 @@
 					not to turn on the narration (unlike traditional audiobooks where only the audio is available).</p>
 
 				<p>In this case, because the audio playback is an extra feature, EPUB creators would
-						<strong>not</strong> list "<code>auditory</code>" as an <a href="#meta-001">access mode</a>.
-					Rather, they would indicate the presence of text and audio synchronization as an <a href="#meta-003"
-						>accessibility feature</a>:</p>
+						<strong>not</strong> list "<code>auditory</code>" as an <a href="#accessMode">access mode</a>.
+					Rather, they would indicate the presence of text and audio synchronization as an <a
+						href="#accessMode-sync">accessibility feature</a>:</p>
 
 				<pre>&lt;meta
     property="schema:accessibilityFeature">
@@ -396,8 +407,8 @@
 &lt;/meta></pre>
 
 				<p>Although the audio is not essential to reading the publication, having full audio playback capability
-					means that there is an auditory <a href="#meta-002">sufficient access mode</a> &#8212; the user can
-					listen to the complete publication. Consequently, the EPUB creator would declare a
+					means that there is an auditory <a href="#accessModeSufficient">sufficient access mode</a> &#8212;
+					the user can listen to the complete publication. Consequently, the EPUB creator would declare a
 						<code>schema:accessModeSufficient</code> property with the value <code>auditory</code>:</p>
 
 				<pre>&lt;meta
@@ -446,7 +457,8 @@
 				</div>
 			</section>
 
-			<section id="meta-003">
+			<section id="accessibilityFeature">
+				<span id="meta-003"></span>
 				<h3>Identify accessibility features</h3>
 
 				<p>Identifying all the accessibility features and adaptations included in an <a
@@ -491,7 +503,8 @@
 					about this property and its values.</p>
 			</section>
 
-			<section id="meta-004">
+			<section id="accessibilityHazard">
+				<span id="meta-004"></span>
 				<h3>Identify accessibility hazards</h3>
 
 				<p>There are three widely recognized hazards that can affect readers of digital content:</p>
@@ -550,19 +563,47 @@
 
 				<p>Do not skip reporting hazards just because an EPUB publication does not contain any content that
 					could present risks. Users cannot infer a meaning when no metadata is present. The value
-						"<code>none</code>" can be used in such cases instead of repeating each non-hazard.</p>
+						"<code>none</code>" can be used in such cases instead of repeating each non-hazard. When the
+						"<code>none</code>" value is used, no other hazards values may be specified.</p>
 
 				<p>If an EPUB publication contains a hazard, provide additional information about its source and nature
-					in the <a href="#meta-005">accessibility summary</a>.</p>
+					in the <a href="#accessibilitySummary">accessibility summary</a>.</p>
 
-				<p>If hazards cannot be definitively determined, report the value "<code>unknown</code>".</p>
+				<p>If an EPUB creator cannot determine if a publication presents a specific hazard for users, list that
+					hazard as unknown. Individual unknown hazards must be specified alongside "no hazard" values.</p>
+
+				<p>For example, determining whether sound hazards are present can be challenging as the causes are
+					currently not well defined. In this case, EPUB creators may prefer to set the
+						"<code>unknownSoundHazard</code>" value, as in the following example.</p>
+
+				<aside class="example"
+					title="Metadata entries for an unknown sound hazard and no motion simulation or sound hazards">
+					<pre>&lt;meta
+    property="schema:accessibilityHazard">
+   noflashingHazard
+&lt;/meta>
+&lt;meta
+    property="schema:accessibilityHazard">
+   noMotionSimulationHazard
+&lt;/meta>
+&lt;meta
+    property="schema:accessibilityHazard">
+   unknownSoundHazard
+&lt;/meta></pre>
+				</aside>
+
+				<p>If it is not possible to determine any hazards, the value "<code>unknown</code>" can be used in place
+					of setting the individual hazards to unknown. This value should be used sparingly, however, as it is
+					of no value to users. EPUB creators should make every effort to determine if hazards are present.
+					When the "<code>unknown</code>" value is set, no other hazard values may be specified.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard">The
 							<code>accessibilityHazard</code> Property</a> [[a11y-discov-vocab]] for more information
 					about this property and its values.</p>
 			</section>
 
-			<section id="meta-005">
+			<section id="accessibilitySummary">
+				<span id="meta-005"></span>
 				<h3>Include an accessibility summary</h3>
 
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
@@ -629,7 +670,8 @@
 					information.</p>
 			</section>
 
-			<section id="meta-006">
+			<section id="accessibilityAPI">
+				<span id="meta-006"></span>
 				<h3>Identify ARIA conformance</h3>
 
 				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for <a
@@ -643,7 +685,8 @@
 					controls.</p>
 			</section>
 
-			<section id="meta-007">
+			<section id="accessibilityControl">
+				<span id="meta-007"></span>
 				<h3>Identify input control methods</h3>
 
 				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for <a
@@ -656,7 +699,8 @@
 					sufficient for authoring purposes.</p>
 			</section>
 
-			<section id="sec-meta-ex">
+			<section id="metadata-examples">
+				<span id="sec-meta-ex"></span>
 				<h3>Examples</h3>
 
 				<p>The following examples show the metadata that would be added to an <a
@@ -854,7 +898,8 @@
 			<section id="sec-wcag-content-access">
 				<h3>Content access</h3>
 
-				<section id="access-001">
+				<section id="spread-order">
+					<span id="access-001"></span>
 					<h4>Ensure meaningful order of content across spreads</h4>
 
 					<p>[[wcag2]] <a data-cite="wcag2#meaningful-sequence">Success Criterion 1.3.2</a> specifies that
@@ -876,7 +921,8 @@
 						user to jump from the break point on the first page to the continuation on the next).</p>
 				</section>
 
-				<section id="access-002">
+				<section id="multiple-ways">
+					<span id="access-002"></span>
 					<h4>Provide multiple ways to access the content</h4>
 
 					<p>[[wcag2]] <a data-cite="wcag2#multiple-ways">Success Criterion 2.4.5</a> requires there be more
@@ -966,7 +1012,8 @@
 					</section>
 				</section>
 
-				<section id="access-003">
+				<section id="toc-linear-order">
+					<span id="access-003"></span>
 					<h4>Ensure the order of table of contents entries matches linear order</h4>
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
@@ -994,7 +1041,7 @@
 						by features, etc.</p>
 
 					<p>When the ordering of the table of contents does not match the content, EPUB creators should
-						include an explanation why in the <a href="#meta-005">accessibility summary</a>.</p>
+						include an explanation why in the <a href="#accessibilitySummary">accessibility summary</a>.</p>
 
 					<p>EPUB creators should avoid including links to supplementary content at the end of the table of
 						contents. Links to figure, tables, illustrations and similar content is better included as a
@@ -1035,7 +1082,8 @@
 			<section id="sec-wcag-roles">
 				<h3>Roles</h3>
 
-				<section id="sem-001">
+				<section id="roles-epub-type">
+					<span id="sem-001"></span>
 					<h4>ARIA roles and <code>epub:type</code></h4>
 
 					<div class="note">
@@ -1079,7 +1127,8 @@
 						equivalent ARIA roles in [[dpub-aria-1.0]] and [[wai-aria]].</p>
 				</section>
 
-				<section id="sem-002">
+				<section id="role-repetition">
+					<span id="sem-002"></span>
 					<h4>Do not repeat roles across chunked content</h4>
 
 					<p>Although <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> appear
@@ -1178,7 +1227,8 @@
 						the document that precedes the first chapter.</p>
 				</section>
 
-				<section id="sem-003">
+				<section id="landmarks">
+					<span id="sem-003"></span>
 					<h4>Include EPUB landmarks</h4>
 
 					<p>[[wai-aria]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
@@ -1186,7 +1236,7 @@
 						designed to provide users with quick access to the major structures of a document, such as
 						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by <a
 							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> from the <a
-							href="#sem-001">roles</a> that have been applied to the markup, so <a
+							href="#roles-epub-type">roles</a> that have been applied to the markup, so <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> only need to follow
 						the requirement to include roles for the landmarks to be made available to users.</p>
 
@@ -1195,7 +1245,8 @@
 							href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content documents</a>. An
 						assistive technology can only present the landmarks available in the currently-loaded document;
 						it cannot provide a complete picture of all the landmarks in a multi-document publication (see
-						the <a href="#sem-002">previous section</a> for more discussion about content chunking).</p>
+						the <a href="#role-repetition">previous section</a> for more discussion about content
+						chunking).</p>
 
 					<p>EPUB landmarks, on the other hand, are compiled by the EPUB creator prior to distribution, and
 						are not directly linked to the use of the <a
@@ -1310,7 +1361,8 @@
 			<section id="sec-wcag-titles">
 				<h3>Titles and headings</h3>
 
-				<section id="titles-001">
+				<section id="pub-title">
+					<span id="titles-001"></span>
 					<h4>Include publication and document titles</h4>
 
 					<p>[[wcag2]] <a data-cite="wcag2#page-titled">Success Criterion 2.4.2</a> requires that each web
@@ -1364,7 +1416,8 @@
 							href="https://www.w3.org/WAI/WCAG21/Techniques/html/H25">Technique H25</a>.</p>
 				</section>
 
-				<section id="titles-002">
+				<section id="heading-hierarchy">
+					<span id="titles-002"></span>
 					<h4>Ensure numbered headings reflect publication hierarchy</h4>
 
 					<p>To a user, an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a>
@@ -1441,7 +1494,8 @@
 					</aside>
 				</section>
 
-				<section id="titles-003">
+				<section id="heading-purpose">
+					<span id="titles-003"></span>
 					<h4>Heading topic or purpose</h4>
 
 					<p>[[wcag2]] <a data-cite="wcag2#non-text-content">Success Criterion 2.4.6</a> currently states that
@@ -1470,7 +1524,8 @@
 			<section id="sec-wcag-descriptions">
 				<h3>Descriptions</h3>
 
-				<section id="desc-001">
+				<section id="alt-text">
+					<span id="desc-001"></span>
 					<h4>Include alternative text descriptions</h4>
 
 					<p>The first version of these techniques only required alternative text for images regardless of
@@ -1499,7 +1554,8 @@
 			<section id="sec-wcag-language">
 				<h3>Language</h3>
 
-				<section id="lang-001">
+				<section id="package-lang">
+					<span id="lang-001"></span>
 					<h4>Language of package document</h4>
 
 					<p>[[wcag2]] Success Criterions <a data-cite="wcag2#language-of-page">3.1.1</a> and <a
@@ -1546,7 +1602,8 @@
 						expression mechanisms it provides).</p>
 				</section>
 
-				<section id="lang-002">
+				<section id="publication-lang">
+					<span id="lang-002"></span>
 					<h4>Language of the EPUB publication</h4>
 
 					<p>In addition to being able to express the language of text content, the <a
@@ -1588,7 +1645,8 @@
 			<section id="sec-wcag-text">
 				<h3>Text</h3>
 
-				<section id="text-001">
+				<section id="unicode-text">
+					<span id="text-001"></span>
 					<h4>Use Unicode for text content</h4>
 
 					<p>[[wcag2]] <a data-cite="wcag2#non-text-content">Success Criterion 1.1.1</a> requires that text
@@ -1643,8 +1701,9 @@
 					publications that contain multiple renditions are conformant to the [[epub-a11y-11]] specification
 					if at least one rendition meets all the content requirements, but EPUB creators at a minimum need to
 					note that a reading system that supports multiple renditions is required in their <a
-						href="#meta-005">accessibility summary</a>. Any other methods the EPUB creator can use to make
-					this dependence known is advisable (e.g., in the <a href="#dist-002">distribution metadata</a>).</p>
+						href="#accessibilitySummary">accessibility summary</a>. Any other methods the EPUB creator can
+					use to make this dependence known is advisable (e.g., in the <a href="#dist-a11y-metadata"
+						>distribution metadata</a>).</p>
 
 				<p>This section will be updated with techniques for using multiple renditions when there is enough
 					support in reading systems to broadly recommend their use.</p>
@@ -1656,7 +1715,8 @@
 			<section id="sec-epub-page-navigation">
 				<h3>Page navigation</h3>
 
-				<section id="page-001">
+				<section id="pageBreakMarkers">
+					<span id="page-001"></span>
 					<h4>Provide page break markers</h4>
 
 					<p>Both the EPUB Structural Semantics Vocabulary [[epub-ssv]] and Digital Publishing WAI-ARIA 1.0
@@ -1664,10 +1724,13 @@
 							href="https://www.w3.org/TR/epub/#pagebreak">pagebreak</a> and <a
 							data-cite="dpub-aria-1.0#doc-pagebreak">doc-pagebreak</a>, respectively.</p>
 
-					<p>It is recommended that both semantics be applied to EPUB 3 content to ensure maximum
-						compatibility with <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
-							systems</a> and <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive
-							technologies</a>.</p>
+					<p>For accessibility purposes, it is most important to specify the <code>role</code> attribute value
+						as this is what <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>
+						will process. The <code>epub:type</code> attribute is not recognized by these devices, but it
+						may be used by <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">epub reading
+							systems</a> to enhance the user experience. For compatibility with both types of devices, it
+						is recommended to apply both attributes, although only the <code>role</code> attribute is
+						strictly required for accessibility conformance.</p>
 
 					<aside class="example" title="Expressing a page break">
 						<p>In this example, the EPUB creator identifies an HTML <code>span</code> element as a page
@@ -1680,15 +1743,26 @@
 					</aside>
 
 					<p>A <code>title</code> or <code>aria-label</code> attribute is required on the element, as it
-						provides the value that is announced to the user. Do not include the page number as text
-						content, as this practice forces the user to hear it announced wherever it occurs (e.g., without
-						any context in the middle of a sentence).</p>
+						provides the value that is announced to the user.</p>
+
+					<p>The page number may be inserted as text content within the element, but assistive technologies
+						may not provide a way to disable announcing of the numbers. As a result, users may hear the
+						numbers announced wherever they occur, which could cause confusion (e.g., the number may seem to
+						be part of the sentence it occurs within).</p>
+
+					<aside class="example" title="Text page break">
+						<pre>&lt;p>With a philosophical flourish Cato throws himself 
+   &lt;span id="page003"
+         epub:type="pagebreak"
+         role="doc-pagebreak">3&lt;/span>
+   upon his sword &#8230;</pre>
+					</aside>
 
 					<p>EPUB 2 does not include markup to identify static page break marks in the content. Page break
-						destinations can be included to enable hyperlinking, but the <a href="#page-003">page
+						destinations can be included to enable hyperlinking, but the <a href="#pageList">page
 						list</a> is the only way a user can jump to the locations.</p>
 
-					<aside class="example" title="Adding a hyperlink destination">
+					<aside class="example" title="Adding a hyperlink destination in EPUB 2">
 						<p>In this example, the EPUB creator adds an XHTML 1.1 <code>span</code> element to use as a
 							hyperlink destination.</p>
 						<pre>&lt;html …>
@@ -1704,9 +1778,20 @@
 					<p>Do not use the [[html]] <a data-lt="a"><code>a</code> element</a> to identify page break
 						locations in EPUB 3 publications. Although this element was previously defined as the anchor for
 						a hyperlink destination, its purpose has been changed in [[html]] for use solely as a link.</p>
+
+					<div class="note">
+						<p>When a publication includes page breaks, ensure that an <a href="#accessibilityFeature"
+									><code>accessibilityFeature</code> metadata property</a> is set with the value <a
+								href="https://www.w3.org/2021/a11y-discov-vocab/latest/#pageBreakMarkers"
+									><code>pageBreakMarkers</code></a> [[a11y-discov-vocab]].</p>
+
+						<p>Do not use the deprecated value <code>printPageNumbers</code>. Page break markers do not
+							always correspond with a print source.</p>
+					</div>
 				</section>
 
-				<section id="page-002">
+				<section id="pageBreakMarkers-audio">
+					<span id="page-002"></span>
 					<h4>Identify pages in audio playback</h4>
 
 					<p>Readers rarely stop reading to review each new page number, so when page numbers are read aloud
@@ -1771,7 +1856,8 @@
 						apply.</p>
 				</section>
 
-				<section id="page-003">
+				<section id="pageList">
+					<span id="page-003"></span>
 					<h4>Provide a page list</h4>
 
 					<p>A page list — a list of hyperlinks to the static page break locations — is the most effective way
@@ -1789,6 +1875,13 @@
 							<code>nav</code></a> [[epub-3]], while the EPUB 2 NCX file provides the same functionality
 						through the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2"
 								><code>pageList</code> element</a> [[opf-201]].</p>
+
+					<div class="note">
+						<p>When a publication includes a page list, ensure that an <a href="#accessibilityFeature"
+									><code>accessibilityFeature</code> metadata property</a> is set with the value <a
+								href="https://www.w3.org/2021/a11y-discov-vocab/latest/#pageNavigation"
+									><code>pageNavigation</code></a> [[a11y-discov-vocab]].</p>
+					</div>
 
 					<aside class="example" title="A page-list nav element">
 						<pre>&lt;nav
@@ -1851,7 +1944,8 @@
 					</aside>
 				</section>
 
-				<section id="page-004">
+				<section id="pageSource">
+					<span id="page-004"></span>
 					<h4>Identify the pagination source</h4>
 
 					<p>Users typically want to know the source of the page break markers included in an <a
@@ -1863,45 +1957,21 @@
 
 					<p>To allow users to determine the suitability of the pagination, identify the ISBN of the source
 						work in the <a href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a>
-						metadata.</p>
+						metadata using the <a href="https://www.w3.org/publishing/a11y/page-source-id/"
+								><code>a11y:pageBreakSource</code> property</a> [[page-source-id]].</p>
 
 					<aside class="example" title="Expressing the source of pagination">
-						<p>In this example, the <code>dc:source</code> element contains the ISBN of the print source of
-							pagination. This example is valid for both EPUB 2 and 3.</p>
+						<p>In this example, the <code>a11y:pageBreakSource</code> property contains the ISBN of the
+							print source of pagination. (For EPUB 2, the <code>name</code> attribute would be used as it
+							does not define a <code>property</code> attribute for <code>meta</code> tags.)</p>
 						<pre>&lt;metadata …>
    …
-   &lt;dc:source>
+   &lt;meta property="a11y:pageBreakSource">
       urn:isbn:9780375704024
-   &lt;/dc:source>
-   …
-&lt;/metadata></pre>
-					</aside>
-
-					<p>EPUB 3 allows the source of pagination to be explicitly identified using the <a
-							href="https://www.w3.org/TR/epub/#source-of"><code>source-of</code> property</a> with the
-						value "<code>pagination</code>" [[epub-3]].</p>
-
-					<aside class="example" title="Adding a source-of declaration">
-						<p>In this example, a <code>dc:source</code> element is explicitly identified as the source of
-							pagination. The <code>refines</code> attribute identifies the ID of the element the
-								<code>source-of</code> property is modifying.</p>
-						<pre>&lt;metadata …>
-   …
-   &lt;dc:source
-       id="pg-src">
-      urn:isbn:9780375704024
-   &lt;/dc:source>
-   &lt;meta
-       property="source-of"
-       refines="#pg-src">
-      pagination
    &lt;/meta>
    …
 &lt;/metadata></pre>
 					</aside>
-
-					<p>The <code>source-of</code> property is particularly useful when there are multiple sources for an
-						EPUB publication as it disambiguates which one the pagination came from.</p>
 
 					<p>If an ISBN is not available, include as much information as possible about the source publication
 						(e.g., the publisher, date, edition, and binding).</p>
@@ -1909,21 +1979,47 @@
 					<aside class="example" title="Text description of the source">
 						<pre>&lt;metadata …>
    …
-   &lt;dc:source>
+   &lt;meta property="a11y:pageBreakSource">
       ACME Publishing, 1945, 2nd Edition, Softcover
-   &lt;/dc:source>
+   &lt;/meta>
    …
 &lt;/metadata></pre>
 					</aside>
 
-					<p>If the page break markers are unique to the EPUB publication, do not identify a print source.</p>
+					<p>If the page break markers are unique to the EPUB publication, use the value <code>none</code>
+						with the <code>a11y:pageBreakSource</code> property.</p>
+
+					<aside class="example" title="Page breaks without a source">
+						<pre><code>&lt;metadata …>
+   …
+   &lt;meta property="a11y:pageBreakSource">
+      none
+   &lt;/meta>
+   …
+&lt;/metadata></code></pre>
+					</aside>
+
+					<div class="note">
+						<p>The <a href="https://www.w3.org/TR/epub/#sec-source-of"><code>source-of</code> property</a>
+							was originally defined to identify the <a
+								href="https://www.w3.org/TR/epub/#sec-opf-dcmes-optional-def"><code>dc:source</code>
+								element</a> containing the source of the pagination [[epub-3]]. This method came with a
+							number of limitations, however. It was not future proof, for example, as it relied on the
+							EPUB 3 <a href="https://www.w3.org/TR/epub/#attrdef-refines"><code>refines</code>
+								attribute</a> [[epub-3]] and it could not handle pagination without a source due to the
+							reliance on a <code>dc:source</code> element.</p>
+
+						<p>Although this method remains valid for backwards compatibility purposes, it is strongly
+							recommended not to use it for new publications.</p>
+					</div>
 				</section>
 			</section>
 
 			<section id="sec-epub-sync-text-audio">
 				<h3>Synchronized text-audio playback</h3>
 
-				<section id="sync-001">
+				<section id="sync-coverage">
+					<span id="sync-001"></span>
 					<h4>Ensuring complete text coverage</h4>
 
 					<p>Ensuring the complete text of an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
@@ -1977,7 +2073,8 @@
 						ARIA attributes may also be used.</p>
 				</section>
 
-				<section id="sync-002">
+				<section id="sync-reading-order">
+					<span id="sync-002"></span>
 					<h4>Specifying the reading order</h4>
 
 					<p>The default reading order should typically represent the order in which <a
@@ -2007,7 +2104,8 @@
 						column.</p>
 				</section>
 
-				<section id="sync-003">
+				<section id="sync-skippability">
+					<span id="sync-003"></span>
 					<h4>Identifying skippable structures</h4>
 
 					<p>Some content elements are not critical to read when following the primary narrative of a work,
@@ -2110,7 +2208,8 @@
 					</aside>
 				</section>
 
-				<section id="sync-004">
+				<section id="sync-escapability">
+					<span id="sync-004"></span>
 					<h4>Identifying escapable structures</h4>
 
 					<p>Some content elements are containers for expressing complex information. A table, for example,
@@ -2216,7 +2315,8 @@
 					</aside>
 				</section>
 
-				<section id="sync-005">
+				<section id="sync-nav">
+					<span id="sync-005"></span>
 					<h4>Synchronizing the navigation document</h4>
 
 					<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> can add a <a
@@ -2237,7 +2337,8 @@
 		<section id="sec-distribution">
 			<h2>Distribution techniques</h2>
 
-			<section id="dist-001">
+			<section id="dist-drm">
+				<span id="dist-001"></span>
 				<h3>Do not restrict access through digital rights management</h3>
 
 				<p><a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> typically require
@@ -2261,7 +2362,8 @@
 					assistive technologies on EPUB publications users have the right to access.</p>
 			</section>
 
-			<section id="dist-002">
+			<section id="dist-a11y-metadata">
+				<span id="dist-002"></span>
 				<h3>Include accessibility metadata in distribution records</h3>
 
 				<p>When an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a> is ingested
@@ -2335,7 +2437,7 @@
 &lt;/ONIXMessage></pre>
 				</aside>
 
-				<section id="sec-dist-002-res">
+				<section id="dist-helpful-resources">
 					<h4>Helpful resources</h4>
 
 					<p>See the following resources for more information about including accessibility metadata in
@@ -2365,14 +2467,28 @@
 				that affect the conformance of <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
 					publications</a> or are similarly noteworthy.</p>
 
-			<p>For a list of all issues addressed during the revision, refer to the <a
+			<p>For a list of all issues addressed in this version, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-A11yTechniques+label%3AAccessibility11+"
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>20-June-2024: Updated guidance on identifying the page source to use the
+						<code>a11y:pageBreakSource</code> property. See <a
+						href="https://github.com/w3c/epub-specs/issues/2626">issue 2626</a>.</li>
+				<li>20-June-2024: Added note to use <code>pageNavigation</code> accessibility feature when a page list
+					is included. See <a href="https://github.com/w3c/epub-specs/issues/2626">issue 2626</a>.</li>
+				<li>20-June-2024: Added note to use <code>pageBreakMarkers</code> accessibility feature not
+						<code>printPageMarkers</code>. See <a href="https://github.com/w3c/epub-specs/issues/2626">issue
+						2626</a>.</li>
+				<li>20-June-2024: Clarified that the <code>role</code> attribute is most important for making page break
+					markers accessible. See <a href="https://github.com/w3c/epub-specs/issues/2621">issue 2621</a>.</li>
+				<li>20-June-2024: Removed restriction against added page numbers as text content but note that it may
+					cause confusion. See <a href="https://github.com/w3c/epub-specs/issues/2627">issue 2627</a>.</li>
+				<li>20-June-2024: Added guidance about using the individual unknown accessibility hazards. See <a
+						href="https://github.com/w3c/epub-specs/issues/2626">issue 2626</a>.</li>
 				<li>27-Mar-2023: Clarified that the <code>none</code> and <code>unknown</code> terms do not meet the
 					reporting requirements for <code>accessibilityFeature </code>. See <a
-						href="https://github.com/w3c/epub-specs/issues/2537">issue 2537</a></li>
+						href="https://github.com/w3c/epub-specs/issues/2537">issue 2537</a>.</li>
 				<li>08-Sept-2022: Clarified that only meeting the techniques in this document is not sufficient for
 					making claims of accessibility. See <a href="https://github.com/w3c/epub-specs/issues/2407">issue
 						2407</a></li>
@@ -2395,8 +2511,8 @@
 						href="https://github.com/w3c/epub-specs/issues/1842">issue 1842</a>.</li>
 				<li>25-Oct-2021: Removed the generic technique labels for each section. See <a
 						href="https://github.com/w3c/epub-specs/issues/1866">issue 1866</a>.</li>
-				<li>29-Sep-2021: Added <a href="#titles-003">new technique</a> to explain that headings only have to be
-					unique, not define the topic or purpose of a section. See <a
+				<li>29-Sep-2021: Added <a href="#heading-purpose">new technique</a> to explain that headings only have
+					to be unique, not define the topic or purpose of a section. See <a
 						href="https://github.com/w3c/epub-specs/issues/1810">issue 1810</a>.</li>
 				<li>10-June-2021: Clarified the technique on meaningful sequence that it applies to content that spans
 					pages in a spread and is not about ordering documents in the spine. See <a
@@ -2409,14 +2525,15 @@
 						href="https://github.com/w3c/epub-specs/issues/1600">issue 1600</a>.</li>
 				<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except where
 					WCAG 2.0 is explicitly mentioned for conformance).</li>
-				<li>08-Jan-2021: Added technique recommending the <a href="#access-003">order of the table of
+				<li>08-Jan-2021: Added technique recommending the <a href="#toc-linear-order">order of the table of
 						contents</a> match the linear reading order of content. See <a
 						href="https://github.com/w3c/epub-specs/issues/1430">issue 1430</a>.</li>
 				<li>16-Dec-2020: Removed the exception that allowed only alternative text for images. See <a
 						href="https://github.com/w3c/epub-specs/issues/1441">issue 1441</a>.</li>
-				<li>16-Nov-2020: The techniques for <a href="#meta-007">accessibility controls</a> and <a
-						href="#meta-006">APIs</a> have been replaced with descriptions of why these properties are not
-					necessary to set. See <a href="https://github.com/w3c/epub-specs/issues/1286">issue 1286</a>.</li>
+				<li>16-Nov-2020: The techniques for <a href="#accessibilityControl">accessibility controls</a> and <a
+						href="#accessibilityAPI">APIs</a> have been replaced with descriptions of why these properties
+					are not necessary to set. See <a href="https://github.com/w3c/epub-specs/issues/1286">issue
+					1286</a>.</li>
 			</ul>
 		</section>
 		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -277,9 +277,9 @@
 				<ul>
 					<li><code>textual</code> &#8212; setting this value indicates that the publication is screen-reader
 						friendly (i.e., all the content is available for text-to-speech rendering by an assistive
-						technology). EPUB creators can set this value for EPUB publications that conform to [[WCAG2]] <a
-							href="https://www.w3.org/TR/WCAG2/#cc1_A">Level A</a> or higher, for example, as there must
-						be textual alternatives for non-text content to meet these thresholds.</li>
+						technology). EPUB creators can set this value for EPUB publications that conform to <a
+							href="https://www.w3.org/TR/WCAG2/#cc1_A">Level A</a> [[wcag2]] or higher, for example, as
+						there must be textual alternatives for non-text content to meet these thresholds.</li>
 					<li><code>auditory</code> &#8212; setting this value indicates that pre-recorded audio is available
 						for the publication. EPUB creators can set this value for EPUB publications that provide media
 						overlays for all the content.</li>
@@ -512,8 +512,8 @@
 				<ul>
 					<li>
 						<p>flashing — if a resource flashes more than three times a second, it can cause seizures (e.g.,
-							videos and animations). See also [[wcag2]] <a
-								data-cite="wcag2#seizures-and-physical-reactions">Guideline 2.3</a>.</p>
+							videos and animations). See also <a data-cite="wcag2#seizures-and-physical-reactions"
+								>Guideline 2.3</a> [[wcag2]].</p>
 					</li>
 					<li>
 						<p>motion simulation — if a resource simulates motion, it can cause a user to become nauseated
@@ -833,7 +833,7 @@
 				<h3>General guidance</h3>
 
 				<p>Techniques for meeting the requirements of the [[wcag2]] are defined in <a
-						href="https://www.w3.org/WAI/WCAG21/Techniques/">Techniques for WCAG</a>. This document does not
+						href="https://www.w3.org/WAI/WCAG22/Techniques/">Techniques for WCAG</a>. This document does not
 					repeat those techniques.</p>
 
 				<p>In general, the differences between the application of WCAG techniques to web pages and their
@@ -881,8 +881,8 @@
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>
 
-					<p>EPUB creators not familiar with the [[wcag2]] may find the number of techniques daunting, as they
-						are intended to provide broad coverage of possible solutions.</p>
+					<p>EPUB creators not familiar with [[wcag2]] may find the number of techniques daunting, as they are
+						intended to provide broad coverage of possible solutions.</p>
 
 					<p>Assistance applying these techniques to EPUB content documents is available from the following
 						sources:</p>
@@ -894,9 +894,9 @@
 								applicable WCAG techniques.</p>
 						</li>
 						<li>
-							<p><a href="https://bisg.org/store/viewproduct.aspx?id=13534677">BISG Quickstart Guide to
-									Accessible Publishing</a> — includes a set of top practices for making content
-								accessible.</p>
+							<p><a href="https://www.bisg.org/products/bisg-guide-to-accessible-publishing--cheat-sheets"
+									>BISG Guide to Accessible Publishing &amp; Cheat Sheets</a> — includes a set of top
+								practices for making content accessible.</p>
 						</li>
 					</ul>
 				</section>
@@ -909,7 +909,7 @@
 					<span id="access-001"></span>
 					<h4>Ensure meaningful order of content across spreads</h4>
 
-					<p>[[wcag2]] <a data-cite="wcag2#meaningful-sequence">Success Criterion 1.3.2</a> specifies that
+					<p><a data-cite="wcag2#meaningful-sequence">Success Criterion 1.3.2</a> [[wcag2]] specifies that
 						each web page have a meaningful order (i.e., that the visual presentation of the content match
 						the underlying markup).</p>
 
@@ -932,7 +932,7 @@
 					<span id="access-002"></span>
 					<h4>Provide multiple ways to access the content</h4>
 
-					<p>[[wcag2]] <a data-cite="wcag2#multiple-ways">Success Criterion 2.4.5</a> requires there be more
+					<p><a data-cite="wcag2#multiple-ways">Success Criterion 2.4.5</a> [[wcag2]] requires there be more
 						than one way to locate a web page within a set of web pages. By default, <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> meet this WCAG
 						requirement so long as <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a>
@@ -1372,7 +1372,7 @@
 					<span id="titles-001"></span>
 					<h4>Include publication and document titles</h4>
 
-					<p>[[wcag2]] <a data-cite="wcag2#page-titled">Success Criterion 2.4.2</a> requires that each web
+					<p><a data-cite="wcag2#page-titled">Success Criterion 2.4.2</a> [[wcag2]] requires that each web
 						page include a title. EPUB has a similar requirement for <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>: publications
 						require a [[dcterms]] <code>title</code> element in the <a
@@ -1505,7 +1505,7 @@
 					<span id="titles-003"></span>
 					<h4>Heading topic or purpose</h4>
 
-					<p>[[wcag2]] <a data-cite="wcag2#non-text-content">Success Criterion 2.4.6</a> currently states that
+					<p><a data-cite="wcag2#non-text-content">Success Criterion 2.4.6</a> [[wcag2]] currently states that
 						all headings must describe their topic or purpose. The implication of this wording is that all
 						chapters in a novel, for example, have a topic or purpose and that the topic or purpose is
 						always clearly reflected by the title of the chapter. Not only is this not always the case, but
@@ -1565,9 +1565,9 @@
 					<span id="lang-001"></span>
 					<h4>Language of package document</h4>
 
-					<p>[[wcag2]] Success Criterions <a data-cite="wcag2#language-of-page">3.1.1</a> and <a
-							data-cite="wcag2#language-of-parts">3.1.2</a> deal with the language of a page and changes
-						of language with in, respectively.</p>
+					<p>Success Criterions <a data-cite="wcag2#language-of-page">3.1.1</a> and <a
+							data-cite="wcag2#language-of-parts">3.1.2</a> [[wcag2]] deal with the language of a page and
+						changes of language with in, respectively.</p>
 
 					<p>For <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>, the <a
 							href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a> is also an
@@ -1631,11 +1631,11 @@
 &lt;/package></code></pre>
 					</aside>
 
-					<p>Although it is not strictly required to set this information to meet [[wcag2]] <a
-							data-cite="wcag2#language-of-page">Success Criterion 3.1.1</a>, as it is non-normative, it
-						should be considered a best practice to always set this field with the proper language
-						information. (Note that EPUB3 requires the language always be specified, so omitting will fail
-						validation requirements.)</p>
+					<p>Although it is not strictly required to set this information to meet <a
+							data-cite="wcag2#language-of-page">Success Criterion 3.1.1</a> [[wcag2]], as it is
+						non-normative, it should be considered a best practice to always set this field with the proper
+						language information. (Note that EPUB3 requires the language always be specified, so omitting
+						will fail validation requirements.)</p>
 
 					<p>Although <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a> do not
 						use this language information to render the text content of the EPUB publication, they do use it
@@ -1656,7 +1656,7 @@
 					<span id="text-001"></span>
 					<h4>Use Unicode for text content</h4>
 
-					<p>[[wcag2]] <a data-cite="wcag2#non-text-content">Success Criterion 1.1.1</a> requires that text
+					<p><a data-cite="wcag2#non-text-content">Success Criterion 1.1.1</a> [[wcag2]] requires that text
 						equivalents be provided for all non-text content to meet <a data-cite="wcag2#cc1_A">Level A</a>.
 						In some regions (e.g., Asia), it is not uncommon to find images of individual text characters,
 						despite the availability of Unicode character equivalents. This practice occurs for various

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -602,7 +602,7 @@
 					When the "<code>unknown</code>" value is set, no other hazard values may be specified.</p>
 
 				<p>EPUB creators must ensure that information about all three types of hazards is included when not
-					using the "<code>unknown</code>" or "<code>none</code>".</p>
+					using the "<code>unknown</code>" or "<code>none</code>" values.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard">The
 							<code>accessibilityHazard</code> Property</a> [[a11y-discov-vocab]] for more information

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -543,7 +543,9 @@
 				<p>Unlike other accessibility properties, the presence of hazards can be expressed both positively and
 					negatively. This design decision was made because users most often search for content that is free
 					from hazards that affect them, but also want to know what dangers are present in any publications
-					they discover.</p>
+					they discover. To indicate that hazards are not present, use the values
+						"<code>noFlashingHazard</code>", "<code>noMotionSimulationHazard</code>", and
+						"<code>noSoundHazard</code>".</p>
 
 				<aside class="example"
 					title="Metadata entries for a flashing hazard but no motion simulation or sound hazards">
@@ -570,7 +572,9 @@
 					in the <a href="#accessibilitySummary">accessibility summary</a>.</p>
 
 				<p>If an EPUB creator cannot determine if a publication presents a specific hazard for users, list that
-					hazard as unknown. Individual unknown hazards must be specified alongside "no hazard" values.</p>
+					hazard as unknown. The following values are used to identify individual unknown hazards:
+						"<code>unknownFlashingHazard</code>", "<code>unknownMotionSimultationHazard</code>", and
+						"<code>unknownSoundHazard</code>".</p>
 
 				<p>For example, determining whether sound hazards are present can be challenging as the causes are
 					currently not well defined. In this case, EPUB creators may prefer to set the
@@ -596,6 +600,9 @@
 					of setting the individual hazards to unknown. This value should be used sparingly, however, as it is
 					of no value to users. EPUB creators should make every effort to determine if hazards are present.
 					When the "<code>unknown</code>" value is set, no other hazard values may be specified.</p>
+
+				<p>EPUB creators must ensure that information about all three types of hazards is included when not
+					using the "<code>unknown</code>" or "<code>none</code>".</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard">The
 							<code>accessibilityHazard</code> Property</a> [[a11y-discov-vocab]] for more information


### PR DESCRIPTION
This pull request updates the techniques to reflect the variety of changes over the last year, as detailed in issues #2621, #2626, and #2627.

I also made a minor editorial change to make the section ids more easily referenceable. I've kept the old ids for now on spans, but ideally these should disappear in time. (They used to match text identifiers we had for each technique but then we dropped those identifiers in 1.1.)

I'm going to give the document another pass to check that the other guidance we have still makes sense.

Fixes #2621 
Fixes #2626 
Fixes #2627 

- [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/technique-updates/epub33/a11y-tech/index.html)
- [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/technique-updates/epub33/a11y-tech/index.html)
