### PR TITLE
Allow xml:lang and dir on all optional DC elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3282,8 +3282,8 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], Dublin Core <a href="#sec-opf-dcmes-required">required</a> and <a
-							href="#sec-opf-dcmes-optional">optional</a> elements, [^meta^], and [^package^].</p>
+					<p>Allowed on: [^collection^], <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and
+						[^package^].</p>
 				</section>
 
 
@@ -3324,9 +3324,8 @@
 						<pre>&lt;dc:title id="pub-title"&gt;The Lord of the Rings&lt;/dc:title&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], Dublin Core <a href="#sec-opf-dcmes-required">required</a> and <a
-							href="#sec-opf-dcmes-optional">optional</a> elements, [^item^], [^itemref^], [^link^],
-						[^manifest^], [^meta^], [^package^], and [^spine^].</p>
+					<p>Allowed on: [^collection^], <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^item^],
+						[^itemref^], [^link^], [^manifest^], [^meta^], [^package^], and [^spine^].</p>
 				</section>
 
 				<section id="attrdef-media-type">
@@ -3457,8 +3456,8 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], Dublin Core <a href="#sec-opf-dcmes-required">required</a> and <a
-							href="#sec-opf-dcmes-optional">optional</a> elements, [^meta^], and [^package^].</p>
+					<p>Allowed on: [^collection^], <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and
+						[^package^].</p>
 				</section>
 			</section>
 
@@ -3746,66 +3745,70 @@
 						space</a>&#160;[[infra]] during processing .</p>
 				</section>
 
-				<section id="sec-opf-dcmes-required">
-					<h4>Dublin Core required elements</h4>
+				<section id="sec-opf-dcmes">
+					<h4 id="sec-opf-dcmes-hd">Dublin Core</h4>
 
-					<section id="sec-opf-dcidentifier">
-						<h5>The <code>dc:identifier</code> element</h5>
+					<section id="sec-opf-dcmes-required" aria-labelledby="sec-opf-dcmes-hd sec-opf-dcmes-required-hd">
+						<h5 id="sec-opf-dcmes-required-hd">Required elements</h5>
 
-						<p>The <code>dc:identifier</code> element [[dcterms]] contains an identifier such as a <abbr
-								title="Universally Unique Identifier">UUID</abbr>, <abbr
-								title="Digital Object Identfier">DOI</abbr> or <abbr
-								title="International Standard Book Number">ISBN</abbr>.</p>
+						<section id="sec-opf-dcidentifier">
+							<h6>The <code>dc:identifier</code> element</h6>
 
-						<dl id="elemdef-opf-dcidentifier" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-											><code>dc:identifier</code></dfn>
-								</p>
-							</dd>
+							<p>The <code>dc:identifier</code> element [[dcterms]] contains an identifier such as a <abbr
+									title="Universally Unique Identifier">UUID</abbr>, <abbr
+									title="Digital Object Identfier">DOI</abbr> or <abbr
+									title="International Standard Book Number">ISBN</abbr>.</p>
 
-							<dt>Namespace:</dt>
-							<dd>
-								<p>
-									<code>http://purl.org/dc/elements/1.1/</code>
-								</p>
-							</dd>
+							<dl id="elemdef-opf-dcidentifier" class="elemdef">
+								<dt>Element Name:</dt>
+								<dd>
+									<p>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+												><code>dc:identifier</code></dfn>
+									</p>
+								</dd>
 
-							<dt>Usage:</dt>
-							<dd>
-								<p>REQUIRED child of [^metadata^]. Repeatable.</p>
-							</dd>
+								<dt>Namespace:</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
+									</p>
+								</dd>
 
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[conditionally required]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
+								<dt>Usage:</dt>
+								<dd>
+									<p>REQUIRED child of [^metadata^]. Repeatable.</p>
+								</dd>
 
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Text</p>
-							</dd>
-						</dl>
+								<dt>Attributes:</dt>
+								<dd>
+									<ul class="nomark">
+										<li>
+											<p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[conditionally required]</code>
+											</p>
+										</li>
+									</ul>
+								</dd>
 
-						<p>The [=EPUB creator=] MUST provide an identifier that is unique to one and only one [=EPUB
-							publication=] — its [=unique identifier=] — in an <code>dc:identifier</code> element. This
-								<code>dc:identifier</code> element MUST specify an <code>id</code> attribute whose value
-							is referenced from the [^package^] element's <a href="#attrdef-package-unique-identifier"
-									><code>unique-identifier</code> attribute</a>.</p>
+								<dt>Content Model:</dt>
+								<dd>
+									<p>Text</p>
+								</dd>
+							</dl>
 
-						<aside class="example" title="Specifying the element with the unique identifier">
-							<pre>&lt;package … unique-identifier="pub-id"&gt;
+							<p>The [=EPUB creator=] MUST provide an identifier that is unique to one and only one [=EPUB
+								publication=] — its [=unique identifier=] — in an <code>dc:identifier</code> element.
+								This <code>dc:identifier</code> element MUST specify an <code>id</code> attribute whose
+								value is referenced from the [^package^] element's <a
+									href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
+									attribute</a>.</p>
+
+							<aside class="example" title="Specifying the element with the unique identifier">
+								<pre>&lt;package … unique-identifier="pub-id"&gt;
     &lt;metadata …&gt;
        &lt;dc:identifier id="pub-id"&gt;
            urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
@@ -3813,36 +3816,37 @@
        …
     &lt;/metadata&gt;
 &lt;/package&gt;</pre>
-						</aside>
+							</aside>
 
-						<p>Although not static, EPUB creators should make changes to the unique identifier for an EPUB
-							publication as infrequently as possible. Unique Identifiers should have maximal persistence
-							both for referencing and distribution purposes. EPUB creators should not issue new
-							identifiers when making minor revisions such as updating metadata, fixing errata, or making
-							similar minor changes.</p>
+							<p>Although not static, EPUB creators should make changes to the unique identifier for an
+								EPUB publication as infrequently as possible. Unique Identifiers should have maximal
+								persistence both for referencing and distribution purposes. EPUB creators should not
+								issue new identifiers when making minor revisions such as updating metadata, fixing
+								errata, or making similar minor changes.</p>
 
-						<p>EPUB creators MAY specify additional identifiers.</p>
+							<p>EPUB creators MAY specify additional identifiers.</p>
 
-						<div class="note">
-							<p>EPUB creators are advised to use <a
-									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL strings</a>
-								[url] for identifiers whenever possible. The inclusion of a domain owned by the EPUB
-								creator can improve the uniqueness of the identifier, for example, while the use of a
-								URN with a <a href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1">namespace
-									identifier</a> [[rfc8141]] improves processing by reading systems.</p>
-						</div>
+							<div class="note">
+								<p>EPUB creators are advised to use <a
+										href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL strings</a>
+									[url] for identifiers whenever possible. The inclusion of a domain owned by the EPUB
+									creator can improve the uniqueness of the identifier, for example, while the use of
+									a URN with a <a href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1"
+										>namespace identifier</a> [[rfc8141]] improves processing by reading
+									systems.</p>
+							</div>
 
-						<p>EPUB creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
-								property</a> to indicate that the value of a <code>dc:identifier</code> element conforms
-							to an established system or an issuing authority granted it.</p>
+							<p>EPUB creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
+									property</a> to indicate that the value of a <code>dc:identifier</code> element
+								conforms to an established system or an issuing authority granted it.</p>
 
-						<aside class="example" title="Specifying the type of the identifier">
-							<p>In this example, the <code>identifier-type</code> property is used with the <a
-									href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to indicate the
-								product identifier type is a <a href="https://www.doi.org">DOI</a> (i.e., the value
-									<code>06</code> in codelist 5 is for DOIs).</p>
+							<aside class="example" title="Specifying the type of the identifier">
+								<p>In this example, the <code>identifier-type</code> property is used with the <a
+										href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to indicate
+									the product identifier type is a <a href="https://www.doi.org">DOI</a> (i.e., the
+									value <code>06</code> in codelist 5 is for DOIs).</p>
 
-							<pre>&lt;metadata …&gt;
+								<pre>&lt;metadata …&gt;
    &lt;dc:identifier
        id="pub-id"&gt;
       urn:doi:10.1016/j.iheduc.2008.03.001
@@ -3855,98 +3859,99 @@
    &lt;/meta&gt;
    …
 &lt;/metadata&gt;</pre>
-						</aside>
-					</section>
+							</aside>
+						</section>
 
-					<section id="sec-opf-dctitle" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L203">
-						<h5>The <code>dc:title</code> element</h5>
+						<section id="sec-opf-dctitle" data-epubcheck="true"
+							data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L203">
+							<h6>The <code>dc:title</code> element</h6>
 
-						<p>The <code>dc:title</code> element [[dcterms]] represents an instance of a name for the [=EPUB
-							publication=].</p>
+							<p>The <code>dc:title</code> element [[dcterms]] represents an instance of a name for the
+								[=EPUB publication=].</p>
 
-						<dl id="elemdef-opf-dctitle" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-											><code>dc:title</code></dfn>
-								</p>
-							</dd>
+							<dl id="elemdef-opf-dctitle" class="elemdef">
+								<dt>Element Name:</dt>
+								<dd>
+									<p>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+												><code>dc:title</code></dfn>
+									</p>
+								</dd>
 
-							<dt>Namespace:</dt>
-							<dd>
-								<p>
-									<code>http://purl.org/dc/elements/1.1/</code>
-								</p>
-							</dd>
+								<dt>Namespace:</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
+									</p>
+								</dd>
 
-							<dt>Usage:</dt>
-							<dd>
-								<p>REQUIRED child of [^metadata^]. Repeatable.</p>
-							</dd>
+								<dt>Usage:</dt>
+								<dd>
+									<p>REQUIRED child of [^metadata^]. Repeatable.</p>
+								</dd>
 
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-dir">
-												<code>dir</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-xml-lang">
-												<code>xml:lang</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
+								<dt>Attributes:</dt>
+								<dd>
+									<ul class="nomark">
+										<li>
+											<p>
+												<a href="#attrdef-dir">
+													<code>dir</code>
+												</a>
+												<code>[optional]</code>
+											</p>
+										</li>
+										<li>
+											<p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[optional]</code>
+											</p>
+										</li>
+										<li>
+											<p>
+												<a href="#attrdef-xml-lang">
+													<code>xml:lang</code>
+												</a>
+												<code>[optional]</code>
+											</p>
+										</li>
+									</ul>
+								</dd>
 
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Text</p>
-							</dd>
-						</dl>
+								<dt>Content Model:</dt>
+								<dd>
+									<p>Text</p>
+								</dd>
+							</dl>
 
-						<p id="title-order">The first <code>dc:title</code> element in document order is the main title
-							of the EPUB publication (i.e., the primary one reading systems present to users).</p>
+							<p id="title-order">The first <code>dc:title</code> element in document order is the main
+								title of the EPUB publication (i.e., the primary one reading systems present to
+								users).</p>
 
-						<aside class="example" title="A basic title element">
-							<pre>&lt;metadata …&gt;
+							<aside class="example" title="A basic title element">
+								<pre>&lt;metadata …&gt;
    &lt;dc:title&gt;
       Norwegian Wood
    &lt;/dc:title&gt;
    …
 &lt;/metadata&gt;
 </pre>
-						</aside>
+							</aside>
 
-						<p>[=EPUB creators=] should use only a single <code>dc:title</code> element to ensure consistent
-							rendering of the title in [=reading systems=].</p>
+							<p>[=EPUB creators=] should use only a single <code>dc:title</code> element to ensure
+								consistent rendering of the title in [=reading systems=].</p>
 
-						<div class="note">
-							<p>Although it is possible to include more than one <code>dc:title</code> element for
-								multipart titles, reading system support for additional <code>dc:title</code> elements
-								is inconsistent. Reading systems may ignore the additional segments or combine them in
-								unexpected ways.</p>
+							<div class="note">
+								<p>Although it is possible to include more than one <code>dc:title</code> element for
+									multipart titles, reading system support for additional <code>dc:title</code>
+									elements is inconsistent. Reading systems may ignore the additional segments or
+									combine them in unexpected ways.</p>
 
-							<p>For example, the following example shows a basic multipart title:</p>
+								<p>For example, the following example shows a basic multipart title:</p>
 
-							<pre>&lt;metadata …&gt;
+								<pre>&lt;metadata …&gt;
    &lt;dc:title&gt;
       THE LORD OF THE RINGS
    &lt;/dc:title&gt;
@@ -3957,10 +3962,10 @@
 &lt;/metadata&gt;
 </pre>
 
-							<p>The same title could instead be expressed using a single <code>dc:title</code> element as
-								follows:</p>
+								<p>The same title could instead be expressed using a single <code>dc:title</code>
+									element as follows:</p>
 
-							<pre>&lt;metadata …&gt;
+								<pre>&lt;metadata …&gt;
    &lt;dc:title&gt;
        THE LORD OF THE RINGS, Part One:
        The Fellowship of the Ring
@@ -3969,169 +3974,175 @@
 &lt;/metadata&gt;
 </pre>
 
-							<p>Previous versions of this specification recommended using the <a href="#sec-title-type"
-										><code>title-type</code></a> and <a href="#sec-display-seq"
-										><code>display-seq</code></a> properties to identify and format the segments of
-								multipart titles (see the <a href="#cookbook-ex">Great Cookbooks example</a>). It is
-								still possible to add these semantics, but they are also not well supported.</p>
-						</div>
-					</section>
+								<p>Previous versions of this specification recommended using the <a
+										href="#sec-title-type"><code>title-type</code></a> and <a
+										href="#sec-display-seq"><code>display-seq</code></a> properties to identify and
+									format the segments of multipart titles (see the <a href="#cookbook-ex">Great
+										Cookbooks example</a>). It is still possible to add these semantics, but they
+									are also not well supported.</p>
+							</div>
+						</section>
 
-					<section id="sec-opf-dclanguage" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L213">
-						<h5>The <code>dc:language</code> element</h5>
+						<section id="sec-opf-dclanguage" data-epubcheck="true"
+							data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L213">
+							<h6>The <code>dc:language</code> element</h6>
 
-						<p>The <code>dc:language</code> element [[dcterms]] specifies the language of the content of the
-							[=EPUB publication=].</p>
+							<p>The <code>dc:language</code> element [[dcterms]] specifies the language of the content of
+								the [=EPUB publication=].</p>
 
-						<dl id="elemdef-opf-dclanguage" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-											><code>dc:language</code></dfn>
-								</p>
-							</dd>
+							<dl id="elemdef-opf-dclanguage" class="elemdef">
+								<dt>Element Name:</dt>
+								<dd>
+									<p>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+												><code>dc:language</code></dfn>
+									</p>
+								</dd>
 
-							<dt>Namespace:</dt>
-							<dd>
-								<p>
-									<code>http://purl.org/dc/elements/1.1/</code>
-								</p>
-							</dd>
+								<dt>Namespace:</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
+									</p>
+								</dd>
 
-							<dt>Usage:</dt>
-							<dd>
-								<p>REQUIRED child of [^metadata^]. Repeatable.</p>
-							</dd>
+								<dt>Usage:</dt>
+								<dd>
+									<p>REQUIRED child of [^metadata^]. Repeatable.</p>
+								</dd>
 
-							<dt>Attributes:</dt>
-							<dd>
-								<p>
-									<a href="#attrdef-id">
-										<code>id</code>
-									</a>
-									<code>[optional]</code>
-								</p>
-							</dd>
+								<dt>Attributes:</dt>
+								<dd>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</dd>
 
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Text</p>
-							</dd>
-						</dl>
+								<dt>Content Model:</dt>
+								<dd>
+									<p>Text</p>
+								</dd>
+							</dl>
 
-						<p>The [=value=] of each <code>dc:language</code> element MUST be a <a
-								data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[bcp47]].</p>
+							<p>The [=value=] of each <code>dc:language</code> element MUST be a <a
+									data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[bcp47]].</p>
 
-						<aside class="example" title="Specifying U.S. English as the language of the EPUB publication">
-							<pre>&lt;metadata …&gt;
+							<aside class="example"
+								title="Specifying U.S. English as the language of the EPUB publication">
+								<pre>&lt;metadata …&gt;
    …
    &lt;dc:language&gt;
       en-US
    &lt;/dc:language&gt;
    …
 &lt;/metadata&gt;</pre>
-						</aside>
+							</aside>
 
-						<p>Although [=EPUB creators=] MAY specify additional <code>dc:language</code> elements for
-							multilingual Publications, [=reading systems=] will treat the first <code>dc:language</code>
-							element in document order as the primary language of the EPUB publication.</p>
+							<p>Although [=EPUB creators=] MAY specify additional <code>dc:language</code> elements for
+								multilingual Publications, [=reading systems=] will treat the first
+									<code>dc:language</code> element in document order as the primary language of the
+								EPUB publication.</p>
 
-						<div class="note">
-							<p>[=Publication resources=] do not inherit their language from the <code>dc:language</code>
-								element(s). EPUB creators must set the language of a resource using the intrinsic
-								methods of the format.</p>
-						</div>
-					</section>
-				</section>
-
-				<section id="sec-opf-dcmes-optional">
-					<h4>Dublin Core optional elements</h4>
-
-					<section id="sec-opf-dcmes-optional-def">
-						<h5>General definition</h5>
-
-						<p>All [[dcterms]] elements except for [^dc:identifier^], [^dc:language^], and [^dc:title^] are
-							designated as OPTIONAL. These elements conform to the following generalized definition:</p>
-
-						<dl class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>dc:contributor</code> | <code>dc:coverage</code> | <code>dc:creator</code> |
-										<code>dc:date</code> | <code>dc:description</code> | <code>dc:format</code> |
-										<code>dc:publisher</code> | <code>dc:relation</code> | <code>dc:rights</code> |
-										<code>dc:source</code> | <code>dc:subject</code> | <code>dc:type</code></p>
-							</dd>
-
-							<dt>Namespace:</dt>
-							<dd>
-								<p>
-									<code>http://purl.org/dc/elements/1.1/</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>OPTIONAL child of [^metadata^]. Repeatable.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p><a href="#attrdef-dir"><code>dir</code></a>
-											<code>[optional]</code></p>
-									</li>
-									<li>
-										<p><a href="#attrdef-id"><code>id</code></a>
-											<code>[optional]</code></p>
-									</li>
-									<li>
-										<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-											<code>[optional]</code></p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Text</p>
-							</dd>
-						</dl>
-
-						<p>This specification does not modify the [[dcterms]] element definitions except as noted in the
-							following sections.</p>
+							<div class="note">
+								<p>[=Publication resources=] do not inherit their language from the
+										<code>dc:language</code> element(s). EPUB creators must set the language of a
+									resource using the intrinsic methods of the format.</p>
+							</div>
+						</section>
 					</section>
 
-					<section id="sec-opf-dccontributor">
-						<h5>The <code>dc:contributor</code> element</h5>
+					<section id="sec-opf-dcmes-optional" aria-labelledby="sec-opf-dcmes-hd sec-opf-dcmes-optional-hd">
+						<h5 id="sec-opf-dcmes-optional-hd">Optional elements</h5>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>dc:contributor</code></dfn> element [[dcterms]] is used to represent the name
-							of a person, organization, etc. that played a secondary role in the creation of the
-							content.</p>
+						<section id="sec-opf-dcmes-optional-def">
+							<h6>General definition</h6>
 
-						<p>The requirements for the <code>dc:contributor</code> element are identical to those for the
-							[^dc:creator^] element in all other respects.</p>
-					</section>
+							<p>All [[dcterms]] elements except for [^dc:identifier^], [^dc:language^], and [^dc:title^]
+								are designated as OPTIONAL. These elements conform to the following generalized
+								definition:</p>
 
-					<section id="sec-opf-dccreator">
-						<h5>The <code>dc:creator</code> element</h5>
+							<dl class="elemdef">
+								<dt>Element Name:</dt>
+								<dd>
+									<p>
+										<code>dc:contributor</code> | <code>dc:coverage</code> | <code>dc:creator</code>
+										| <code>dc:date</code> | <code>dc:description</code> | <code>dc:format</code> |
+											<code>dc:publisher</code> | <code>dc:relation</code> |
+											<code>dc:rights</code> | <code>dc:source</code> | <code>dc:subject</code> |
+											<code>dc:type</code></p>
+								</dd>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:creator</code></dfn> element [[dcterms]] represents the name of a person,
-							organization, etc. responsible for the creation of the content. [=EPUB creators=] MAY <a
-								href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
-							with the element to indicate the function the creator played.</p>
+								<dt>Namespace:</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
+									</p>
+								</dd>
 
-						<aside class="example" title="Specifying that a creator is an author">
-							<p>In this example, the <a href="https://id.loc.gov/vocabulary/relators.html">MARC
-									relators</a> scheme is used to indicate the role (i.e., the value <code>aut</code>
-								indicates an author in MARC).</p>
+								<dt>Usage:</dt>
+								<dd>
+									<p>OPTIONAL child of [^metadata^]. Repeatable.</p>
+								</dd>
 
-							<pre>&lt;metadata …&gt;
+								<dt>Attributes:</dt>
+								<dd>
+									<ul class="nomark">
+										<li>
+											<p><a href="#attrdef-dir"><code>dir</code></a>
+												<code>[optional]</code></p>
+										</li>
+										<li>
+											<p><a href="#attrdef-id"><code>id</code></a>
+												<code>[optional]</code></p>
+										</li>
+										<li>
+											<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
+												<code>[optional]</code></p>
+										</li>
+									</ul>
+								</dd>
+
+								<dt>Content Model:</dt>
+								<dd>
+									<p>Text</p>
+								</dd>
+							</dl>
+
+							<p>This specification does not modify the [[dcterms]] element definitions except as noted in
+								the following sections.</p>
+						</section>
+
+						<section id="sec-opf-dccontributor">
+							<h6>The <code>dc:contributor</code> element</h6>
+
+							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+										><code>dc:contributor</code></dfn> element [[dcterms]] is used to represent the
+								name of a person, organization, etc. that played a secondary role in the creation of the
+								content.</p>
+
+							<p>The requirements for the <code>dc:contributor</code> element are identical to those for
+								the [^dc:creator^] element in all other respects.</p>
+						</section>
+
+						<section id="sec-opf-dccreator">
+							<h6>The <code>dc:creator</code> element</h6>
+
+							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+										><code>dc:creator</code></dfn> element [[dcterms]] represents the name of a
+								person, organization, etc. responsible for the creation of the content. [=EPUB
+								creators=] MAY <a href="#subexpression">associate</a> a <a href="#role"
+										><code>role</code> property</a> with the element to indicate the function the
+								creator played.</p>
+
+							<aside class="example" title="Specifying that a creator is an author">
+								<p>In this example, the <a href="https://id.loc.gov/vocabulary/relators.html">MARC
+										relators</a> scheme is used to indicate the role (i.e., the value
+										<code>aut</code> indicates an author in MARC).</p>
+
+								<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
        id="creator"&gt;
@@ -4146,18 +4157,18 @@
    &lt;/meta&gt;
    …
 &lt;/metadata&gt;</pre>
-						</aside>
+							</aside>
 
-						<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB creators
-							intend [=reading systems=] to display it to users.</p>
+							<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB
+								creators intend [=reading systems=] to display it to users.</p>
 
-						<p>EPUB creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
-							<a href="#subexpression">to associate</a> a normalized form of the creator's name, and the
-								<a href="#alternate-script"><code>alternate-script</code> property</a> to represent the
-							creator's name in another language or script.</p>
+							<p>EPUB creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
+								<a href="#subexpression">to associate</a> a normalized form of the creator's name, and
+								the <a href="#alternate-script"><code>alternate-script</code> property</a> to represent
+								the creator's name in another language or script.</p>
 
-						<aside class="example" title="Expressing sorting and rendering information for a creator">
-							<pre>&lt;metadata …&gt;
+							<aside class="example" title="Expressing sorting and rendering information for a creator">
+								<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
        id="creator"&gt;
@@ -4176,19 +4187,19 @@
    &lt;/meta&gt;
    …
 &lt;/metadata&gt;</pre>
-						</aside>
+							</aside>
 
-						<p>If an [=EPUB publication=] has more than one creator, EPUB creators should specify each in a
-							separate <code>dc:creator</code> element.</p>
+							<p>If an [=EPUB publication=] has more than one creator, EPUB creators should specify each
+								in a separate <code>dc:creator</code> element.</p>
 
-						<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code> section
-							determines the display priority, where the first <code>dc:creator</code> element encountered
-							is the primary creator.</p>
+							<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code>
+								section determines the display priority, where the first <code>dc:creator</code> element
+								encountered is the primary creator.</p>
 
-						<aside class="example" title="Expressing the primary creator">
-							<p>In this example, Lewis Carroll is the primary creator because he is listed first.</p>
+							<aside class="example" title="Expressing the primary creator">
+								<p>In this example, Lewis Carroll is the primary creator because he is listed first.</p>
 
-							<pre>&lt;metadata …&gt;
+								<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
        id="creator01"&gt;
@@ -4200,59 +4211,59 @@
    &lt;/dc:creator&gt;
    …
 &lt;/metadata&gt;</pre>
-						</aside>
+							</aside>
 
-						<p>EPUB creators should represent secondary contributors using the [^dc:contributor^]
-							element.</p>
-					</section>
+							<p>EPUB creators should represent secondary contributors using the [^dc:contributor^]
+								element.</p>
+						</section>
 
-					<section id="sec-opf-dcdate" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L231">
-						<h5>The <code>dc:date</code> element</h5>
+						<section id="sec-opf-dcdate" data-epubcheck="true"
+							data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L231">
+							<h6>The <code>dc:date</code> element</h6>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:date</code></dfn> element [[dcterms]] defines the publication date of the
-							[=EPUB publication=]. The publication date is not the same as the <a
-								href="#last-modified-date">last modified date</a> (the last time the [=EPUB creator=]
-							changed the EPUB publication).</p>
+							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+									><code>dc:date</code></dfn> element [[dcterms]] defines the publication date of the
+								[=EPUB publication=]. The publication date is not the same as the <a
+									href="#last-modified-date">last modified date</a> (the last time the [=EPUB
+								creator=] changed the EPUB publication).</p>
 
-						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
-							expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
-							machine readable.</p>
+							<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
+								expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
+								machine readable.</p>
 
-						<aside class="example" title="Expressing the publication date">
-							<pre>&lt;metadata …&gt;
+							<aside class="example" title="Expressing the publication date">
+								<pre>&lt;metadata …&gt;
    …
    &lt;dc:date&gt;
       2000-01-01T00:00:00Z
    &lt;/dc:date&gt;
    …
 &lt;/metadata&gt;</pre>
-						</aside>
+							</aside>
 
-						<p>EPUB creators should express additional dates using the specialized date properties available
-							in the [[dcterms]] vocabulary, or similar.</p>
+							<p>EPUB creators should express additional dates using the specialized date properties
+								available in the [[dcterms]] vocabulary, or similar.</p>
 
-						<p>EPUB publications MUST NOT contain more than one <code>dc:date</code> element.</p>
-					</section>
+							<p>EPUB publications MUST NOT contain more than one <code>dc:date</code> element.</p>
+						</section>
 
-					<section id="sec-opf-dcsubject">
-						<h5>The <code>dc:subject</code> element</h5>
+						<section id="sec-opf-dcsubject">
+							<h6>The <code>dc:subject</code> element</h6>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:subject</code></dfn> element [[dcterms]] identifies the subject of the [=EPUB
-							publication=]. [=EPUB creators=] should set the [=value=] of the element to the
-							human-readable heading or label, but may use a code value if the subject taxonomy does not
-							provide a separate descriptive label.</p>
+							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+										><code>dc:subject</code></dfn> element [[dcterms]] identifies the subject of the
+								[=EPUB publication=]. [=EPUB creators=] should set the [=value=] of the element to the
+								human-readable heading or label, but may use a code value if the subject taxonomy does
+								not provide a separate descriptive label.</p>
 
-						<p>EPUB creators MAY identify the system or scheme they drew the element's [=value=] from using
-							the <a href="#authority"><code>authority</code> property</a>.</p>
+							<p>EPUB creators MAY identify the system or scheme they drew the element's [=value=] from
+								using the <a href="#authority"><code>authority</code> property</a>.</p>
 
-						<p>When a scheme is identified, EPUB creators MUST <a href="#subexpression">associate</a> a
-							subject code using the <a href="#term"><code>term</code> property</a>.</p>
+							<p>When a scheme is identified, EPUB creators MUST <a href="#subexpression">associate</a> a
+								subject code using the <a href="#term"><code>term</code> property</a>.</p>
 
-						<aside class="example" title="Specifying a BISAC code and heading">
-							<pre>&lt;metadata …&gt;
+							<aside class="example" title="Specifying a BISAC code and heading">
+								<pre>&lt;metadata …&gt;
    &lt;dc:subject id="subject01"&gt;
       FICTION / Occult &amp;amp; Supernatural
    &lt;/dc:subject&gt;
@@ -4267,10 +4278,10 @@
       FIC024000
    &lt;/meta&gt;
 &lt;/metadata></pre>
-						</aside>
+							</aside>
 
-						<aside class="example" title="Specifying a URL for the scheme">
-							<pre>&lt;metadata …&gt;
+							<aside class="example" title="Specifying a URL for the scheme">
+								<pre>&lt;metadata …&gt;
    &lt;dc:subject id="sbj01"&gt;
       Number Theory
    &lt;/dc:subject&gt;
@@ -4285,32 +4296,33 @@
      11
   &lt;/meta&gt;
 &lt;/metadata&gt;</pre>
-						</aside>
+							</aside>
 
-						<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
-									<code>dc:subject</code> element</a> that does not specify a scheme.</p>
+							<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
+										<code>dc:subject</code> element</a> that does not specify a scheme.</p>
 
-						<p>The [=values=] of the <code>dc:subject</code> element and <code>term</code> property are case
-							sensitive only when the designated scheme requires.</p>
-					</section>
+							<p>The [=values=] of the <code>dc:subject</code> element and <code>term</code> property are
+								case sensitive only when the designated scheme requires.</p>
+						</section>
 
-					<section id="sec-opf-dctype">
-						<h5>The <code>dc:type</code> element</h5>
+						<section id="sec-opf-dctype">
+							<h6>The <code>dc:type</code> element</h6>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:type</code></dfn> element [[dcterms]] is used to indicate that the [=EPUB
-							publication=] is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
-							format).</p>
+							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+									><code>dc:type</code></dfn> element [[dcterms]] is used to indicate that the [=EPUB
+								publication=] is of a specialized type (e.g., annotations or a dictionary packaged in
+								EPUB format).</p>
 
-						<p>[=EPUB creators=] MAY use any text string as a [=value=].</p>
+							<p>[=EPUB creators=] MAY use any text string as a [=value=].</p>
 
-						<div class="note">
-							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-								Working Group maintained a <a href="http://idpf.org/epub/vocab/package/types/"
-									>non-normative registry of specialized EPUB publication types</a> for use with this
-								element. This Working Group no longer maintains the registry and does not anticipate
-								developing new specialized publication types.</p>
-						</div>
+							<div class="note">
+								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
+									Working Group maintained a <a href="http://idpf.org/epub/vocab/package/types/"
+										>non-normative registry of specialized EPUB publication types</a> for use with
+									this element. This Working Group no longer maintains the registry and does not
+									anticipate developing new specialized publication types.</p>
+							</div>
+						</section>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3282,12 +3282,8 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
+					<p>Allowed on: [^collection^], Dublin Core <a href="#sec-opf-dcmes-required">required</a> and <a
+							href="#sec-opf-dcmes-optional">optional</a> elements, [^meta^], and [^package^].</p>
 				</section>
 
 
@@ -3328,16 +3324,9 @@
 						<pre>&lt;dc:title id="pub-title"&gt;The Lord of the Rings&lt;/dc:title&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], [^dc:date^], <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, [^dc:identifier^],
-						[^dc:language^], <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, [^dc:subject^], [^dc:title^],
-						[^dc:type^], [^item^], [^itemref^], [^link^], [^manifest^], [^meta^], [^package^] and
-						[^spine^].</p>
+					<p>Allowed on: [^collection^], Dublin Core <a href="#sec-opf-dcmes-required">required</a> and <a
+							href="#sec-opf-dcmes-optional">optional</a> elements, [^item^], [^itemref^], [^link^],
+						[^manifest^], [^meta^], [^package^], and [^spine^].</p>
 				</section>
 
 				<section id="attrdef-media-type">
@@ -3387,7 +3376,7 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^item^], [^itemref^] and [^link^].</p>
+					<p>Allowed on: [^item^], [^itemref^], and [^link^].</p>
 				</section>
 
 				<section id="attrdef-refines" data-epubcheck="true"
@@ -3468,12 +3457,8 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
+					<p>Allowed on: [^collection^], Dublin Core <a href="#sec-opf-dcmes-required">required</a> and <a
+							href="#sec-opf-dcmes-optional">optional</a> elements, [^meta^], and [^package^].</p>
 				</section>
 			</section>
 
@@ -4097,23 +4082,15 @@
 								<ul class="nomark">
 									<li>
 										<p><a href="#attrdef-dir"><code>dir</code></a>
-											<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
-												<code>dc:coverage</code>, <code>dc:creator</code>,
-												<code>dc:description</code>, <code>dc:publisher</code>,
-												<code>dc:relation</code>, <code>dc:rights</code>,
-											<code>dc:source</code>, and <code>dc:subject</code>.</p>
+											<code>[optional]</code></p>
 									</li>
 									<li>
 										<p><a href="#attrdef-id"><code>id</code></a>
-											<code>[optional]</code> – allowed on any element.</p>
+											<code>[optional]</code></p>
 									</li>
 									<li>
 										<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-											<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
-												<code>dc:coverage</code>, <code>dc:creator</code>,
-												<code>dc:description</code>, <code>dc:publisher</code>,
-												<code>dc:relation</code>, <code>dc:rights</code>,
-											<code>dc:source</code>, and <code>dc:subject</code>.</p>
+											<code>[optional]</code></p>
 									</li>
 								</ul>
 							</dd>


### PR DESCRIPTION
This pull request removes the lists of allowed elements from the optional DC definition. It also simplifies the global attribute definitions for xml:lang, dir, and id by referring to the required and optional element sections rather than list out every individual element.

Fixes #2650


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2654.html" title="Last updated on Oct 3, 2024, 6:44 PM UTC (2dab955)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2654/4969dd3...2dab955.html" title="Last updated on Oct 3, 2024, 6:44 PM UTC (2dab955)">Diff</a>