### PR TITLE
Remove the lint rule to check the wpt repository for tests

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -56,9 +56,6 @@
                 preProcess:[inlineCustomCSS],
                 postProcess:[addCautionHeaders, data_test_display, fixErrataField],
                 testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
-                lint: {
-                     "wpt-tests-exist": true,
-				},
 				xref: {
 					profile: "web-platform",
 					specs: ["epub-rs-33"]

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -110,9 +110,6 @@
 				preProcess:[inlineCustomCSS],
 				postProcess: [data_test_display, fixErrataField],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
-				lint: {
-					"wpt-tests-exist": true,
-				},
 				xref: {
 					profile: "web-platform",
 					specs: ["epub-33"]

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -56,9 +56,6 @@
                 preProcess:[inlineCustomCSS],
                 postProcess:[addCautionHeaders, data_test_display, fixErrataField],
                 testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
-                lint: {
-                     "wpt-tests-exist": true,
-				},
 				xref: {
 					profile: "web-platform",
 					specs: ["epub-rs-34"]

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -115,9 +115,6 @@
 				preProcess:[inlineCustomCSS],
 				postProcess: [data_test_display, fixErrataField],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
-				lint: {
-					"wpt-tests-exist": true,
-				},
 				xref: {
 					profile: "web-platform",
 					specs: ["epub-34"]


### PR DESCRIPTION
This rule appears to be the big slowdown in the load time of the editor drafts. We're not hosting our tests in the wpt repository, so respec spins its wheels for several seconds before throwing a warning about an invalid path.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2696.html" title="Last updated on Mar 17, 2025, 1:58 PM UTC (d3c3694)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2696/27a1728...d3c3694.html" title="Last updated on Mar 17, 2025, 1:58 PM UTC (d3c3694)">Diff</a>