### PR TITLE
Start accessibility spec at 1.1.1

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB Accessibility Techniques 1.2</title>
+		<title>EPUB Accessibility Techniques 1.1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
@@ -11,7 +11,7 @@
 				group: "pm",
 				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
-				shortName: "epub-a11y-tech-12",
+				shortName: "epub-a11y-tech-111",
 				noRecTrack: true,
 				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-tech/",
                 // previousPublishDate: "2024-04-12",
@@ -53,6 +53,11 @@
 				},
 				profile: "web-platform",
 				localBiblio: {
+					"epub-a11y-111": {
+						"title": "EPUB Accessibility 1.1.1",
+						"href": "https://w3c.github.io/epub-specs/epub34/a11y/",
+						"publisher": "W3C"
+					},
 					"a11y-discov-vocab": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
 						"href": "https://www.w3.org/2021/a11y-discov-vocab/latest/",
@@ -127,29 +132,29 @@
 				<h3>Overview</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides informative guidance on how to understand and
-					apply the discovery and accessibility requirements defined in the EPUB Accessibility 1.1
-					specification [[epub-a11y-11]] that are unique to <a
+					apply the discovery and accessibility requirements defined in the EPUB Accessibility 1.1.1
+					specification [[epub-a11y-111]] that are unique to <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>.</p>
 
 				<p>This document does not cover general web accessibility techniques already addressed in [[wcag2]] and
 					[[wai-aria]], for example, for which no substantive differences in application exist. Following
 					those techniques, as applicable, is also essential to meeting the accessibility requirements of the
-					EPUB Accessibility 1.1 specification.</p>
+					EPUB Accessibility 1.1.1 specification.</p>
 
 				<p>This document is not intended to be read in isolation, in other words, as it does not define
 					conformance requirements for making accessibility claims or cover every method for producing
-					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1 to
+					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1.1 to
 					make a claim of accessibility. Verifying only the techniques in this document does not mean an <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> can claim conformance to
-					EPUB Accessibility 1.1.</p>
+					EPUB Accessibility 1.1.1.</p>
 			</section>
 
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
 				<p>This document uses terminology defined in <a href="https://www.w3.org/TR/epub/#sec-terminology">EPUB
-						3.3</a> [[epub-3]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.1</a>
-					[[epub-a11y-11]]:</p>
+						3.3</a> [[epub-3]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.1.1</a>
+					[[epub-a11y-111]]:</p>
 
 				<div class="note">
 					<p>Only the first instance of a term in a section links to its definition.</p>
@@ -162,7 +167,7 @@
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
 					<a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> create <a
 					href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> that conform to the
-				requirements in [[epub-a11y-11]], but they are not all applicable in all situations and there may be
+				requirements in [[epub-a11y-111]], but they are not all applicable in all situations and there may be
 				other ways to meet the requirements of that specification. As a result, this document should not be read
 				as providing prescriptive requirements.</p>
 
@@ -496,7 +501,7 @@
 					and "<a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#feature-unknown"
 							><code>unknown</code></a>", these terms cannot be used to meet the reporting requirements
 					for the property. Authors must indicate at least one feature that is not one of these values to
-					claim conformance to EPUB Accessibility 1.1 [[epub-a11y-11]].</p>
+					claim conformance to EPUB Accessibility 1.1.1 [[epub-a11y-111]].</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
 							<code>accessibilityFeature</code> Property</a> [[a11y-discov-vocab]] for more information
@@ -640,7 +645,7 @@
 				<p>EPUB creators should not include an accessibility summary when they have nothing more to add to the
 					conformance claim and other discovery metadata.</p>
 
-				<p>If an EPUB publication does not meet the requirements for content accessibility in [[epub-a11y-11]],
+				<p>If an EPUB publication does not meet the requirements for content accessibility in [[epub-a11y-111]],
 					the reason(s) it fails should be noted in the summary. Similarly, if an EPUB creator is hesitant to
 					make a formal claim of conformance, the reasons why can be explained in the summary.</p>
 
@@ -1540,7 +1545,7 @@
 
 					<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> must now ensure that
 						their image-based content meets [[wcag2]] requirements for alternative text and extended
-						descriptions to conform with [[epub-a11y-11]].</p>
+						descriptions to conform with [[epub-a11y-111]].</p>
 
 					<section id="sec-desc-001-res">
 						<h5>Helpful resources</h5>
@@ -1705,7 +1710,7 @@
 
 				<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> therefore need to use their
 					best discretion when implementing this functionality to meet accessibility requirements. EPUB
-					publications that contain multiple renditions are conformant to the [[epub-a11y-11]] specification
+					publications that contain multiple renditions are conformant to the [[epub-a11y-111]] specification
 					if at least one rendition meets all the content requirements, but EPUB creators at a minimum need to
 					note that a reading system that supports multiple renditions is required in their <a
 						href="#accessibilitySummary">accessibility summary</a>. Any other methods the EPUB creator can

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB Accessibility 1.2</title>
+		<title>EPUB Accessibility 1.1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
@@ -14,7 +14,7 @@
 				group: "pm",
                 wgPublicList: "public-pm-wg",
 				specStatus: "ED",
-				shortName: "epub-a11y-12",
+				shortName: "epub-a11y-111",
 				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y/",
                 // implementationReportURI: "https://w3c.github.io/epub-specs/epub34/reports/",
                 // previousPublishDate: "2023-05-25",
@@ -106,17 +106,17 @@
 				},
 				preProcess:[inlineCustomCSS],
 				postProcess: [data_test_display, fixErrataField],
-				// otherLinks: [
-				//	{
-				//		key: "This document is also available in this non-normative format:",
-				//		data: [
-				//			{
-				//				value: "EPUB 3",
-				//				href: "./epub-a11y-12.epub"
-				//			}
-				//		]
-				//	}
-				//]
+				/* otherLinks: [
+					{
+						key: "This document is also available in this non-normative format:",
+						data: [
+							{
+								value: "EPUB 3",
+								href: "./epub-a11y-12.epub"
+							}
+						]
+					}
+				]*/
 			};</script>
 		<style>
 			.conf-pattern {

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -112,7 +112,7 @@
 						data: [
 							{
 								value: "EPUB 3",
-								href: "./epub-a11y-12.epub"
+								href: "./epub-a11y-111.epub"
 							}
 						]
 					}

--- a/epub34/authoring/biblio.js
+++ b/epub34/authoring/biblio.js
@@ -13,8 +13,8 @@ var biblio = {
 		"href": "https://www.w3.org/TR/dpub-aria/",
 		"publisher": "W3C"
 	},
-	"epub-a11y-12": {
-		"title": "EPUB Accessibility 1.2",
+	"epub-a11y-111": {
+		"title": "EPUB Accessibility 1.1.1",
 		"href": "https://w3c.github.io/epub-specs/epub34/a11y/",
 		"publisher": "W3C"
 	},

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -114,7 +114,7 @@
 							and present their content to users.</p>
 					</li>
 					<li>
-						<p><a data-cite="epub-a11y-12#">EPUB Accessibility</a> [[epub-a11y-12]] — defines accessibility
+						<p><a data-cite="epub-a11y-111#">EPUB Accessibility</a> [[epub-a11y-111]] — defines accessibility
 							conformance and discovery requirements for EPUB publications.</p>
 					</li>
 				</ul>
@@ -166,7 +166,7 @@
 					rendering, such as images, audio and video clips, scripts, and style sheets.</p>
 
 				<p>Refer to <a href="#sec-contentdocs"></a> for detailed information about the rules and requirements to
-					produce EPUB content documents, and [[epub-a11y-12]] for accessibility requirements.</p>
+					produce EPUB content documents, and [[epub-a11y-111]] for accessibility requirements.</p>
 
 				<p>An EPUB publication also includes another key file called the [=EPUB navigation document=]. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
@@ -691,7 +691,7 @@
 				</li>
 				<li>
 					<p id="confreq-a11y">SHOULD conform to the accessibility requirements defined in
-						[[epub-a11y-12]].</p>
+						[[epub-a11y-111]].</p>
 				</li>
 				<li>
 					<p id="confreq-ocf">MUST be packaged in an [=EPUB container=] as defined in <a href="#sec-ocf"
@@ -3722,7 +3722,7 @@
 						EPUB specifications.</p>
 
 					<div class="note">
-						<p>See [[epub-a11y-12]] for accessibility metadata recommendations.</p>
+						<p>See [[epub-a11y-111]] for accessibility metadata recommendations.</p>
 					</div>
 				</section>
 
@@ -5815,7 +5815,7 @@ No Entry</pre>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
-							[[epub-a11y-12]] applies to XHTML content documents. See <a href="#confreq-a11y"
+							[[epub-a11y-111]] applies to XHTML content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -6073,7 +6073,7 @@ No Entry</pre>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
-							[[epub-a11y-12]] applies to SVG content documents. See <a href="#confreq-a11y"
+							[[epub-a11y-111]] applies to SVG content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -9466,12 +9466,12 @@ html.my-document-playing * {
 				These guidelines also form the basis for defining accessibility in [=EPUB publications=].</p>
 
 			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
-					data-cite="epub-a11y-12#">EPUB Accessibility</a> [[epub-a11y-12]], defines how to apply the standard
+					data-cite="epub-a11y-111#">EPUB Accessibility</a> [[epub-a11y-111]], defines how to apply the standard
 				to EPUB publications. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
 			<p>This specification recommends that EPUB publications <a href="#confreq-a11y">conform to the accessibility
-					requirements</a> defined in&#160;[[epub-a11y-12]]. A benefit of following this recommendation is
+					requirements</a> defined in&#160;[[epub-a11y-111]]. A benefit of following this recommendation is
 				that it helps to ensure that EPUB publications meet the accessibility requirements legislated in
 				jurisdictions around the world.</p>
 

--- a/epub34/errata.html
+++ b/epub34/errata.html
@@ -96,10 +96,10 @@
       </section>
 
       <section data-erratalabel="Spec-Accessibility">
-        <h2>Open Errata on the “EPUB Accessibility 1.2” Recommendation</h2>
+        <h2>Open Errata on the “EPUB Accessibility 1.1.1” Recommendation</h2>
         <dl>
             <dt>Latest Published Version:</dt>
-            <dd><a href="https://www.w3.org/TR/epub-a11y-12/">https://www.w3.org/TR/epub-a11y-12/</a></dd>
+            <dd><a href="https://www.w3.org/TR/epub-a11y-111/">https://www.w3.org/TR/epub-a11y-111/</a></dd>
             <dt>Editors’ draft:</dt>
             <dd><a href="https://w3c.github.io/epub-specs/epub34/a11y/">https://w3c.github.io/epub-specs/epub34/a11y/</a></dd>
         </dl>
@@ -112,10 +112,10 @@
       </section>
 
       <section data-erratalabel="Spec-A11YTechniques">
-        <h2>Open Errata on the “EPUB Accessibility Techniques 1.2” Working Group Note</h2>
+        <h2>Open Errata on the “EPUB Accessibility Techniques 1.1.1” Working Group Note</h2>
         <dl>
             <dt>Latest Published Version:</dt>
-            <dd><a href="https://www.w3.org/TR/epub-a11y-tech-12/">https://www.w3.org/TR/epub-a11y-tech-11/</a></dd>
+            <dd><a href="https://www.w3.org/TR/epub-a11y-tech-111/">https://www.w3.org/TR/epub-a11y-tech-111/</a></dd>
             <dt>Editors’ draft:</dt>
             <dd><a href="https://w3c.github.io/epub-specs/epub34/a11y-tech/">https://w3c.github.io/epub-specs/epub34/a11y-tech/</a></dd>
         </dl>

--- a/epub34/index-page/index.html
+++ b/epub34/index-page/index.html
@@ -8,8 +8,8 @@
 		<script>
             const specs = [
                 "epub-34",
-                "epub-a11y-12",
-                "epub-a11y-tech-12",
+                "epub-a11y-111",
+                "epub-a11y-tech-111",
                 "epub-overview-34",
                 "epub-rs-34",
             ];
@@ -55,11 +55,38 @@
                 permalinkHide: false,
                 xref: {
                     profile: "web-platform",
-                    specs: ["epub-rs-33", "epub-33"]
+                    specs: ["epub-rs-34", "epub-34"]
                 },
                 github: {
                     repoURL: "https://github.com/w3c/epub-specs",
                     branch: "main"
+                },
+                localBiblio: {
+					"epub-a11y-111": {
+						"title": "EPUB Accessibility 1.1.1",
+						"href": "https://w3c.github.io/epub-specs/epub34/a11y/",
+						"publisher": "W3C"
+					},
+					"epub-a11y-tech-111": {
+						"title": "EPUB Accessibility Techniques 1.1.1",
+						"href": "https://w3c.github.io/epub-specs/epub34/a11y-tech/",
+						"publisher": "W3C"
+					},
+					"epub-34": {
+						"title": "EPUB 3.4",
+						"href": "https://w3c.github.io/epub-specs/epub34/authoring/",
+						"publisher": "W3C"
+					},
+					"epub-rs-34": {
+						"title": "EPUB Reading Systems 3.4",
+						"href": "https://w3c.github.io/epub-specs/epub34/rs/",
+						"publisher": "W3C"
+					},
+					"epub-overview-34": {
+						"title": "EPUB 3 Overview",
+						"href": "https://w3c.github.io/epub-specs/epub34/overview/",
+						"publisher": "W3C"
+					},
                 }
             };
         </script>
@@ -74,8 +101,7 @@
 		<section>
 			<h2>About EPUB 3.4</h2>
 			<p> EPUB 3.4 is a revision of the EPUB 3 specification, which can be considered as a successor to <a
-					href="https://www.w3.org/publishing/epub33/">EPUB 3.3</a>. It is also the first W3C Recommendation
-				of the EPUB series of specifications. </p>
+					href="https://www.w3.org/publishing/epub33/">EPUB 3.3</a>.</p>
 
 			<p> EPUB 3.4 is backward compatible with EPUB 3.3, insofar as any EPUB 3.3 document is also valid EPUB 3.4.
 				In other words, moving from EPUB 3.3 to EPUB 3.4 does not require any changes to current publication
@@ -108,14 +134,14 @@
 							data-cite="epub-33#sec-ocf">container format</a>. </li>
 					<li>EPUB Reading Systems 3.4 [[epub-rs-34]]: defines the conformance requirements for EPUB 3 reading
 						systems — the user agents that render EPUB 3 Publications. </li>
-					<li>EPUB Accessibility 1.2 [[epub-a11y-12]]: specifies content conformance requirements for
+					<li>EPUB Accessibility 1.1.1 [[epub-a11y-111]]: specifies content conformance requirements for
 						verifying the accessibility of EPUB 3 Publications. </li>
 				</ul>
 
 				<div class="note"> The recommendation-track documents include detailed change logs on the substantive
 					changes since the previous official releases. See the change log for <a
 						data-cite="epub-34#change-log">EPUB 3.4</a>, <a data-cite="epub-rs-34#change-log">EPUB reading
-						systems 3.4</a>, and <a data-cite="epub-a11y-12#change-log">EPUB Accessibility 1.2</a>,
+						systems 3.4</a>, and <a data-cite="epub-a11y-111#change-log">EPUB Accessibility 1.1.1</a>,
 					respectively. </div>
 			</section>
 
@@ -128,8 +154,8 @@
 				<ul>
 					<li> EPUB 3 Overview [[epub-overview-34]]: gives a high level overview of the main EPUB 3.4 concepts
 						and terms. </li>
-					<li> EPUB Accessibility Techniques 1.2 [[epub-a11y-tech-12]]: provides guidance on how to meet the
-						EPUB Accessibility 1.2 [[epub-a11y-12]] discovery and accessibility requirements for EPUB
+					<li> EPUB Accessibility Techniques 1.1.1 [[epub-a11y-tech-111]]: provides guidance on how to meet the
+						EPUB Accessibility 1.1.1 [[epub-a11y-111]] discovery and accessibility requirements for EPUB
 						publications. </li>
 				</ul>
 			</section>


### PR DESCRIPTION
It was noted in the working group meeting yesterday that we may not have substantive enough changes to warrant a new 1.2 version number, which would require a new conformance string and all that change would entail.

The more prudent course of action is to start the accessibility specification and techniques as a 1.1.1 revision and then upgrade them later if we determine we need to bump the number to accommodate substantive changes to conformance.

To that end, this pull request changes all the numbering in the /epub34 directory to 1.1.1.

(There are also some unrelated fixes to add temporary spec info to local bibliographies to get rid of some respec errors.)