### PR TITLE
GitHub actions: replace ubuntu-20.04 with ubuntu-latest

### DIFF
--- a/.github/workflows/epub-a11y-eaa-mapping.yml
+++ b/.github/workflows/epub-a11y-eaa-mapping.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB Accessibility - EU Accessibility Act Mapping 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-a11y-exemption-property.yml
+++ b/.github/workflows/epub-a11y-exemption-property.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB Accessibility Exemption Property 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-a11y-tech.yml
+++ b/.github/workflows/epub-a11y-tech.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB Accessibility Techniques 1.1 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-a11y.this_should_be_yml
+++ b/.github/workflows/epub-a11y.this_should_be_yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB Accessibility 1.1 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-core.this_should_be_yml
+++ b/.github/workflows/epub-core.this_should_be_yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB 33 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-fxl-a11y
+++ b/.github/workflows/epub-fxl-a11y
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB Fixed Layout Accessibility 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-multi-rend.yml
+++ b/.github/workflows/epub-multi-rend.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB Multiple-Rendition Publications 1.1 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-overview.yml
+++ b/.github/workflows/epub-overview.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB 3 Overview 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-rs.this_should_be_yml
+++ b/.github/workflows/epub-rs.this_should_be_yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish Reading Systems 3.3 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-ssv.yml
+++ b/.github/workflows/epub-ssv.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish Structural Semantics Vocabulary 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/epub-tts.yml
+++ b/.github/workflows/epub-tts.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   main:
     name: Publish EPUB 3 Text-to-Speech Enhancements 1.0 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2


### PR DESCRIPTION
[GitHub will no longer support the Ubuntu 20.04 runner image starting from April 1, 2025](https://github.com/actions/runner-images/issues/11101). That PR updates the actions to use ubuntu-latest instead