### PR TITLE
Integrate proposed corrections into EPUB 3.3

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10912,8 +10912,9 @@ html.my-document-playing * {
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). EPUB creators MAY include any in the authored tag so long as
-					the result is valid to this definition.</p>
+					within the attribute to single spaces). EPUB creators MAY include any <a data-cite="xml#NT-S"
+						>whitespace characters</a> [[xml]] in the authored tag so long as the result is valid to this
+					definition.</p>
 
 				<div class="note">
 					<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -90,11 +90,7 @@
 			<p>This specification defines the authoring requirements for [=EPUB publications=] and represents the third
 				major revision of the standard.</p>
 		</section>
-		<section id="sotd" class="updateable-rec">
-			<p><span hidden="hidden" class="proposed-correction"></span>This document includes Proposed Corrections to
-				the current <a href="https://www.w3.org/TR/2023/REC-epub-33-20230525/">W3C Recommendation dated 25 May
-					2023</a>.</p>
-		</section>
+		<section id="sotd" class="updateable-rec"></section>
 		<section id="sec-introduction">
 			<h2>Introduction</h2>
 
@@ -5973,44 +5969,19 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L910,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 						<h5>Embedded SVG</h5>
 
-						<div class="proposed correction" id="change_1">
-							<span class="marker">Proposed Correction 1</span>
-							<p data-cite="svg2">The current section does not clearly indicate that an SVG embedded by
-								reference is already required to be a conforming SVG content document (not a document
-								fragment) or that its requirements are defined in section 6.2. The only unique case here
-								is embedding by inclusion, as the [^svg^] element embedded in the HTML markup, although
-								a document fragment, still has to conform to the restrictions for SVG content documents.
-								This change breaks out the two cases to better explain these requirements. For more
-								information, refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue
-									2555</a>.</p>
-						</div>
+						<p>[=XHTML content documents=] support the embedding of SVG:</p>
 
-						<p>[=XHTML content documents=] support the embedding of <del cite="#change_1"><a
+						<ul>
+							<li id="sec-xhtml-svg-reference"><em>by reference</em> &#8212; for example, from an [[html]]
+								[^img^] or [^object^] element. SVGs embedded by reference are <a href="#cmt-svg">SVG
+									core media types</a> so their requirements are already defined in <a href="#sec-svg"
+								></a>.</li>
+							<li id="sec-xhtml-svg-inclusion"><em>by inclusion</em> &#8212; via direct inclusion of an <a
 									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
-									fragments</a> [[svg]] <em>by reference</em> (embedding via reference, for example,
-								from an <code>img</code> or <code>object</code> element) and <em>by inclusion</em>
-								(embedding via direct inclusion of the <code>svg</code> element in the XHTML content
-								document).</del><ins cite="#change_1">SVG:</ins></p>
-
-						<del cite="#change_1">
-							<p>The content conformance constraints for SVG embedded in XHTML content documents are the
-								same as defined for [=SVG content documents=] in <a href="#sec-svg-restrictions"
-								></a>.</p>
-						</del>
-
-						<ins cite="#change_1">
-							<ul>
-								<li id="sec-xhtml-svg-reference"><em>by reference</em> &#8212; for example, from an
-									[[html]] [^img^] or [^object^] element. SVGs embedded by reference are <a
-										href="#cmt-svg">SVG core media types</a> so their requirements are already
-									defined in <a href="#sec-svg"></a>.</li>
-								<li id="sec-xhtml-svg-inclusion"><em>by inclusion</em> &#8212; via direct inclusion of
-									an <a href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG
-										document fragment</a> [[svg]] in an XHTML content document. SVGs embedded by
-									inclusion have the same content conformance constraints as those defined for [=SVG
-									content documents=] in <a href="#sec-svg-restrictions"></a>.</li>
-							</ul>
-						</ins>
+									fragment</a> [[svg]] in an XHTML content document. SVGs embedded by inclusion have
+								the same content conformance constraints as those defined for [=SVG content documents=]
+								in <a href="#sec-svg-restrictions"></a>.</li>
+						</ul>
 
 						<div class="note">
 							<p>The <a href="#svg"><code>svg</code> property</a> of the [=EPUB manifest | manifest=]
@@ -6095,47 +6066,10 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L33,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L41,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L47,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 					<h4>SVG requirements</h4>
 
-					<div class="proposed correction" id="change_2">
-						<span class="marker">Proposed Correction 2</span>
-						<p data-cite="svg2">SVG already allows foreign-namespaced attributes to be used anywhere. The
-							two "MAY" bullets in the current text that allow the <code>epub:</code> namespaced
-							attributes are consequently not real requirements and are removed. That the attributes are
-							allowed on SVGs is now a note in the next section on the content model restrictions (see <a
-								href="#change_3">proposed correction 3</a>), as that is where the restriction in the
-							second bullet on what elements the <code>epub:type</code> attribute is allowed is moved. For
-							more information, refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue
-								2555</a>.</p>
-					</div>
-
-					<p id="confreq-cd-svg-docprops-schema">An [=SVG content document=]<del cite="#change_2">:</del>
-						<ins cite="#change_2">MUST be a <a
-								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">conforming
-								SVG stand-alone file</a> [[svg]] and conform to all content conformance constraints
-							expressed in <a href="#sec-svg-restrictions"></a>.</ins></p>
-
-					<del cite="#change_2">
-						<ul class="conformance-list">
-							<li>
-								<p>MUST be a <a
-										href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
-										>conforming SVG stand-alone file</a> [[svg]] and conform to all content
-									conformance constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
-							</li>
-							<li>
-								<p>MAY include the [^/epub:type^] attribute for expressing <a
-										href="#app-structural-semantics">structural semantics</a>. When specified, the
-									attribute MUST only be included on <a
-										href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement"
-										>structural</a>, <a
-										href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
-										href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
-							</li>
-							<li>
-								<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"
-										>vocabulary association mechanisms</a>.</p>
-							</li>
-						</ul>
-					</del>
+					<p id="confreq-cd-svg-docprops-schema">An [=SVG content document=] MUST be a <a
+							href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">conforming SVG
+							stand-alone file</a> [[svg]] and conform to all content conformance constraints expressed in
+							<a href="#sec-svg-restrictions"></a>.</p>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
@@ -6177,55 +6111,28 @@ No Entry</pre>
 							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] [^title^] element contains
 								marked-up text, the markup MUST contain only elements declared in the <a
 									data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
-							<ins cite="#change_3">
-								<div class="note">
-									<p>Although the [[svg]] <code>title</code> element allows markup elements, support
-										for this feature is limited. [=EPUB creators=] are advised to use text-only
-										titles for maximum interoperability.</p>
-								</div>
-							</ins>
+							<div class="note">
+								<p>Although the [[svg]] <code>title</code> element allows markup elements, support for
+									this feature is limited. [=EPUB creators=] are advised to use text-only titles for
+									maximum interoperability.</p>
+							</div>
 						</li>
 						<li>
-							<div class="proposed correction" id="change_3">
-								<span class="marker">Proposed Correction 3</span>
-								<p>This correction adds the restriction on where the <code>epub:type</code> attribute is
-									allowed (refer to <a href="#change_2">proposed correction 2</a> for its former
-									placement). Moving the restriction into this section also makes it applicable to
-									SVGs embedded by inclusion in HTML documents, a requirement that was not clearly
-									established when the restriction was in the preceding section. For more information,
-									refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue 2555</a>.</p>
-								<p data-cite="svg2">This correction also addresses the list of elements the
-									[^/epub:type^] attribute is allowed on. The current list (see <a href="#change_2"
-										>proposed correction 2</a>) does not allow the attribute on the SVG [^a^]
-									element. The text is corrected to use the [[svg2]] definition of a renderable
-									element to avoid the problem of missing elements when selecting more granular
-									element classes. For more information, refer to <a
-										href="https://github.com/w3c/epub-specs/issues/2556">issue 2556</a>.</p>
+							<p id="confreq-svg-structural-semantics">When specified, the [^/epub:type^] attribute MUST
+								only be included on [=renderable elements=] [[svg]].</p>
+							<div class="note">
+								<p>The SVG content model allows authors to <a
+										href="https://www.w3.org/TR/SVG/struct.html#ForeignNamespaces">include
+										namespaced attributes</a>, so this specification does not need to allow the
+									[^/epub:type^] attribute or <a href="#sec-vocab-assoc">vocabulary association
+										mechanisms</a>.</p>
+								<p>One key difference between SVGs embedded by reference and by inclusion, however, is
+									that SVGs embedded by inclusion cannot have an <a href="#sec-prefix-attr"
+											><code>epub:prefix</code></a> attribute on their root [^svg^] element
+									[[svg]]. For more information, refer to <a href="#sec-prefix-attr"></a>.</p>
 							</div>
-							<ins cite="#change_3">
-								<p id="confreq-svg-structural-semantics">When specified, the [^/epub:type^] attribute
-									MUST only be included on [=renderable elements=] [[svg]].</p>
-								<div class="note">
-									<p>The SVG content model allows authors to <a
-											href="https://www.w3.org/TR/SVG/struct.html#ForeignNamespaces">include
-											namespaced attributes</a>, so this specification does not need to allow the
-										[^/epub:type^] attribute or <a href="#sec-vocab-assoc">vocabulary association
-											mechanisms</a>.</p>
-									<p>One key difference between SVGs embedded by reference and by inclusion, however,
-										is that SVGs embedded by inclusion cannot have an <a href="#sec-prefix-attr"
-												><code>epub:prefix</code></a> attribute on their root [^svg^] element
-										[[svg]]. For more information, refer to <a href="#sec-prefix-attr"></a>.</p>
-								</div>
-							</ins>
 						</li>
 					</ul>
-					<del cite="#change_3">
-						<div class="note">
-							<p>Although the [[svg]] <code>title</code> element allows markup elements, support for this
-								feature is limited. [=EPUB creators=] are advised to use text-only titles for maximum
-								interoperability.</p>
-						</div>
-					</del>
 				</section>
 			</section>
 
@@ -11002,33 +10909,18 @@ html.my-document-playing * {
 						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
 						>assignment character</a>.</p>
 
-				<div class="proposed correction" id="change_4">
-					<span class="marker">Proposed Correction 4</span>
-					<p data-cite="svg2">The following paragraph mixed in a reference to the [[infra]] specification's
-						definition of whitespace characters, which is only valid for HTML documents. This would have
-						allowed the Form Feed character in <code>viewport meta</code> tags even though Form Feed is not
-						valid XML whitespace character. This change corrects the reference to point to the [[xml]]
-						definition and adds an explanatory note about the difference between the two definitions. For
-						more information, refer to <a href="https://github.com/w3c/epub-specs/issues/2637">issue
-							2637</a>.</p>
-				</div>
-
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). EPUB creators MAY include any <ins cite="#change_4"><a
-							data-cite="xml#NT-S">whitespace characters</a> [[xml]]</ins><del cite="#change_4">valid
-						[=ascii whitespace=] [[infra]]</del> in the authored tag so long as the result is valid to this
-					definition.</p>
+					within the attribute to single spaces). EPUB creators MAY include any in the authored tag so long as
+					the result is valid to this definition.</p>
 
-				<ins cite="#change_4">
-					<div class="note">
-						<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
-								data-cite="infra#ascii-whitespace">definition of whitespace</a>, the Form Feed (U+000C)
-							character is not valid whitespace per the [[xml]] definition. It cannot be used in the XML
-							syntax (i.e., in XHTML content documents).</p>
-					</div>
-				</ins>
+				<div class="note">
+					<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
+							data-cite="infra#ascii-whitespace">definition of whitespace</a>, the Form Feed (U+000C)
+						character is not valid whitespace per the [[xml]] definition. It cannot be used in the XML
+						syntax (i.e., in XHTML content documents).</p>
+				</div>
 
 				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
 							><code>meta</code></a> element by the [[html]] grammar.</p>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10932,8 +10932,9 @@ html.my-document-playing * {
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). EPUB creators MAY include any in the authored tag so long as
-					the result is valid to this definition.</p>
+					within the attribute to single spaces). EPUB creators MAY include any <a data-cite="xml#NT-S"
+						>whitespace characters</a> [[xml]] in the authored tag so long as the result is valid to this
+					definition.</p>
 
 				<div class="note">
 					<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a


### PR DESCRIPTION
Does as the title says.

While double-checking the changes, I noticed that "whitespace characters [xml]" got removed along with the infra reference in the 3.4 spec so I've added it back.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2689.html" title="Last updated on Mar 11, 2025, 3:16 PM UTC (960bbf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2689/8991fab...960bbf6.html" title="Last updated on Mar 11, 2025, 3:16 PM UTC (960bbf6)">Diff</a>