### PR TITLE
Misspelling OCF (was OFC)

### DIFF
--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -181,7 +181,7 @@
 				own content transformation pipelines.</p>
 
 			<p>For more information about an EPUB publication's representation as a container file, refer to <a
-					data-cite="epub-33#sec-ocf">Open Container Format (OFC)</a> [[epub-33]].</p>
+					data-cite="epub-33#sec-ocf">Open Container Format (OCF)</a> [[epub-33]].</p>
 
 		</section>
 		<section id="sec-package-file">
@@ -649,7 +649,7 @@
 					approved by the IDPF as the OEBPS Container Format (OCF) in 2006. Work on a 2.0 revision of OEBPS
 					began in parallel which was renamed EPUB 2.0 in October 2007 and approved in September 2010. This
 					revision consisted of a triumvirate of specifications: Open Package Format (OPF), Open Publication
-					Format (OPF), and OCF. EPUB 2.0.1, which was a maintenance update to the 2.0 specification set,
+					Structure (OPS), and OCF. EPUB 2.0.1, which was a maintenance update to the 2.0 specification set,
 					primarily intended to clarify and correct errata in the specifications. See [[opf-201]] [[ops-201]]
 					[[ocf-201]]. </p>
 


### PR DESCRIPTION
Was signalled through email by Grégoire Clemencin (thank you).

I also spotted another possible misspelling in the history part. @mattgarrish, as the living memory of all the EPUB versions ❤️, can you check these?