### PR TITLE
Clarify that script and script resources are exempt

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1197,8 +1197,8 @@
 				<dl>
 					<dt id="exempt-fonts">Fonts</dt>
 					<dd id="confreq-resources-cd-fonts">
-						<p>All font resources not already covered as <a href="#cmt-grp-font">font core media types</a>
-							are exempt resources.</p>
+						<p>Font resources not covered as <a href="#cmt-grp-font">font core media types</a> are exempt
+							resources.</p>
 						<p>This exemption allows EPUB creators to use any font format without a fallback, regardless of
 							reading system support expectations, as CSS rules will ensure a fallback font in case of no
 							support.</p>
@@ -1209,42 +1209,46 @@
 					<dt id="exempt-links">Linked resources</dt>
 					<dd id="confreq-resources-cd-fallback-link">
 						<p>Any resource referenced from the [[html]] <a data-cite="html#the-link-element"
-									><code>link</code></a> element that is not already a core media type resource (e.g.,
-							CSS style sheets) is an exempt resource.</p>
+									><code>link</code></a> element that is not a core media type resource (e.g., CSS
+							style sheets) is an exempt resource.</p>
 					</dd>
 
 					<div class="proposed correction" id="change_1">
 						<span class="marker">Proposed Correction 1</span>
-						<p>The exemption for resources not referenced from the spine or embedded in content documents
-							(refer to the paragraphs following note below), includes resources referenced from
-								<code>script</code> elements, as well as resources retrieved by scripts for processing.
-							The description focused on data sets travelling in the EPUB container, but that was only one
-							use case. This change adds scripting to the major exemption groups and removes it from the
-							case for resources travelling in the container. For more information, refer to <a
+						<p>The <a href="#confreq-foreign-no-fallback">general exemption</a> defined below is ambiguous
+							about whether it applies to scripts and any modules they may use (the <code>script</code>
+							element is not in the list of embedding elements cited as not being exempt). This change
+							makes it clear that these resources are exempt. It also adds the use case of resources being
+							retrieved for processing. For more information, refer to <a
 								href="https://github.com/w3c/epub-specs/issues/2649">issue 2649</a>.</p>
 					</div>
 
 					<ins cite="#change_1">
-						<dt id="exempt-script">Scripts and script resources</dt>
+						<dt id="exempt-script">Scripts and modules</dt>
 						<dd id="confreq-resources-cd-fallback-script">
 							<p>Any resource referenced from the [[html]] <a data-cite="html#the-script-element"
-										><code>script</code></a> element that is not already a core media type resource
-								(e.g., JavaScript) is an exempt resource.</p>
+										><code>script</code></a> element that is not a core media type resource (e.g.,
+								JavaScript) is an exempt resource.</p>
 							<p>In addition, any resources retrieved by a script (e.g., using an <code>import</code>
-								declaration [[ecmascript]] or the XmlHttpRequest [[xhr]] or Fetch [[fetch]] APIs) are
+								declaration [[ecmascript]], or the XmlHttpRequest [[xhr]] or Fetch [[fetch]] APIs) are
 								exempt.</p>
+							<div class="note">
+								<p>These resources may still be subject to fallback requirements depending on how the
+									script uses them. For more information, refer to <a href="#confreq-cd-scripted-flbk"
+									></a>.</p>
+							</div>
 						</dd>
 					</ins>
 
 					<dt id="exempt-track">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
-						<p>All audio and video tracks (e.g., [[?webvtt]] captions, subtitles and descriptions)
-							referenced from the [[html]]&#160;[^track^] element are exempt resources.</p>
+						<p>Audio and video tracks (e.g., [[?webvtt]] captions, subtitles and descriptions) referenced
+							from the [[html]]&#160;[^track^] element are exempt resources.</p>
 					</dd>
 
 					<dt id="exempt-video">Video</dt>
 					<dd id="confreq-resources-cd-fallback-video">
-						<p>All video codecs referenced from the [[html]] [^video^] —&#160;including any child [^source^]
+						<p>Video codecs referenced from the [[html]] [^video^] —&#160;including any child [^source^]
 							elements&#160;— are exempt resources.</p>
 						<div class="note">
 							<p>Although reading systems are encouraged to support at least one of the H.264 [[?h264]]

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1213,15 +1213,28 @@
 							CSS style sheets) is an exempt resource.</p>
 					</dd>
 
-					<dt id="exempt-script">Scripts and script resources</dt>
-					<dd id="confreq-resources-cd-fallback-script">
-						<p>Any resource referenced from the [[html]] <a data-cite="html#the-script-element"
-									><code>script</code></a> element that is not already a core media type resource
-							(e.g., JavaScript) is an exempt resource.</p>
-						<p>In addition, any resources retrieved by a script (e.g., using an <code>import</code>
-							declaration [[ecmascript]] or the XmlHttpRequest [[xhr]] or Fetch [[fetch]] APIs) are
-							exempt.</p>
-					</dd>
+					<div class="proposed correction" id="change_1">
+						<span class="marker">Proposed Correction 1</span>
+						<p>The exemption for resources not referenced from the spine or embedded in content documents
+							(refer to the paragraphs following note below), includes resources referenced from
+								<code>script</code> elements, as well as resources retrieved by scripts for processing.
+							The description focused on data sets travelling in the EPUB container, but that was only one
+							use case. This change adds scripting to the major exemption groups and removes it from the
+							case for resources travelling in the container. For more information, refer to <a
+								href="https://github.com/w3c/epub-specs/issues/2649">issue 2649</a>.</p>
+					</div>
+
+					<ins cite="#change_1">
+						<dt id="exempt-script">Scripts and script resources</dt>
+						<dd id="confreq-resources-cd-fallback-script">
+							<p>Any resource referenced from the [[html]] <a data-cite="html#the-script-element"
+										><code>script</code></a> element that is not already a core media type resource
+								(e.g., JavaScript) is an exempt resource.</p>
+							<p>In addition, any resources retrieved by a script (e.g., using an <code>import</code>
+								declaration [[ecmascript]] or the XmlHttpRequest [[xhr]] or Fetch [[fetch]] APIs) are
+								exempt.</p>
+						</dd>
+					</ins>
 
 					<dt id="exempt-track">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
@@ -1267,8 +1280,10 @@
 
 				<p>This exemption allows EPUB creators to include resources in the [=EPUB container=] that are not for
 					use by EPUB reading systems. The primary case for this exemption is to allow data files to travel
-					with an [=EPUB publication=] for external applications to use (e.g., a scientific journal might
-					include a data set with instructions on how to extract it from the EPUB container).</p>
+					with an [=EPUB publication=]<del cite="#change_1">, whether for scripts to use in their
+						constituent EPUB content documents or</del> for external applications to use (e.g., a scientific
+					journal might include a data set with instructions on how to extract it from the EPUB
+					container).</p>
 
 				<p>It also allows EPUB creators to use foreign resources in foreign content documents without reading
 					systems or [=EPUB conformance checkers=] having to understand the fallback capabilities of those
@@ -5989,7 +6004,7 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L910,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 						<h5>Embedded SVG</h5>
 
-						<div class="proposed correction" id="change_1">
+						<div class="proposed correction" id="change_2">
 							<span class="marker">Proposed Correction 1</span>
 							<p data-cite="svg2">The current section does not clearly indicate that an SVG embedded by
 								reference is already required to be a conforming SVG content document (not a document
@@ -6001,20 +6016,20 @@ No Entry</pre>
 									2555</a>.</p>
 						</div>
 
-						<p>[=XHTML content documents=] support the embedding of <del cite="#change_1"><a
+						<p>[=XHTML content documents=] support the embedding of <del cite="#change_2"><a
 									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
 									fragments</a> [[svg]] <em>by reference</em> (embedding via reference, for example,
 								from an <code>img</code> or <code>object</code> element) and <em>by inclusion</em>
 								(embedding via direct inclusion of the <code>svg</code> element in the XHTML content
-								document).</del><ins cite="#change_1">SVG:</ins></p>
+								document).</del><ins cite="#change_2">SVG:</ins></p>
 
-						<del cite="#change_1">
+						<del cite="#change_2">
 							<p>The content conformance constraints for SVG embedded in XHTML content documents are the
 								same as defined for [=SVG content documents=] in <a href="#sec-svg-restrictions"
 								></a>.</p>
 						</del>
 
-						<ins cite="#change_1">
+						<ins cite="#change_2">
 							<ul>
 								<li id="sec-xhtml-svg-reference"><em>by reference</em> &#8212; for example, from an
 									[[html]] [^img^] or [^object^] element. SVGs embedded by reference are <a
@@ -6111,25 +6126,25 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L33,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L41,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L47,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 					<h4>SVG requirements</h4>
 
-					<div class="proposed correction" id="change_2">
+					<div class="proposed correction" id="change_3">
 						<span class="marker">Proposed Correction 2</span>
 						<p data-cite="svg2">SVG already allows foreign-namespaced attributes to be used anywhere. The
 							two "MAY" bullets in the current text that allow the <code>epub:</code> namespaced
 							attributes are consequently not real requirements and are removed. That the attributes are
 							allowed on SVGs is now a note in the next section on the content model restrictions (see <a
-								href="#change_3">proposed correction 3</a>), as that is where the restriction in the
+								href="#change_4">proposed correction 3</a>), as that is where the restriction in the
 							second bullet on what elements the <code>epub:type</code> attribute is allowed is moved. For
 							more information, refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue
 								2555</a>.</p>
 					</div>
 
-					<p id="confreq-cd-svg-docprops-schema">An [=SVG content document=]<del cite="#change_2">:</del>
-						<ins cite="#change_2">MUST be a <a
+					<p id="confreq-cd-svg-docprops-schema">An [=SVG content document=]<del cite="#change_3">:</del>
+						<ins cite="#change_3">MUST be a <a
 								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">conforming
 								SVG stand-alone file</a> [[svg]] and conform to all content conformance constraints
 							expressed in <a href="#sec-svg-restrictions"></a>.</ins></p>
 
-					<del cite="#change_2">
+					<del cite="#change_3">
 						<ul class="conformance-list">
 							<li>
 								<p>MUST be a <a
@@ -6193,7 +6208,7 @@ No Entry</pre>
 							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] [^title^] element contains
 								marked-up text, the markup MUST contain only elements declared in the <a
 									data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
-							<ins cite="#change_3">
+							<ins cite="#change_4">
 								<div class="note">
 									<p>Although the [[svg]] <code>title</code> element allows markup elements, support
 										for this feature is limited. [=EPUB creators=] are advised to use text-only
@@ -6202,23 +6217,23 @@ No Entry</pre>
 							</ins>
 						</li>
 						<li>
-							<div class="proposed correction" id="change_3">
+							<div class="proposed correction" id="change_4">
 								<span class="marker">Proposed Correction 3</span>
 								<p>This correction adds the restriction on where the <code>epub:type</code> attribute is
-									allowed (refer to <a href="#change_2">proposed correction 2</a> for its former
+									allowed (refer to <a href="#change_3">proposed correction 2</a> for its former
 									placement). Moving the restriction into this section also makes it applicable to
 									SVGs embedded by inclusion in HTML documents, a requirement that was not clearly
 									established when the restriction was in the preceding section. For more information,
 									refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue 2555</a>.</p>
 								<p data-cite="svg2">This correction also addresses the list of elements the
-									[^/epub:type^] attribute is allowed on. The current list (see <a href="#change_2"
+									[^/epub:type^] attribute is allowed on. The current list (see <a href="#change_3"
 										>proposed correction 2</a>) does not allow the attribute on the SVG [^a^]
 									element. The text is corrected to use the [[svg2]] definition of a renderable
 									element to avoid the problem of missing elements when selecting more granular
 									element classes. For more information, refer to <a
 										href="https://github.com/w3c/epub-specs/issues/2556">issue 2556</a>.</p>
 							</div>
-							<ins cite="#change_3">
+							<ins cite="#change_4">
 								<p id="confreq-svg-structural-semantics">When specified, the [^/epub:type^] attribute
 									MUST only be included on [=renderable elements=] [[svg]].</p>
 								<div class="note">
@@ -6234,7 +6249,7 @@ No Entry</pre>
 							</ins>
 						</li>
 					</ul>
-					<del cite="#change_3">
+					<del cite="#change_4">
 						<div class="note">
 							<p>Although the [[svg]] <code>title</code> element allows markup elements, support for this
 								feature is limited. [=EPUB creators=] are advised to use text-only titles for maximum
@@ -11017,7 +11032,7 @@ html.my-document-playing * {
 						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
 						>assignment character</a>.</p>
 
-				<div class="proposed correction" id="change_4">
+				<div class="proposed correction" id="change_5">
 					<span class="marker">Proposed Correction 4</span>
 					<p data-cite="svg2">The following paragraph mixed in a reference to the [[infra]] specification's
 						definition of whitespace characters, which is only valid for HTML documents. This would have
@@ -11031,12 +11046,12 @@ html.my-document-playing * {
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). EPUB creators MAY include any <ins cite="#change_4"><a
-							data-cite="xml#NT-S">whitespace characters</a> [[xml]]</ins><del cite="#change_4">valid
+					within the attribute to single spaces). EPUB creators MAY include any <ins cite="#change_5"><a
+							data-cite="xml#NT-S">whitespace characters</a> [[xml]]</ins><del cite="#change_5">valid
 						[=ascii whitespace=] [[infra]]</del> in the authored tag so long as the result is valid to this
 					definition.</p>
 
-				<ins cite="#change_4">
+				<ins cite="#change_5">
 					<div class="note">
 						<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
 								data-cite="infra#ascii-whitespace">definition of whitespace</a>, the Form Feed (U+000C)
@@ -12033,6 +12048,8 @@ EPUB/images/cover.png</pre>
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2023/REC-epub-33-20230525/"
 						>Recommendation</a> of 2023-05-25</summary>
 				<ul>
+					<li>03-Oct-2024: Clarified that scripts and resources retrieved by them are exempt resources. See <a
+							href="https://github.com/w3c/epub-specs/issues/2649">issue 2649</a>.</li>
 					<li>16-July-2024: Fixed the definition of whitespace allowed in viewport meta tags to refer to the
 						characters allowed by the XML standard. See <a
 							href="https://github.com/w3c/epub-specs/issues/2637">issue 2637</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1213,6 +1213,16 @@
 							CSS style sheets) is an exempt resource.</p>
 					</dd>
 
+					<dt id="exempt-script">Scripts and script resources</dt>
+					<dd id="confreq-resources-cd-fallback-script">
+						<p>Any resource referenced from the [[html]] <a data-cite="html#the-script-element"
+									><code>script</code></a> element that is not already a core media type resource
+							(e.g., JavaScript) is an exempt resource.</p>
+						<p>In addition, any resources retrieved by a script (e.g., using an <code>import</code>
+							declaration [[ecmascript]] or the XmlHttpRequest [[xhr]] or Fetch [[fetch]] APIs) are
+							exempt.</p>
+					</dd>
+
 					<dt id="exempt-track">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
 						<p>All audio and video tracks (e.g., [[?webvtt]] captions, subtitles and descriptions)
@@ -1257,9 +1267,8 @@
 
 				<p>This exemption allows EPUB creators to include resources in the [=EPUB container=] that are not for
 					use by EPUB reading systems. The primary case for this exemption is to allow data files to travel
-					with an [=EPUB publication=], whether for scripts to use in their constituent EPUB content documents
-					or for external applications to use (e.g., a scientific journal might include a data set with
-					instructions on how to extract it from the EPUB container).</p>
+					with an [=EPUB publication=] for external applications to use (e.g., a scientific journal might
+					include a data set with instructions on how to extract it from the EPUB container).</p>
 
 				<p>It also allows EPUB creators to use foreign resources in foreign content documents without reading
 					systems or [=EPUB conformance checkers=] having to understand the fallback capabilities of those

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1280,10 +1280,9 @@
 
 				<p>This exemption allows EPUB creators to include resources in the [=EPUB container=] that are not for
 					use by EPUB reading systems. The primary case for this exemption is to allow data files to travel
-					with an [=EPUB publication=]<del cite="#change_1">, whether for scripts to use in their
-						constituent EPUB content documents or</del> for external applications to use (e.g., a scientific
-					journal might include a data set with instructions on how to extract it from the EPUB
-					container).</p>
+					with an [=EPUB publication=]<del cite="#change_1">, whether for scripts to use in their constituent
+						EPUB content documents or</del> for external applications to use (e.g., a scientific journal
+					might include a data set with instructions on how to extract it from the EPUB container).</p>
 
 				<p>It also allows EPUB creators to use foreign resources in foreign content documents without reading
 					systems or [=EPUB conformance checkers=] having to understand the fallback capabilities of those
@@ -6005,7 +6004,7 @@ No Entry</pre>
 						<h5>Embedded SVG</h5>
 
 						<div class="proposed correction" id="change_2">
-							<span class="marker">Proposed Correction 1</span>
+							<span class="marker">Proposed Correction 2</span>
 							<p data-cite="svg2">The current section does not clearly indicate that an SVG embedded by
 								reference is already required to be a conforming SVG content document (not a document
 								fragment) or that its requirements are defined in section 6.2. The only unique case here
@@ -6127,12 +6126,12 @@ No Entry</pre>
 					<h4>SVG requirements</h4>
 
 					<div class="proposed correction" id="change_3">
-						<span class="marker">Proposed Correction 2</span>
+						<span class="marker">Proposed Correction 3</span>
 						<p data-cite="svg2">SVG already allows foreign-namespaced attributes to be used anywhere. The
 							two "MAY" bullets in the current text that allow the <code>epub:</code> namespaced
 							attributes are consequently not real requirements and are removed. That the attributes are
 							allowed on SVGs is now a note in the next section on the content model restrictions (see <a
-								href="#change_4">proposed correction 3</a>), as that is where the restriction in the
+								href="#change_4">proposed correction 4</a>), as that is where the restriction in the
 							second bullet on what elements the <code>epub:type</code> attribute is allowed is moved. For
 							more information, refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue
 								2555</a>.</p>
@@ -6218,9 +6217,9 @@ No Entry</pre>
 						</li>
 						<li>
 							<div class="proposed correction" id="change_4">
-								<span class="marker">Proposed Correction 3</span>
+								<span class="marker">Proposed Correction 4</span>
 								<p>This correction adds the restriction on where the <code>epub:type</code> attribute is
-									allowed (refer to <a href="#change_3">proposed correction 2</a> for its former
+									allowed (refer to <a href="#change_3">proposed correction 3</a> for its former
 									placement). Moving the restriction into this section also makes it applicable to
 									SVGs embedded by inclusion in HTML documents, a requirement that was not clearly
 									established when the restriction was in the preceding section. For more information,
@@ -11033,7 +11032,7 @@ html.my-document-playing * {
 						>assignment character</a>.</p>
 
 				<div class="proposed correction" id="change_5">
-					<span class="marker">Proposed Correction 4</span>
+					<span class="marker">Proposed Correction 5</span>
 					<p data-cite="svg2">The following paragraph mixed in a reference to the [[infra]] specification's
 						definition of whitespace characters, which is only valid for HTML documents. This would have
 						allowed the Form Feed character in <code>viewport meta</code> tags even though Form Feed is not


### PR DESCRIPTION
The current prose about exempt resources including resources not referenced from the spine or embedded in content documents already excludes these resources, but this creates a formal exemption group to make this clear.

The pull request does not get into whether WASM should be a core media type or be supported by reading systems, so it only rises to a class 3 change. (For that reason, I'm not setting this to auto-close #2649.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2655.html" title="Last updated on Oct 7, 2024, 5:50 PM UTC (1784159)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2655/4969dd3...1784159.html" title="Last updated on Oct 7, 2024, 5:50 PM UTC (1784159)">Diff</a>