### PR TITLE
Minor typo

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1469,7 +1469,7 @@
 						numbering on <code>nav</code> elements when presenting them outside of the spine, regardless of
 						support for CSS, as the default display style of list items is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-								none</code> property</a> [[csssnapshot]].).</p>
+								none</code> property</a> [[csssnapshot]].</p>
 				</li>
 			</ul>
 


### PR DESCRIPTION
Removes the closing parenthesis and extra period from the nav styling bullet. Must have been from an earlier wording.

***

[Preview](https://raw.githack.com/w3c/epub-specs/rs/nav-typo/epub34/rs/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/rs/nav-typo/epub34/rs/index.html)
