### PR TITLE
Fix name conflict in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/50-epub-ssv.md
+++ b/.github/ISSUE_TEMPLATE/50-epub-ssv.md
@@ -1,8 +1,8 @@
 ---
-name: EPUB 3 Text-to-Speech
+name: EPUB 3 Structural Semantics Vocabulary
 about: Issue related to the “EPUB 3 Structural Semantics Vocabulary 1.1” Working Group Note
 title: ''
-labels: Spec-TTS
+labels: Spec-SSV
 assignees: ''
 
 ---


### PR DESCRIPTION
The structural semantics vocabulary template has the same name as the TTS template so neither is appearing in the list of options when you try to open a new issue. This should fix the problem.