### PR TITLE
Remove the a11y prefix from the pageBreakSource property

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1993,7 +1993,7 @@
 						<p>The <code>pageBreakSource</code> property is the proposed replacement for this property. It
 							is still being incubated for inclusion in the <a
 								href="https://www.w3.org/TR/epub/#app-meta-property-vocab">Meta properties
-								vocabulary</a> [[epub-3]] but it is anticipated it will be added in the upcoming
+								vocabulary</a> [[epub-3]] but it is anticipated that it will be added in the upcoming
 							revision. That is why these techniques no longer refer to the <code>source-of</code>
 							property, even though it remains the official property in the specification.</p>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1980,6 +1980,29 @@
 &lt;/metadata></pre>
 					</aside>
 
+					<div class="note">
+						<p>The <a href="https://www.w3.org/TR/epub/#sec-source-of"><code>source-of</code> property</a>
+							was previously recommended in these techniques to identify the <a
+								href="https://www.w3.org/TR/epub/#sec-opf-dcmes-optional-def"><code>dc:source</code>
+								element</a> containing the source of the pagination [[epub-3]]. This method came with a
+							number of limitations, however. It was not future proof, for example, as it relied on the
+							EPUB 3 <a href="https://www.w3.org/TR/epub/#attrdef-refines"><code>refines</code>
+								attribute</a> [[epub-3]] and it could not handle pagination without a source due to the
+							reliance on a <code>dc:source</code> element.</p>
+
+						<p>The <code>pageBreakSource</code> property is the proposed replacement for this property. It
+							is still being incubated for inclusion in the <a
+								href="https://www.w3.org/TR/epub/#app-meta-property-vocab">Meta properties
+								vocabulary</a> [[epub-3]] but it is anticipated it will be added in the upcoming
+							revision. That is why these techniques no longer refer to the <code>source-of</code>
+							property, even though it remains the official property in the specification.</p>
+
+						<p>It is strongly recommended that EPUB creators switch to using the
+								<code>pageBreakSource</code> property. EPUBCheck already accepts it so it should not
+							cause validation issues. Although the <code>source-of</code> method will remain valid for
+							backwards compatibility purposes, it is no longer recommended for new publications.</p>
+					</div>
+
 					<p>If an ISBN is not available, include as much information as possible about the source publication
 						(e.g., the publisher, date, edition, and binding).</p>
 
@@ -2005,20 +2028,6 @@
    …
 &lt;/metadata></code></pre>
 					</aside>
-
-					<div class="note">
-						<p>The <a href="https://www.w3.org/TR/epub/#sec-source-of"><code>source-of</code> property</a>
-							was originally defined to identify the <a
-								href="https://www.w3.org/TR/epub/#sec-opf-dcmes-optional-def"><code>dc:source</code>
-								element</a> containing the source of the pagination [[epub-3]]. This method came with a
-							number of limitations, however. It was not future proof, for example, as it relied on the
-							EPUB 3 <a href="https://www.w3.org/TR/epub/#attrdef-refines"><code>refines</code>
-								attribute</a> [[epub-3]] and it could not handle pagination without a source due to the
-							reliance on a <code>dc:source</code> element.</p>
-
-						<p>Although this method remains valid for backwards compatibility purposes, it is strongly
-							recommended not to use it for new publications.</p>
-					</div>
 				</section>
 			</section>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1965,15 +1965,15 @@
 					<p>To allow users to determine the suitability of the pagination, identify the ISBN of the source
 						work in the <a href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a>
 						metadata using the <a href="https://www.w3.org/publishing/a11y/page-source-id/"
-								><code>a11y:pageBreakSource</code> property</a> [[page-source-id]].</p>
+								><code>pageBreakSource</code> property</a> [[page-source-id]].</p>
 
 					<aside class="example" title="Expressing the source of pagination">
-						<p>In this example, the <code>a11y:pageBreakSource</code> property contains the ISBN of the
-							print source of pagination. (For EPUB 2, the <code>name</code> attribute would be used as it
-							does not define a <code>property</code> attribute for <code>meta</code> tags.)</p>
+						<p>In this example, the <code>pageBreakSource</code> property contains the ISBN of the print
+							source of pagination. (For EPUB 2, the <code>name</code> attribute would be used as it does
+							not define a <code>property</code> attribute for <code>meta</code> tags.)</p>
 						<pre>&lt;metadata …>
    …
-   &lt;meta property="a11y:pageBreakSource">
+   &lt;meta property="pageBreakSource">
       urn:isbn:9780375704024
    &lt;/meta>
    …
@@ -1986,7 +1986,7 @@
 					<aside class="example" title="Text description of the source">
 						<pre>&lt;metadata …>
    …
-   &lt;meta property="a11y:pageBreakSource">
+   &lt;meta property="pageBreakSource">
       ACME Publishing, 1945, 2nd Edition, Softcover
    &lt;/meta>
    …
@@ -1994,12 +1994,12 @@
 					</aside>
 
 					<p>If the page break markers are unique to the EPUB publication, use the value <code>none</code>
-						with the <code>a11y:pageBreakSource</code> property.</p>
+						with the <code>pageBreakSource</code> property.</p>
 
 					<aside class="example" title="Page breaks without a source">
 						<pre><code>&lt;metadata …>
    …
-   &lt;meta property="a11y:pageBreakSource">
+   &lt;meta property="pageBreakSource">
       none
    &lt;/meta>
    …
@@ -2479,8 +2479,10 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>02-Dec-2024: Removed incorrect use of <code>a11y</code> prefix on the <code>pageBreakSource</code>
+					property. See <a href="https://github.com/w3c/epub-specs/issues/2667">issue 2667</a>.</li>
 				<li>20-June-2024: Updated guidance on identifying the page source to use the
-						<code>a11y:pageBreakSource</code> property. See <a
+						<code>pageBreakSource</code> property. See <a
 						href="https://github.com/w3c/epub-specs/issues/2626">issue 2626</a>.</li>
 				<li>20-June-2024: Added note to use <code>pageNavigation</code> accessibility feature when a page list
 					is included. See <a href="https://github.com/w3c/epub-specs/issues/2626">issue 2626</a>.</li>


### PR DESCRIPTION
Fixes #2667 

***

[Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/pbs-property-prefix/epub33/a11y-tech/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/pbs-property-prefix/epub33/a11y-tech/index.html)

