### PR TITLE
Add change logs to rs and a11y specs

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1898,7 +1898,7 @@
 				<p>No substantive changes were made.</p>
 			</details>
 
-			<details id="changes-cr" open="">
+			<details id="changes-cr">
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2022/CR-epub-a11y-11-20220512/"
 						>Candidate Recommendation</a> of 2022-05-12</summary>
 				<ul>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -128,6 +128,9 @@
 			}
 			pre {
 				white-space: break-spaces !important;
+			}
+			#change-log > details > p {
+				margin-left: 1rem;
 			}</style>
 	</head>
 	<body>
@@ -1889,15 +1892,11 @@
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-Accessibility+label%3AAccessibility11"
 					>working group's issue tracker</a>.</p>
 
-			<!-- Uncomment when there are substantive changes to publish
 			<details id="changes-from-rec-20230523" open="">
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2023/REC-epub-a11y-11-20230525/"
 						>Recommendation</a> of 2023-05-25</summary>
-				<ul>
-					<li></li>
-				</ul>
+				<p>No substantive changes were made.</p>
 			</details>
-				-->
 
 			<details id="changes-cr" open="">
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2022/CR-epub-a11y-11-20220512/"

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -128,6 +128,11 @@
 					}
 				]
 			};//]]></script>
+		<style>
+			#change-log > details > p {
+				margin-left: 1rem;
+			}
+		</style>
 	</head>
 	<body>
 		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
@@ -2708,15 +2713,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-ReadingSystems"
 					>working group's issue tracker</a>.</p>
 
-			<!-- Uncomment when there are substantive changes to publish
 			<details id="changes-from-rec-20230523" open="">
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2023/REC-epub-rs-33-20230525/"
 						>Recommendation</a> of 2023-05-25</summary>
-				<ul>
-					<li></li>
-				</ul>
+				<p>No substantive changes were made.</p>
 			</details>
-				-->
 
 			<details id="changes-cr" open="">
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2022/CR-epub-rs-33-20220512/"

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2719,7 +2719,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<p>No substantive changes were made.</p>
 			</details>
 
-			<details id="changes-cr" open="">
+			<details id="changes-cr">
 				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2022/CR-epub-rs-33-20220512/"
 						>Candidate Recommendation</a> of 2022-05-12</summary>
 				<ul>


### PR DESCRIPTION
Even though we are only making class 1 and 2 changes to these specifications, I assume we should still note this is the case in a change log entry. Otherwise, it might invite some confusion.