### PR TITLE
Add WCAG 2.2 to accessibility specification

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -425,7 +425,7 @@
 			<section id="sec-rel-wcag" class="informative">
 				<h3>Relationship to WCAG</h3>
 
-				<p>WCAG [[wcag2]] and its <a href="https://www.w3.org/WAI/WCAG21/Techniques/">associated techniques</a>
+				<p>WCAG [[wcag2]] and its <a href="https://www.w3.org/WAI/WCAG22/Techniques/">associated techniques</a>
 					provide extensive coverage of issues and solutions for web content accessibility, covering
 					everything from multimedia to interactive content to structured markup and more. They represent the
 					foundation that this specification builds upon.</p>
@@ -1163,7 +1163,7 @@
 					<aside class="example" title="A basic conformance statement">
 						<p>In this example, the <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a>
 							is stating that their publication conforms to the EPUB Accessibility 1.1 specification at
-							WCAG 2.1 Level AA.</p>
+							WCAG 2.2 Level AA.</p>
 
 						<pre>&lt;package …>
    &lt;metadata …>
@@ -1171,7 +1171,7 @@
       &lt;meta 
           property="dcterms:conformsTo"
           id="conf">
-         EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+         EPUB Accessibility 1.1 - WCAG 2.2 Level AA
       &lt;/meta>
       …
    &lt;/metadata>
@@ -1188,6 +1188,9 @@
 						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level A</li>
 						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</li>
 						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level A</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</li>
 					</ul>
 
 					<div class="note">
@@ -1265,7 +1268,7 @@
   &lt;meta
       property="dcterms:conformsTo"
       id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
   &lt;/meta>
   
   &lt;meta
@@ -1290,7 +1293,7 @@
   &lt;meta
       property="dcterms:conformsTo"
       id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
   &lt;/meta>
   &lt;meta
       property="a11y:certifiedBy"
@@ -1315,7 +1318,7 @@
   &lt;meta
       property="dcterms:conformsTo"
       id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
   &lt;/meta>
   
   &lt;meta
@@ -1339,7 +1342,7 @@
   …
   &lt;meta
       name="dcterms:conformsTo"
-      content="EPUB Accessibility 1.1 - WCAG 2.1 Level AA"/>
+      content="EPUB Accessibility 1.1 - WCAG 2.2 Level AA"/>
   
   &lt;meta
       name="a11y:certifiedBy"
@@ -1394,7 +1397,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
    &lt;/meta>
    
    &lt;meta
@@ -1428,7 +1431,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
    &lt;/meta>
 
    &lt;meta
@@ -1452,7 +1455,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
    &lt;/meta>
    
    &lt;meta


### PR DESCRIPTION
This pull request makes a few editorial changes to keep pace with the latest WCAG recommendation:

- it adds examples of the three possible 2.2 conformance strings
- it updates the conformance strings in the examples to reference 2.2
- it updates a link to the 2.1 techniques document to 2.2 (there is no auto-updating link for this document)

Fixes #2629 

- [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/conf-22/epub33/a11y/index.html)
- [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/conf-22/epub33/a11y/index.html)

