### PR TITLE
Update workflow paths

### DIFF
--- a/.github/workflows/epub-a11y-eaa-mapping.yml
+++ b/.github/workflows/epub-a11y-eaa-mapping.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths: 
       - "wg-notes/epub-a11y-eaa-mapping/**"
-      - "wg-notes/common/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 

--- a/.github/workflows/epub-a11y-eaa-mapping.yml
+++ b/.github/workflows/epub-a11y-eaa-mapping.yml
@@ -3,13 +3,13 @@ name: CI (EPUB EU Accessibility Act Mapping)
 on:
   pull_request:
     paths: 
-      - "epub33/epub-a11y-eaa-mapping/**"
-      - "epub33/common/**"
+      - "wg-notes/epub-a11y-eaa-mapping/**"
+      - "wg-notes/common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/epub-a11y-eaa-mapping/**"
-      - "epub33/common/**"
+      - "wg-notes/epub-a11y-eaa-mapping/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB Accessibility - EU Accessibility Act Mapping 
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/epub-a11y-eaa-mapping/
+          SOURCE: wg-notes/epub-a11y-eaa-mapping/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y_EAA_MAPPING }}
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-06-18-epub#resolution2

--- a/.github/workflows/epub-a11y-exemption-property.yml
+++ b/.github/workflows/epub-a11y-exemption-property.yml
@@ -3,13 +3,13 @@ name: CI (EPUB Accessibility Exemption Property)
 on:
   pull_request:
     paths: 
-      - "epub33/a11y-exemption/**"
-      - "epub33/common/**"
+      - "wg-notes/a11y-exemption/**"
+      - "wg-notes/common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/a11y-exemption/**"
-      - "epub33/common/**"
+      - "wg-notes/a11y-exemption/**"
+      - "wg-notes/common/**"
 jobs:
   main:
     name: Publish EPUB Accessibility Exemption Property 
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/a11y-exemption/
+          SOURCE: wg-notes/a11y-exemption/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y_EXEMPTION }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-pm-wg/2023Oct/0028.html

--- a/.github/workflows/epub-a11y-exemption-property.yml
+++ b/.github/workflows/epub-a11y-exemption-property.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     paths: 
       - "wg-notes/a11y-exemption/**"
-      - "wg-notes/common/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
       - "wg-notes/a11y-exemption/**"
-      - "wg-notes/common/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB Accessibility Exemption Property 

--- a/.github/workflows/epub-a11y-tech.yml
+++ b/.github/workflows/epub-a11y-tech.yml
@@ -1,15 +1,15 @@
-# .github/workflows/epub-a11-tech-11.yml
+# .github/workflows/epub-a11-tech-111.yml
 name: CI (EPUB Accessibility Techniques)
 on:
   pull_request:
     paths: 
-      - "epub33/a11y-tech/**"
-      - "epub33/common/**"
+      - "epub34/a11y-tech/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/a11y-tech/**"
-      - "epub33/common/**"
+      - "epub34/a11y-tech/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB Accessibility Techniques 1.1 
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/a11y-tech/
+          SOURCE: epub34/a11y-tech/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y_TECH }}
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-02-12-epub#resolution2
           W3C_BUILD_OVERRIDE: |
-             shortName: epub-a11y-tech-11
+             shortName: epub-a11y-tech-111
              specStatus: NOTE

--- a/.github/workflows/epub-a11y.yml
+++ b/.github/workflows/epub-a11y.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths: 
       - "epub34/a11y/**"
+      - "epub34/acknowledgements.html"
       - "common/**"
   push:
     branches: [main]

--- a/.github/workflows/epub-a11y.yml
+++ b/.github/workflows/epub-a11y.yml
@@ -1,15 +1,16 @@
-# .github/workflows/epub-a11y-11.yml
+# .github/workflows/epub-a11y-111.yml
 name: CI (EPUB Accessibility)
 on:
   pull_request:
     paths: 
-      - "epub33/a11y/**"
-      - "epub33/common/**"
+      - "epub34/a11y/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/a11y/**"
-      - "epub33/common/**"
+      - "epub34/a11y/**"
+      - "epub34/acknowledgements.html"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB Accessibility 1.1 
@@ -18,10 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/a11y/
+          SOURCE: epub34/a11y/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y }}
-          W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-02-12-epub#resolution2
+          W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
-             shortName: epub-a11y-11
+             shortName: epub-a11y-111
              specStatus: REC

--- a/.github/workflows/epub-aria-authoring.yml
+++ b/.github/workflows/epub-aria-authoring.yml
@@ -3,13 +3,13 @@ name: CI (EPUB Type to ARIA Role Authoring Guide)
 on:
   pull_request:
     paths: 
-      - "epub33/epub-aria-authoring/**"
-      - "epub33/common/**"
+      - "wg-notes/epub-aria-authoring/**"
+      - "wg-notes/common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/epub-aria-authoring/**"
-      - "epub33/common/**"
+      - "wg-notes/epub-aria-authoring/**"
+      - "wg-notes/common/**"
 jobs:
   main:
     name: Publish EPUB Type to ARIA Role Authoring Guide 
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/epub-aria-authoring/
+          SOURCE: wg-notes/epub-aria-authoring/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_EPUB_ARIA_AUTHORING }}
           W3C_WG_DECISION_URL: https://www.w3.org/2023/01/05-epub-minutes.html#resolution04

--- a/.github/workflows/epub-aria-authoring.yml
+++ b/.github/workflows/epub-aria-authoring.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     paths: 
       - "wg-notes/epub-aria-authoring/**"
-      - "wg-notes/common/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
       - "wg-notes/epub-aria-authoring/**"
-      - "wg-notes/common/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB Type to ARIA Role Authoring Guide 

--- a/.github/workflows/epub-authoring.yml
+++ b/.github/workflows/epub-authoring.yml
@@ -3,13 +3,13 @@ name: CI (Content)
 on:
   pull_request:
     paths: 
-      - "epub34/core/**"
+      - "epub34/authoring/**"
       - "epub34/acknowledgements.html"
       - "common/**"
   push:
     branches: [main]
     paths: 
-      - "epub34/core/**"
+      - "epub34/authoring/**"
       - "epub34/acknowledgements.html"
       - "common/**"
 jobs:
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub34/core/
+          SOURCE: epub34/authoring/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_CONTENT }}
           W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175

--- a/.github/workflows/epub-authoring.yml
+++ b/.github/workflows/epub-authoring.yml
@@ -1,15 +1,16 @@
-# .github/workflows/epub-33.yml
+# .github/workflows/epub-34.yml
 name: CI (Content)
 on:
   pull_request:
     paths: 
-      - "epub33/core/**"
-      - "epub33/common/**"
+      - "epub34/core/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/core/**"
-      - "epub33/common/**"
+      - "epub34/core/**"
+      - "epub34/acknowledgements.html"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB 33 
@@ -18,10 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/core/
+          SOURCE: epub34/core/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_CONTENT }}
-          W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-11-20-epub#resolution2
+          W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
-             shortName: epub-33
+             shortName: epub-34
              specStatus: REC

--- a/.github/workflows/epub-authoring.yml
+++ b/.github/workflows/epub-authoring.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths: 
       - "epub34/core/**"
+      - "epub34/acknowledgements.html"
       - "common/**"
   push:
     branches: [main]

--- a/.github/workflows/epub-fxl-a11y
+++ b/.github/workflows/epub-fxl-a11y
@@ -3,13 +3,13 @@ name: CI (EPUB FXL A11Y)
 on:
   pull_request:
     paths: 
-      - "epub33/fxl-a11y/**"
-      - "epub33/common/**"
+      - "wg-notes/fxl-a11y/**"
+      - "wg-notes/common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/fxl-a11y/**"
-      - "epub33/common/**"
+      - "wg-notes/fxl-a11y/**"
+      - "wg-notes/common/**"
 jobs:
   main:
     name: Publish EPUB Fixed Layout Accessibility 
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/fxl-a11y/
+          SOURCE: wg-notes/fxl-a11y/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_FXL_A11Y }}
           W3C_WG_DECISION_URL:  https://lists.w3.org/Archives/Public/public-pm-wg/2023Oct/0028.html

--- a/.github/workflows/epub-fxl-a11y
+++ b/.github/workflows/epub-fxl-a11y
@@ -4,12 +4,12 @@ on:
   pull_request:
     paths: 
       - "wg-notes/fxl-a11y/**"
-      - "wg-notes/common/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
       - "wg-notes/fxl-a11y/**"
-      - "wg-notes/common/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB Fixed Layout Accessibility 

--- a/.github/workflows/epub-multi-rend.yml
+++ b/.github/workflows/epub-multi-rend.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     paths: 
       - "wg-notes/multi-rend/**"
-      - "wg-notes/common/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
       - "wg-notes/multi-rend/**"
-      - "wg-notes/common/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB Multiple-Rendition Publications 1.1 

--- a/.github/workflows/epub-multi-rend.yml
+++ b/.github/workflows/epub-multi-rend.yml
@@ -3,13 +3,13 @@ name: CI (Multiple Renditions)
 on:
   pull_request:
     paths: 
-      - "epub33/multi-rend/**"
-      - "epub33/common/**"
+      - "wg-notes/multi-rend/**"
+      - "wg-notes/common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/multi-rend/**"
-      - "epub33/common/**"
+      - "wg-notes/multi-rend/**"
+      - "wg-notes/common/**"
 jobs:
   main:
     name: Publish EPUB Multiple-Rendition Publications 1.1 
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/multi-rend/
+          SOURCE: wg-notes/multi-rend/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_MULTI_REND }}
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-11-20-epub#resolution2

--- a/.github/workflows/epub-overview.yml
+++ b/.github/workflows/epub-overview.yml
@@ -1,15 +1,15 @@
-# .github/workflows/epub-overview-33.yml
+# .github/workflows/epub-overview-34.yml
 name: CI (Overview)
 on:
   pull_request:
     paths: 
-      - "epub33/overview/**"
-      - "epub33/common/**"
+      - "epub34/overview/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/overview/**"
-      - "epub33/common/**"
+      - "epub34/overview/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB 3 Overview 
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/overview/
+          SOURCE: epub34/overview/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_OVERVIEW }}
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-11-20-epub#resolution2
           W3C_BUILD_OVERRIDE: |
-             shortName: epub-overview-33
+             shortName: epub-overview-34
              specStatus: NOTE

--- a/.github/workflows/epub-rs.yml
+++ b/.github/workflows/epub-rs.yml
@@ -1,15 +1,16 @@
-# .github/workflows/epub-rs-33.yml
+# .github/workflows/epub-rs-34.yml
 name: CI (Reading System)
 on:
   pull_request:
     paths: 
-      - "epub33/rs/**"
-      - "epub33/common/**"
+      - "epub34/rs/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/rs/**"
-      - "epub33/common/**"
+      - "epub34/rs/**"
+      - "epub34/acknowledgements.html"
+      - "common/**"
 jobs:
   main:
     name: Publish Reading Systems 3.3 
@@ -18,10 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/rs/
+          SOURCE: epub34/rs/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_RS }}
-          W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-11-20-epub#resolution2
+          W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
-             shortName: epub-rs-33
+             shortName: epub-rs-34
              specStatus: REC

--- a/.github/workflows/epub-rs.yml
+++ b/.github/workflows/epub-rs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths: 
       - "epub34/rs/**"
+      - "epub34/acknowledgements.html"
       - "common/**"
   push:
     branches: [main]

--- a/.github/workflows/epub-ssv.yml
+++ b/.github/workflows/epub-ssv.yml
@@ -3,13 +3,13 @@ name: CI (EPUB SSV)
 on:
   pull_request:
     paths: 
-      - "epub33/ssv/**"
-      - "epub33/common/**"
+      - "wg-notes/ssv/**"
+      - "wg-notes/common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/ssv/**"
-      - "epub33/common/**"
+      - "wg-notes/ssv/**"
+      - "wg-notes/common/**"
 jobs:
   main:
     name: Publish Structural Semantics Vocabulary 
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/ssv/
+          SOURCE: wg-notes/ssv/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_SSV }}
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-10-14-epub#resolution1

--- a/.github/workflows/epub-ssv.yml
+++ b/.github/workflows/epub-ssv.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     paths: 
       - "wg-notes/ssv/**"
-      - "wg-notes/common/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
       - "wg-notes/ssv/**"
-      - "wg-notes/common/**"
+      - "common/**"
 jobs:
   main:
     name: Publish Structural Semantics Vocabulary 

--- a/.github/workflows/epub-tts.yml
+++ b/.github/workflows/epub-tts.yml
@@ -3,13 +3,13 @@ name: CI (EPUB TTS)
 on:
   pull_request:
     paths: 
-      - "epub33/tts/**"
-      - "epub33/common/**"
+      - "wg-notes/tts/**"
+      - "wg-notes/common/**"
   push:
     branches: [main]
     paths: 
-      - "epub33/tts/**"
-      - "epub33/common/**"
+      - "wg-notes/tts/**"
+      - "wg-notes/common/**"
 jobs:
   main:
     name: Publish EPUB 3 Text-to-Speech Enhancements 1.0 
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: epub33/tts/
+          SOURCE: wg-notes/tts/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_TTS }}
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-07-08-epub#resolution3

--- a/.github/workflows/epub-tts.yml
+++ b/.github/workflows/epub-tts.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     paths: 
       - "wg-notes/tts/**"
-      - "wg-notes/common/**"
+      - "common/**"
   push:
     branches: [main]
     paths: 
       - "wg-notes/tts/**"
-      - "wg-notes/common/**"
+      - "common/**"
 jobs:
   main:
     name: Publish EPUB 3 Text-to-Speech Enhancements 1.0 


### PR DESCRIPTION
Updates the yml files to use the new /epub34, /common, and /wg-notes paths.

I also updated the REC track yml files to link to the resolutions from the last meeting, but we'll need to add the same later for the overview and a11y techniques.