### PR TITLE
Fix mention of predefined prefix

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4738,7 +4738,7 @@ XHTML:
 					<aside class="example" title="Declaring a new link relationship">
 						<p>In this example, the <code>link</code> element is used to associate an author's home page
 							using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
-								href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be declared in the
+								href="#sec-metadata-reserved-prefixes">reserved prefix</a>, it must be declared in the
 								<a href="#attrdef-package-prefix">prefix attribute</a>.</p>
 
 						<pre>&lt;package


### PR DESCRIPTION
Changes to "reserved prefix" as noted in #2631 

Fixes #2631


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2633.html" title="Last updated on Jul 3, 2024, 12:25 PM UTC (7385a96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2633/436099a...7385a96.html" title="Last updated on Jul 3, 2024, 12:25 PM UTC (7385a96)">Diff</a>