### PR TITLE
Switch from infra to xml definition of whitespace for viewport meta

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11011,8 +11011,9 @@ html.my-document-playing * {
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). EPUB creators MAY include any valid [=ascii whitespace=]
-					[[infra]] in the authored tag so long as the result is valid to this definition.</p>
+					within the attribute to single spaces). EPUB creators MAY include any <a data-cite="xml#NT-S"
+						>whitespace characters</a> [[xml]] in the authored tag so long as the result is valid to this
+					definition.</p>
 
 				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
 							><code>meta</code></a> element by the [[html]] grammar.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11008,12 +11008,33 @@ html.my-document-playing * {
 						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
 						>assignment character</a>.</p>
 
+				<div class="proposed correction" id="change_4">
+					<span class="marker">Proposed Correction 4</span>
+					<p data-cite="svg2">The following paragraph mixed in a reference to the [[infra]] specification's
+						definition of whitespace characters, which is only valid for HTML documents. This would have
+						allowed the Form Feed character in <code>viewport meta</code> tags even though Form Feed is not
+						valid XML whitespace character. This change corrects the reference to point to the [[xml]]
+						definition and adds an explanatory note about the difference between the two definitions. For
+						more information, refer to <a href="https://github.com/w3c/epub-specs/issues/2637">issue
+							2637</a>.</p>
+				</div>
+
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). EPUB creators MAY include any <a data-cite="xml#NT-S"
-						>whitespace characters</a> [[xml]] in the authored tag so long as the result is valid to this
+					within the attribute to single spaces). EPUB creators MAY include any <ins cite="#change_4"><a
+							data-cite="xml#NT-S">whitespace characters</a> [[xml]]</ins><del cite="#change_4">valid
+						[=ascii whitespace=] [[infra]]</del> in the authored tag so long as the result is valid to this
 					definition.</p>
+
+				<ins cite="#change_4">
+					<div class="note">
+						<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
+								data-cite="infra#ascii-whitespace">definition of whitespace</a>, the Form Feed (U+000C)
+							character is not valid whitespace per the [[xml]] definition. It cannot be used in the XML
+							syntax (i.e., in XHTML content documents).</p>
+					</div>
+				</ins>
 
 				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
 							><code>meta</code></a> element by the [[html]] grammar.</p>
@@ -12003,12 +12024,15 @@ EPUB/images/cover.png</pre>
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2023/REC-epub-33-20230525/"
 						>Recommendation</a> of 2023-05-25</summary>
 				<ul>
+					<li>16-July-2024: Fixed the definition of whitespace allowed in viewport meta tags to refer to the
+						characters allowed by the XML standard. See <a
+							href="https://github.com/w3c/epub-specs/issues/2637">issue 2637</a>.</li>
 					<li>25-July-2023: Updated where the <code>epub:type</code> is allowed on SVGs to use the definition
 						of a renderable element. See <a href="https://github.com/w3c/epub-specs/issues/2556">issue
-							2556</a>. </li>
+							2556</a>.</li>
 					<li>25-July-2023: Clarified the definitions of embedded SVGs and moved the restriction on where the
 							<code>epub:type</code> attribute is allowed to apply so it applies to all SVG definitions.
-						See <a href="https://github.com/w3c/epub-specs/issues/2555">issue 2555</a>. </li>
+						See <a href="https://github.com/w3c/epub-specs/issues/2555">issue 2555</a>.</li>
 				</ul>
 			</details>
 


### PR DESCRIPTION
If we agree to merge this, I guess I'll have to go back and configure it with the necessary class 3 markup/descriptions. That's assuming we can't justify it as a class 2 change of reference only -- based on form feed not being a "valid" xml whitespace character in the old wording. (It's not like you could use form feed without halting xml processing even if you found some odd reason to author it, regardless of what the spec seemed to be suggesting, so there's a zero likelihood it's ever been used in content.)

Fixes #2637


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2640.html" title="Last updated on Jul 16, 2024, 3:50 PM UTC (5d23b86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2640/cf1af14...5d23b86.html" title="Last updated on Jul 16, 2024, 3:50 PM UTC (5d23b86)">Diff</a>