### PR TITLE
Remove normative keywords and conformance section from the exemption note

### DIFF
--- a/epub33/a11y-exemption/index.html
+++ b/epub33/a11y-exemption/index.html
@@ -81,13 +81,19 @@
 					would require a fundamental alteration of the product.</p>
 
 				<p>Although it is possible to explain these exemptions in the accessibility summary for an [=EPUB
-					publication=], plain language statements are not easily processed by machines. A vendor may want to
-					know that a publication is exempt before allowing it in their bookstore without an accessibility
+					publication=], plain language statements are not easily processed by machines. A vendor might want
+					to know that a publication is exempt before allowing it in their bookstore without an accessibility
 					conformance claim, for example.</p>
 
 				<p>This document defines a new property named <code>exemption</code> in the <a
 						href="https://www.w3.org/TR/epub-a11y/#app-vocab-ref">accessibility vocabulary namespace</a>
 					[[epub-a11y]] to address this need for machine-readable metadata.</p>
+
+				<div class="note">
+					<p>This property is defined as a convenience for publishers and vendors who require the exchange of
+						exemption information. It is not anticipated that the property will become a formal part of
+						either the EPUB Accessibility [[epub-a11y]] or EPUB 3 [[epub-33]] standards.</p>
+				</div>
 			</section>
 
 			<section id="sec-terminology">
@@ -100,8 +106,6 @@
 					<p>Only the first instance of a term in a section links to its definition.</p>
 				</div>
 			</section>
-
-			<section id="conformance"></section>
 		</section>
 		<section id="sec-evaluator-name">
 			<h3>Accessibility conformance exemptions</h3>
@@ -124,7 +128,7 @@
 					otherwise list the accessibility status as unknown.</p>
 			</div>
 
-			<p>The property MAY be repeated to list exemptions for multiple jurisdictions and/or for multiple exemptions
+			<p>The property can be repeated to list exemptions for multiple jurisdictions and/or for multiple exemptions
 				within a single jurisdiction.</p>
 
 			<aside class="example" title="An EPUB publication with two exemptions from the European Accessibility Act">
@@ -168,7 +172,8 @@
 						<th>Description:</th>
 						<td>
 							<p>Identifies the accessibility exemption the [=EPUB publication=] falls under.</p>
-							<p>The value SHOULD be one of the values listed in <a href="#exemption-values"></a>.</p>
+							<p>It is advised to use only the values listed in <a href="#exemption-values"></a> for
+								consistent processing.</p>
 						</td>
 					</tr>
 					<tr>
@@ -183,8 +188,8 @@
 					</tr>
 					<tr>
 						<th>Extends:</th>
-						<td>Only applies to the [=EPUB publication=]. MUST NOT be used when the <a
-								data-cite="epub-33#attrdef-refines">refines attribute</a> [[epub-33]] is present.</td>
+						<td>Only applies to the [=EPUB publication=]. Do not use with the <a
+								data-cite="epub-33#attrdef-refines">refines attribute</a> [[epub-33]].</td>
 					</tr>
 					<tr>
 						<th>Example:</th>


### PR DESCRIPTION
Concerns have been raised in the charter process about the use of normative language in the exemption note. There are only three instances where we've used normative keywords, primarily in defining the value of the property. None of these is essential and this pull request rewords them out of the document.

I've also added a note to the overview that the we don't plan to take this property any further down the standardization track; that's it's defined as a convenience for those who need it.

Let me know if there are any concerns with this before we take it any further.

---

See [Preview](https://raw.githack.com/w3c/epub-specs/fix/exempt-note-non-norm/epub33/a11y-exemption/index.html), [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FTR%2Fepub-a11y-exemption%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fexempt-note-non-norm%2Fepub33%2Fa11y-exemption%2Findex.html)