### PR TITLE
Add dark mode to 3.4 docs

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -3,8 +3,10 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.1.1</title>
+		<meta name="color-scheme" content="light dark"/>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/fix-errata.js" class="remove"></script>
+		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1.1</title>
+		<meta name="color-scheme" content="light dark"/>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
+		<meta name="color-scheme" content="light dark"/>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../common/js/fix-errata.js" class="remove"></script>

--- a/epub34/common/css/common.css
+++ b/epub34/common/css/common.css
@@ -327,3 +327,53 @@ a.epubcheck {
     background-color: antiquewhite ;
 }
 
+/***************** Dark mode settings ******************/
+
+body.darkmode details.explanation, body.darkmode details.desc {
+    color: black;
+    background-color: hsla(240, 0%, 68%, 1.0);
+}
+
+body.darkmode table.zebra tr:nth-child(even) {
+    color: black;
+}
+
+body.darkmode dl.elemdef,
+body.darkmode table.tabledef th,
+body.darkmode table.tabledef td,
+body.darkmode table.productionset
+{
+    background-color: hsl(240, 0%, 20%);
+    color: #ddd
+}
+
+body.darkmode table.tabledef div.note {
+    background: hsl(0, 0%, 15%);
+}
+
+body.darkmode p.caution, body.darkmode div.caution {
+    background-color: hsl(180, 40%, 20%);
+}
+
+body.darkmode div.caution-title > span {
+    color: rgb(255,140,0)
+}
+
+body.darkmode details.respec-tests-details[open] {
+    background-color: antiquewhite;
+    color: black;
+}
+
+body.darkmode details.explanation a,
+body.darkmode table.productionset a
+{
+    color: hsla(213, 100%, 48%, 1.0);
+}
+
+body.darkmode table.prefix th {
+    color: hsl(66, 100%, 95%);
+}
+
+body.darkmode img {
+    background: hsl(48, 33%, 93%) ;
+}

--- a/epub34/overview/index.html
+++ b/epub34/overview/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Overview</title>
+		<meta name="color-scheme" content="light dark"/>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../common/js/add-caution-hd.js" class="remove"></script>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Reading Systems 3.4</title>
+		<meta name="color-scheme" content="light dark"/>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>


### PR DESCRIPTION
This matches the changes in #2672 for the 3.4 docs.

It also adds the css-inline code to the accessibility techniques. The rest already had it.