### PR TITLE
Add IDs to EAA exemption value definitions

### DIFF
--- a/epub33/a11y-exemption/index.html
+++ b/epub33/a11y-exemption/index.html
@@ -204,7 +204,7 @@
 						<th>Definition</th>
 					</tr>
 					<tr>
-						<td class="top">
+						<td class="top" id="eaa-disproportionate-burden">
 							<p><code>eaa-disproportionate-burden</code></p>
 						</td>
 						<td>
@@ -222,7 +222,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td class="top">
+						<td class="top" id="eaa-fundamental-alteration">
 							<p><code>eaa-fundamental-alteration</code></p>
 						</td>
 						<td>
@@ -239,7 +239,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td class="top">
+						<td class="top" id="eaa-microenterprise">
 							<p><code>eaa-microenterprise</code></p>
 						</td>
 						<td>


### PR DESCRIPTION
While looking to [update the schema.org crosswalk](https://github.com/w3c/a11y-discov-vocab/pull/115), we noticed that the individual values don't have linkable IDs. Currently, you can only link to the section that contains the table. This pull request fixes that.

- [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/exemption-ids/epub33/a11y-exemption/index.html)
