### PR TITLE
Updated list of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/epub-a11-eaa-mapping.md
+++ b/.github/ISSUE_TEMPLATE/epub-a11-eaa-mapping.md
@@ -1,0 +1,19 @@
+---
+name: EPUB Accessibility - EU Accessibility Act Mapping
+about: Issue related to the “EPUB Accessibility - EU Accessibility Act Mapping” Working Group Note
+title: ''
+labels: Spec-EAAMapping
+assignees: ''
+
+---
+
+## Issue on the [“EPUB Accessibility - EU Accessibility Act Mapping”](https://www.w3.org/TR/epub-a11y-eaa-mapping/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-a11.md
+++ b/.github/ISSUE_TEMPLATE/epub-a11.md
@@ -1,0 +1,19 @@
+---
+name: EPUB Accessibility
+about: Issue related to the “EPUB Accessibility 1.1” Recommendation
+title: ''
+labels: Spec-Accessibility
+assignees: ''
+
+---
+
+## Issue on the [“EPUB Accessibility 1.1”](https://www.w3.org/TR/epub-a11y-11/) Recommendation
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-a11y-exemption.md
+++ b/.github/ISSUE_TEMPLATE/epub-a11y-exemption.md
@@ -1,0 +1,19 @@
+---
+name:  EPUB Accessibility exemption property
+about: Issue related to “The EPUB Accessibility exemption property” Working Group Note
+title: ''
+labels: Spec-AccessibilityExemption
+assignees: ''
+
+---
+
+## Issue on the [“The EPUB Accessibility exemption property”](https://www.w3.org/TR/epub-a11y-exemption/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-a11y-tech.md
+++ b/.github/ISSUE_TEMPLATE/epub-a11y-tech.md
@@ -1,0 +1,19 @@
+---
+name: EPUB 3 Accessibility Techniques
+about: Issue related to the “EPUB Accessibility Techniques 1.1” Working Group Note
+title: ''
+labels: Spec-A11yTechniques
+assignees: ''
+
+---
+
+## Issue on the [“EPUB Accessibility Techniques 1.1”](https://www.w3.org/TR/epub-a11y-tech-11/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-aria-authoring.md
+++ b/.github/ISSUE_TEMPLATE/epub-aria-authoring.md
@@ -1,0 +1,19 @@
+---
+name: EPUB Type to ARIA Role Authoring
+about: Issue related to the “EPUB Type to ARIA Role Authoring Guide 1.1” Working Group Note
+title: ''
+labels: Spec-EPUBTypeToAria
+assignees: ''
+
+---
+
+## Issue on the [“EPUB Type to ARIA Role Authoring Guide 1.1”](https://www.w3.org/TR/epub-aria-authoring-11/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-fxl-a11.md
+++ b/.github/ISSUE_TEMPLATE/epub-fxl-a11.md
@@ -1,0 +1,19 @@
+---
+name: EPUB 3 Fixed Layout Accessibility
+about: Issue related to the “EPUB Fixed Layout Accessibility” Working Group Note
+title: ''
+labels: Spec-FXL-A11y
+assignees: ''
+
+---
+
+## Issue on the [“EPUB Fixed Layout Accessibility”](https://www.w3.org/TR/epub-fxl-a11y/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-multi-rend.md
+++ b/.github/ISSUE_TEMPLATE/epub-multi-rend.md
@@ -1,0 +1,19 @@
+---
+name: EPUB 3 Multiple Rendition
+about: Issue related to the “EPUB 3 Multiple-Rendition Publications 1.1” Working Group Note
+title: ''
+labels: Spec-MultipleRendition
+assignees: ''
+
+---
+
+## Issue on the [“EPUB 3 Multiple-Rendition Publications 1.1”](https://www.w3.org/TR/epub-multi-rend-11/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-overview.md
+++ b/.github/ISSUE_TEMPLATE/epub-overview.md
@@ -1,0 +1,19 @@
+---
+name: EPUB 3 Overview
+about: Issue related to the “EPUB 3 Overview” Working Group Note
+title: ''
+labels: Spec-Overview
+assignees: ''
+
+---
+
+## Issue on the [“EPUB 3 Overview”](https://www.w3.org/TR/epub-overview-33/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-rs.md
+++ b/.github/ISSUE_TEMPLATE/epub-rs.md
@@ -1,0 +1,19 @@
+---
+name: EPUB Reading Systems 3.3
+about: Issue related to the “EPUB Reading Systems 3.3” Recommendation
+title: ''
+labels: Spec-ReadingSystems
+assignees: ''
+
+---
+
+## Issue on the [“EPUB Reading Systems 3.3”](https://www.w3.org/TR/epub-rs-33/) Recommendation
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-ssv.md
+++ b/.github/ISSUE_TEMPLATE/epub-ssv.md
@@ -1,0 +1,19 @@
+---
+name: EPUB 3 Text-to-Speech
+about: Issue related to the “EPUB 3 Structural Semantics Vocabulary 1.1” Working Group Note
+title: ''
+labels: Spec-TTS
+assignees: ''
+
+---
+
+## Issue on the [“EPUB 3 Structural Semantics Vocabulary 1.1”](https://www.w3.org/TR/epub-ssv-11/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub-tts.md
+++ b/.github/ISSUE_TEMPLATE/epub-tts.md
@@ -1,0 +1,19 @@
+---
+name: EPUB 3 Text-to-Speech
+about: Issue related to the “EPUB 3 Text-to-Speech Enhancements 1.0” Working Group Note
+title: ''
+labels: Spec-TTS
+assignees: ''
+
+---
+
+## Issue on the [“EPUB 3 Text-to-Speech Enhancements 1.0”](https://www.w3.org/TR/epub-tts-10/) WG Note
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/epub.md
+++ b/.github/ISSUE_TEMPLATE/epub.md
@@ -1,0 +1,19 @@
+---
+name: EPUB 3.3
+about: Issue related to the EPUB 3.3 Recommendation
+title: ''
+labels: Spec-EPUB3
+assignees: ''
+
+---
+
+## Issue on the [EPUB 3.3](https://www.w3.org/TR/epub-33/) Recommendation
+
+If appropriate, include the relevant section.
+
+## Describe the problem 
+
+What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
+
+## Describe the fix or new feature you propose
+

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 ## Before opening an issue
-This repository is only for issues with the following W3C documents. Questions or issues with specific reading systems, achieving specific styling, understanding validation errors, and similar will be considered as out of scope and will be closed without further action.
+This repository is only for issues with the following W3C documents; please, use the appropriate issue templates for questions/issues related to those documents. Questions or issues with specific reading systems, achieving specific styling, understanding validation errors, and similar will be considered as out of scope and will be closed without further action.
 
 * [EPUB 3 Overview](https://www.w3.org/TR/epub-overview-33/), WG Note
 * [EPUB 3.3](https://www.w3.org/TR/epub-33/), Recommendation
@@ -22,19 +22,11 @@ This repository is only for issues with the following W3C documents. Questions o
 * [EPUB Type to ARIA Role Authoring Guide 1.1](https://www.w3.org/TR/epub-aria-authoring-11/), WG Note
 * [EPUB Fixed Layout Accessibility](https://www.w3.org/TR/epub-fxl-a11y/), WG Note
 
-
 Some possible alternative locations get help to your problems:
 
 * the [epub forum](https://www.mobileread.com/forums/forumdisplay.php?f=179) at mobileread
 * the [W3C publishing community group](https://github.com/w3c/publishingcg/issues)
 * the [ebooks section](https://ebooks.stackexchange.com/questions/tagged/epub) at stackexchange
-## Which standard or note is this issue related to?
 
-Please include the title and version number. For bug reports, include the relevant section.
 
-## Describe the problem? 
-
-What is not working? What would you like to see improved? For bug reports, cite the relevant text from the specification.
-
-## Describe the fix or new feature you propose?
 


### PR DESCRIPTION
I deliberately did not add version number to the template file names; if we do an EPUB 3.4, for example, the file should remain the same, although its content might change. One future hurdle less...