### PR TITLE
Allow dir and xml:lang on dc:source elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4100,8 +4100,8 @@
 											<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
 												<code>dc:coverage</code>, <code>dc:creator</code>,
 												<code>dc:description</code>, <code>dc:publisher</code>,
-												<code>dc:relation</code>, <code>dc:rights</code>, and
-												<code>dc:subject</code>.</p>
+												<code>dc:relation</code>, <code>dc:rights</code>,
+											<code>dc:source</code>, and <code>dc:subject</code>.</p>
 									</li>
 									<li>
 										<p><a href="#attrdef-id"><code>id</code></a>
@@ -4112,8 +4112,8 @@
 											<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
 												<code>dc:coverage</code>, <code>dc:creator</code>,
 												<code>dc:description</code>, <code>dc:publisher</code>,
-												<code>dc:relation</code>, <code>dc:rights</code>, and
-												<code>dc:subject</code>.</p>
+												<code>dc:relation</code>, <code>dc:rights</code>,
+											<code>dc:source</code>, and <code>dc:subject</code>.</p>
 									</li>
 								</ul>
 							</dd>
@@ -8964,8 +8964,8 @@ No Entry</pre>
 						<p>The granularity level of the media overlay depends on how [=EPUB creators=] mark up the
 							[=EPUB content document=] and the type of fragment identifier they use in the [^text^]
 							elements' <code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
-							attributes. For example, when referencing [[html]] elements, if the finest level of markup is
-							at the paragraph level, then that is the finest possible level for media overlay
+							attributes. For example, when referencing [[html]] elements, if the finest level of markup
+							is at the paragraph level, then that is the finest possible level for media overlay
 							synchronization. Likewise, if sub-paragraph markup is available, such as [[html]] [^span^]
 							element representing phrases or sentences, then finer granularity is possible in the media
 							overlay. Finer granularity gives users more precise results for synchronized playback when


### PR DESCRIPTION
For the case where a source has to be described in plain language.

Fixes #2635


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2643.html" title="Last updated on Jul 30, 2024, 6:19 PM UTC (9593920)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2643/b72b4bf...9593920.html" title="Last updated on Jul 30, 2024, 6:19 PM UTC (9593920)">Diff</a>