### PR TITLE
Addressing APA feedback in FXL Accessibility Document

### DIFF
--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB Best Practices for Fixed Layout Accessibility</title>
+		<title>EPUB Accessibility - Fixed Layout Challenges and Best Practices</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
@@ -51,7 +51,7 @@
 	</head>
 <body data-include-format="markdown">
     <section id="abstract">
-        <p>This document, EPUB Best Practices for Fixed Layout Accessibility, outlines the goals for EPUB accessible fixed layout ebooks while acknowledging the challenges unique to the fixed layout format.</p>
+        <p>An accessible fixed layout EPUB file is one that meets the accessibility requirements of the Web Content Accessibility Guidelines 2.x level AA [[wcag2]] and EPUB Accessibility 1.1 [[epub-a11y-11].This document, Fixed Layout Challenges and Best Practices, outlines the goals for EPUB accessible fixed layout ebooks while acknowledging the challenges unique to the fixed layout format.</p>
     </section>
 
     <section id="sotd"></section>

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB Fixed Layout Accessibility</title>
+		<title>EPUB Best Practices for Fixed Layout Accessibility</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
@@ -51,7 +51,7 @@
 	</head>
 <body data-include-format="markdown">
     <section id="abstract">
-        <p>This document, EPUB Fixed Layout Accessibility, outlines the goals for EPUB accessible fixed layout ebooks while acknowledging the challenges unique to the fixed layout format.</p>
+        <p>This document, EPUB Best Practices for Fixed Layout Accessibility, outlines the goals for EPUB accessible fixed layout ebooks while acknowledging the challenges unique to the fixed layout format.</p>
     </section>
 
     <section id="sotd"></section>

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -192,7 +192,7 @@
 
             <blockquote>A key concept of EPUB is that an EPUB publication consists of multiple resources that can be completely navigated and consumed by a person or program in some specific order. - 1.2.1 Reading Order EPUB 3.3 Overview [[epub-overview-33]]</blockquote>
 
-            <p>Reading order in EPUB refers to the order of content documents in the <a href="https://www.w3.org/TR/epub-33/#sec-pkg-spine"><code>spine</code></a> section of the <a href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package</a> document. However, the concept of reading order is also an important consideration for accessibility and refers to the visual and programmatic order of elements in a content document. In both EPUB and accessibility usage, reading order must be logical and accurate both visually and programmatically.</p>
+            <p>Reading order in EPUB refers to the order of content documents in the <a href="https://www.w3.org/TR/epub-33/#sec-pkg-spine"><code>spine</code></a> section of the <a href="https://www.w3.org/TR/epub-33/#sec-package-doc">package document</a>. However, the concept of reading order is also an important consideration for accessibility and refers to the visual and programmatic order of elements in a content document. In both EPUB and accessibility usage, reading order must be logical and accurate both visually and programmatically.</p>
 
             <p>Whereas many reflowable publications have an obvious reading order, or logical progression through their content, fixed layout publications are often more complex in their design and layout and may consist of multiple readable objects on the same page.</p>
 

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -192,6 +192,8 @@
 
             <blockquote>A key concept of EPUB is that an EPUB publication consists of multiple resources that can be completely navigated and consumed by a person or program in some specific order. - 1.2.1 Reading Order EPUB 3.3 Overview [[epub-overview-33]]</blockquote>
 
+            <p>Reading order in EPUB refers to the order of content documents in the <a href="https://www.w3.org/TR/epub-33/#sec-pkg-spine"><code>spine</code></a> section of the <a href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package</a> document. However, the concept of reading order is also an important consideration for accessibility and refers to the visual and programmatic order of elements in a content document. In both EPUB and accessibility usage, reading order must be logical and accurate both visually and programmatically.</p>
+
             <p>Whereas many reflowable publications have an obvious reading order, or logical progression through their content, fixed layout publications are often more complex in their design and layout and may consist of multiple readable objects on the same page.</p>
 
             <p>For viewers of the visual page, the reading order can be inferred by various visual triggers including:</p>
@@ -224,12 +226,14 @@
 
                 <blockquote>If a blind user, who reads the page with a screen reader that follows the source order, is working with a sighted user who reads the page in visual order, they may be confused when they encounter information in different orders. A user with low vision who uses a screen magnifier in combination with a screen reader may be confused when the reading order appears to skip around on the screen. A keyboard user may have trouble predicting where focus will go next when the source order does not match the visual order. - <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C27">Making the DOM order match the visual order</a></blockquote>
 
+                <p>EPUB authors need to be mindful of how the reading order of a page is presented both visually and programmatically to readers. The DOM order, or programmatic order, refers to the order of elements in the source code for a content document. As much as possible, the programmatic order of a page should match its visual order.</p>
+
             </section>
 
             <section id="reading-order-removing">
                 <h4>Removing items from the reading order</h4>
 
-                <p>There may be cases when text appears on the page but is unnecessary, duplicated or otherwise confusing for it to be added to the reading order, e.g. page numbers, running headers and footers, or text used for visual effects.</p>
+                <p>There may be cases when text appears on the page but is unnecessary, duplicated or otherwise confusing for it to be added to the programmatic reading order, e.g. page numbers, running headers and footers, or text used for visual effects.</p>
 
                 <p>See the <a href="https://w3c.github.io/epub-specs/epub33/fxl-a11y-tech/#reading-order-removing">techniques</a> document for guidance on how to apply this recommendation.</p>
             </section>
@@ -237,7 +241,7 @@
             <section id="reading-order-spreads">
                 <h4>Reading order across the 'fold'</h4>
 
-                <p>Fixed layout documents can be presented as synthetic spreads where two pages are arranged side-by-side. As each page of the fixed layout document is a separate XHTML document, it is expected that the reading order of the EPUB flows from one page to the next. Even if the content is presented in a synthetic spread, the reading order should not require that the reader move between pages to read the content in order.</p>
+                <p>Fixed layout documents can be presented as synthetic spreads where two pages are arranged side-by-side. As each page of the fixed layout document is a separate XHTML document, it is expected that the reading order of the EPUB flows from one page to the next. Even if the content is presented in a synthetic spread, the reading order should not require that the reader move back and forth between pages to read the content in order.</p>
 
                 <p>If the text must be read in this way, the only solution to maintain the correct reading order is to convert the double page spread in to a single landscape page that contains the entire content of the spread and for the EPUB to be rendered as single pages.</p>
             </section>


### PR DESCRIPTION
This PR includes some edits to address the feedback we received regarding the FXL Accessibility document from APA during our session with them at TPAC. 

Two main changes: 
1. Adjusted the name of the document to include "Best Practices" to avoid confusion around conformance. 
2. Added text to further clarify the reading order section, including noting the difference between EPUB's concept of reading order and accessibility's concept of reading order. 

Feedback welcome!