### PR TITLE
Update date/time references to iso8601-1

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4230,7 +4230,7 @@
 									href="#last-modified-date">last modified date</a> (the last time the [=EPUB
 								creator=] changed the EPUB publication).</p>
 
-							<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
+							<p>It is RECOMMENDED that the date string conform to [[iso8601-1]], particularly the subset
 								expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
 								machine readable.</p>
 
@@ -4492,8 +4492,9 @@
 
 					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one <dfn
 							class="export" data-lt-no-plural=""><code>dcterms:modified</code></dfn> property [[dcterms]]
-						containing the last modification date. The [=value=] of this property MUST be an [[xmlschema-2]]
-						dateTime conformant date of the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
+						containing the last modification date. The [=value=] of this property MUST be an [[iso8601-1]]
+						complete representation of a date and time of day matching the extended format:
+							<code>YYYY-MM-DDThh:mm:ssZ</code></p>
 
 					<p>[=EPUB creators=] MUST express the last modification date in Coordinated Universal Time (UTC) and
 						MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>


### PR DESCRIPTION
This pull requests updates the reference to 8601 to 8601-1 in the dc:date section.

I also switched the xml schemas reference in the last modification date section to iso8601-1 and changed the wording slightly to match up with how 8601-1 describes this pattern in s. 4.3. I also changed "CCYY" to "YYYY" in the pattern to match 8601's nomenclature, but they're functionally equivalent expressions.

(I think the statement in the next paragraph that the pattern must terminate with "Z" is duplicative of the pattern requirement itself, but in the interest of not taking out a normative statement and seeing if it triggers a class 3 change, I'll leave that for another day.)

Fixes #2658


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2661.html" title="Last updated on Oct 21, 2024, 4:13 PM UTC (74ee06d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2661/0c3ffb6...74ee06d.html" title="Last updated on Oct 21, 2024, 4:13 PM UTC (74ee06d)">Diff</a>