### PR TITLE
Creating a 3.4 version of the implementation reports.

### DIFF
--- a/epub33/reports/index.html
+++ b/epub33/reports/index.html
@@ -66,7 +66,7 @@
               <p>
                 <a href="exit_criteria.html#exit-criteria-core-2-3">Categories 2 and 3</a>: each <em>required</em> constraint on EPUB-specific files, as well as restrictions on [=publication resources=], must be enforceable when checking validity through <a href="https://github.com/w3c/epubcheck/releases/tag/v5.0.0">EPUBCheck 5</a>.
               </p> 
-              <p>See the <a href="https://w3c.github.io/epub-structural-tests/">EPUB 3.3 Structural Test Results</a> document.</p>
+              <p>See the <a href="https://w3c.github.io/epub-structural-tests/epub33">EPUB 3.3 Structural Test Results</a> document.</p>
             </li>
             <li>
               <p>

--- a/epub34/reports/a11y-properties-use.html
+++ b/epub34/reports/a11y-properties-use.html
@@ -2,6 +2,8 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
+
     <title>EPUB Accessibility 1.1.1 Metadata Usage Report</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>

--- a/epub34/reports/a11y-properties-use.html
+++ b/epub34/reports/a11y-properties-use.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>EPUB Accessibility 1.1.1 Metadata Usage Report</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style>
+      .todo {
+        background-color: yellow;
+        color: #900;
+      }
+      .todo::before {
+        content: "(still to be done)";
+      }
+        /* Table zebra style... */
+
+        table {
+            font-size:inherit;
+            font:90%;
+            margin:1em;
+        }
+
+        table td {
+            padding-left: 0.3em;
+        }
+
+        table th {
+            font-weight: bold;
+            text-align: center;
+            background-color: rgb(0,0,128) !important;
+            font-size: 110%;
+            background: hsl(180, 30%, 50%);
+            color: #fff;
+        }
+
+        table th a:link {
+          color: #fff;
+        }
+
+        table th a:visited {
+          color: #aaa;
+        }
+
+        table tr:nth-child(even) {
+            background-color: hsl(180, 30%, 93%) !important;
+        }
+
+        table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+        table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+    </style>
+    <script class="remove">
+        var respecConfig = {
+            specStatus: "base",
+            latestVersion: "https://w3c.github.io/epub-specs/epub34/reports/a11y-properties-use.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub34/reports/a11y-properties-use.html",
+            noRecTrack: true,
+            editors: [{
+                name: "Matt Garrish",
+                company: "DAISY Consortium",
+                companyURL: "https://daisy.org",
+                w3cid: 51655
+            }],
+            github: {
+                repoURL: "https://github.com/w3c/epub-specs",
+                branch: "main"
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <section id="abstract">
+        <p>
+            This document provides information on the usage of the accessibility metadata defined by the [[epub-a11y-111]] specification.
+            It corresponds to the specification's <a href="exit_criteria.html#exit-criteria-a11y-2">category 2 exit criteria</a>.
+    </section>
+    <section id="sotd">
+    </section>
+
+    <div data-include="a11y-properties-use.md" data-include-format="markdown" data-include-replace="true"></div>
+
+</body>
+</html>

--- a/epub34/reports/a11y-properties-use.md
+++ b/epub34/reports/a11y-properties-use.md
@@ -1,0 +1,457 @@
+## Candidate Recommendation Exit Criteria
+
+The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
+the [EPUB Accessibility 1.1.1](https://www.w3.org/TR/epub-a11y-111/) specification for
+consideration as a W3C Proposed Recommendation after documenting implementation of each feature.
+
+For this specification to advance to Proposed Recommendation, it has to be
+proven that metadata defined and required in this specification have sufficient usage by the
+target communities. This metadata falls into two categories:
+
+1. required and recommended schema.org metadata for describing the accessibility
+of publications; and
+2. EPUB-defined metadata properties for reporting aspects of conformance
+
+Usage of these properties means that they are regularly included in the package document
+metadata for their EPUB publications (as appropriate for each title).
+
+## Publisher Implementations
+
+### Schema.org discovery metadata
+
+The following table provides a list of publishers who have stated that they are currently using
+the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package)
+in production or who are in the process of rolling out their implementations.
+
+Discovery properties are expressed in the
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-a11y-111/#attrdef-meta-property).
+
+<table>
+    <thead>
+        <tr>
+            <th>Role</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessibilityFeature">schema:accessibilityFeature</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Fondazione LIA</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessibilityHazard">schema:accessibilityHazard</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Fondazione LIA</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="hhttps://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessibilitySummary">schema:accessibilitySummary</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessMode">schema:accessMode</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Fondazione LIA</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessModeSufficient">schema:accessModeSufficient</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Fondazione LIA</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Conformance metadata
+
+The following table provides a list of publishers who have stated that they are currently using
+the [conformance reporting metadata properties](https://w3c.github.io/epub-specs/epub34/a11y/#sec-conf-reporting)
+in production or who are in the process of rolling out their implementations.
+
+Conformance properties are expressed in the
+[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub34/authoring/#attrdef-meta-property)
+and in the
+[`link` element's `rel` attribute](https://w3c.github.io/epub-specs/epub34/authoring/#attrdef-link-rel).
+
+<table>
+    <thead>
+        <tr>
+            <th>Role</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#dcterms-conformsTo">dcterms:conformsTo</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Fondazione LIA</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#a11y-certifiedBy">a11y:certifiedBy</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Fondazione LIA</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#a11y-certifierCredential">a11y:certifierCredential</a></td>
+            <td>
+            	<ul>
+            		<li>Acorn Press</li>
+                    <li>alto Éditeur d'étonnant</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+                    <li>Brick Books</li>
+                    <li>Brush Education Inc.</li>
+                    <li>Dog Training Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+                    <li>Flanker Press</li>
+                    <li>Fondazione LIA</li>
+                    <li>Formac Lorimer</li>
+            		<li>Goose Lane Editions</li>
+            		<li>Guilford Press</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Hurtubise</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+                    <li>Linda Leith Publishing</li>
+            		<li>Macmillan Learning</li>
+                    <li>md</li>
+                    <li>Nimbus Publishing</li>
+            		<li>Playwrights Canada</li>
+                    <li>Pearson</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+            		<li>Tidewater Press</li>
+                    <li>UBC Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
+                    <li>XYZ</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#a11y-certifierReport">a11y:certifierReport</a></td>
+            <td>
+            	<ul>
+                    <li>Fondazione LIA</li>
+            		<li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+## Validation and Authoring Tool Implementations
+
+The [Ace by DAISY](https://daisy.github.io/ace/) validator provides machine checking of the EPUB Accessibility
+specification requirements. A version that supports the 1.1 specification was released in July 2022.
+
+The [Ace SMART](https://smart.daisy.org) tool assists users with carrying out manual verification of the EPUB
+Accessibility specification. A version that supports the 1.1 specification was also released in July 2022.
+The tool additionally allows authors to generate discovery and certifier metadata for use in their publications.
+
+
+## Vendor Implementations
+
+The following is a list of vendors who have stated that they are currently including
+the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package) for the publishers they serve. For publishers who have received third-party certification, they also include the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting) on their behalf.
+
+- Amnet
+- Apex
+- Canadian Electronic Library
+- Codemantra
+- Lumina Datamatics
+- Newgen
+- S4Carlisle
+- Westchester Publishing
+
+## Bookstore Implementations
+
+The following is a list of Bookstore's who display the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package)
+and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting) when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
+
+- [RedShelf](https://redshelf.com)
+- [VitalSource](https://www.vitalsource.com)
+
+
+## Catalog Feed
+
+The following is a list of Vendors who provide the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package) and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting) in their catalog feed to partners when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
+
+- [VitalSource](https://www.vitalsource.com)

--- a/epub34/reports/a11y-usage.html
+++ b/epub34/reports/a11y-usage.html
@@ -2,6 +2,8 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
+
     <title>EPUB Accessibility 1.1.1 Usage Report</title>
     <style>
         .todo {

--- a/epub34/reports/a11y-usage.html
+++ b/epub34/reports/a11y-usage.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>EPUB Accessibility 1.1.1 Usage Report</title>
+    <style>
+        .todo {
+          background-color: yellow;
+          color: #900;
+        }
+        .todo::before {
+          content: "(still to be done)";
+        }
+          /* Table zebra style... */
+  
+          table {
+              font-size:inherit;
+              font:90%;
+              margin:1em;
+          }
+  
+          table td {
+              padding-left: 0.3em;
+          }
+  
+          table th {
+              font-weight: bold;
+              text-align: center;
+              background-color: rgb(0,0,128) !important;
+              font-size: 110%;
+              background: hsl(180, 30%, 50%);
+              color: #fff;
+          }
+  
+          table th a:link {
+            color: #fff;
+          }
+  
+          table th a:visited {
+            color: #aaa;
+          }
+  
+          table tr:nth-child(even) {
+              background-color: hsl(180, 30%, 93%) !important;
+          }
+  
+          table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+          table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+      </style>
+      <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <script class="remove">
+        var respecConfig = {
+            specStatus: "base",
+            latestVersion: "https://w3c.github.io/epub-specs/epub34/reports/a11y-usage.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub34/reports/a11y-usage.html",
+            noRecTrack: true,
+            editors: [{
+                name: "Matt Garrish",
+                company: "DAISY Consortium",
+                companyURL: "https://daisy.org",
+                w3cid: 51655
+            }],
+            github: {
+                repoURL: "https://github.com/w3c/epub-specs",
+                branch: "main"
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <section id="abstract">
+        <p>
+            This document provides information on publishers who are able to produce EPUB publications that conform
+            to the <a href="https://w3c.github.io/epub-specs/epub34/a11y/">EPUB Accessibility 1.1</a> specification
+        	at WCAG 2.0 Level AA.
+            It corresponds to the specification's <a href="exit_criteria.html#exit-criteria-a11y-1">category 1 exit criteria</a>.
+    </section>
+	
+    <section id="sotd">
+    </section>
+
+    <div data-include="a11y-usage.md" data-include-format="markdown" data-include-replace="true"></div>
+</body>
+</html>

--- a/epub34/reports/a11y-usage.md
+++ b/epub34/reports/a11y-usage.md
@@ -1,0 +1,69 @@
+## Candidate Recommendation Exit Criteria
+
+The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
+the [EPUB Accessibility 1.1.1](https://www.w3.org/TR/epub-a11y-111/) specification for
+consideration as a W3C Proposed Recommendation after documenting that publishers can
+meet the requirements at WCAG 2.0 Level AA.
+
+For this specification to advance to Proposed Recommendation, it has to be
+proven that at least 5 publishers will produce at least 1 EPUB publication each that 
+conform to [EPUB Accessibility 1.1 - WCAG 2.0 Level AA](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting-pub).
+
+Publishers are not expected to be producing content that claims conformance
+to the specification prior to it becoming a recommendation, only that they have
+verified that the content they produce now can meet the requirements by
+verifying at least one publication.
+
+Publishers currently meeting EPUB Accessibility 1.0 at WCAG 2.0 Level AA already
+meet the requirements to claim conformance to the new specification, as the
+new revision does not introduce stricter content requirements.
+
+## Publisher Implementations
+
+- Acorn Press
+- Annick Press
+- Au Press
+- BTL Book
+- Book*hug Press
+- Brick Books
+- Brush Education Inc.
+- Coach House Books
+- Cormorant Books
+- DCB
+- Dog Training Press
+- Dundurn Press
+- ECW Press
+- Éditions Alto
+- Éditions Bourton d'or Acadie
+- Éditions MultiMondes
+- Flanker Press
+- Fondazione LIA
+- Formac Lorimer
+- Goose Lane Editions
+- Guilford Press
+- House of Anansi Press/Groundwood Books
+- Heritage Group Distribution
+- Hurtubise
+- Invisible Publishing
+- Jones and Bartlett Learning
+- Kogan Page
+- Les Éditions Perce-Neige
+- Linda Leith Publishing
+- Macmillan Learning
+- md
+- Nimbus Publishing
+- Pearson
+- Planète rebelle
+- Playwrights Canada
+- Radiant Press
+- Saint Jean
+- Second Story Press
+- Simon &amp; Schuster
+- Taylor &amp; Francis
+- Tidewater Press
+- UBC Press
+- University of Michigan Press
+- University of Ottawa Press
+- Wiley
+- Wilfred Laurier University Press
+- XYZ

--- a/epub34/reports/epub-properties-use.html
+++ b/epub34/reports/epub-properties-use.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>EPUB 3.4 Metadata Usage Report</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>

--- a/epub34/reports/epub-properties-use.html
+++ b/epub34/reports/epub-properties-use.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>EPUB 3.4 Metadata Usage Report</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style>
+      .todo {
+        background-color: yellow;
+        color: #900;
+      }
+      .todo::before {
+        content: "(still to be done)";
+      }
+        /* Table zebra style... */
+
+        table {
+            font-size:inherit;
+            font:90%;
+            margin:1em;
+        }
+
+        table td {
+            padding-left: 0.3em;
+        }
+
+        table th {
+            font-weight: bold;
+            text-align: center;
+            background-color: rgb(0,0,128) !important;
+            font-size: 110%;
+            background: hsl(180, 30%, 50%);
+            color: #fff;
+        }
+
+        table th a:link {
+          color: #fff;
+        }
+
+        table th a:visited {
+          color: #aaa;
+        }
+
+        table tr:nth-child(even) {
+            background-color: hsl(180, 30%, 93%) !important;
+        }
+
+        table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+        table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+    </style>
+    <script class="remove">
+        var respecConfig = {
+            specStatus: "base",
+            latestVersion: "https://w3c.github.io/epub-specs/epub34/reports/epub-properties-use.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub34/reports/epub-properties-use.html",
+            noRecTrack: true,
+            editors: [{
+                name: "Matt Garrish",
+                company: "DAISY Consortium",
+                companyURL: "https://daisy.org",
+                w3cid: 51655
+            }],
+            github: {
+                repoURL: "https://github.com/w3c/epub-specs",
+                branch: "main"
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <section id="abstract">
+        <p>
+            This document provides information on the usage of the various metadata defined by the [[epub-34]] specification.
+            It corresponds to the specification's <a href="exit_criteria.html#exit-criteria-core-3">category 3 exit criteria</a>.
+
+    </section>
+    <section id="sotd">
+    </section>
+
+    <div data-include="epub-properties-use.md" data-include-format="markdown" data-include-replace="true"></div>
+
+</body>
+</html>

--- a/epub34/reports/epub-properties-use.md
+++ b/epub34/reports/epub-properties-use.md
@@ -1,0 +1,1100 @@
+## Candidate Recommendation Exit Criteria
+
+The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
+the [EPUB 3.4](https://www.w3.org/TR/epub-34/) specification for consideration
+as a W3C Proposed Recommendation after documenting implementation of each feature.
+
+For this specification to advance to Proposed Recommendation, it has to be
+proven that metadata defined and required in this specification have sufficient usage by the
+target communities. This metadata falls into two categories:
+
+1. metadata for expressing information about the publication in the package document; and
+2. metadata for expressing preferred rendering of the content
+
+Usage of these properties, as listed in the following tables, means that the organizations regularly
+include the metadata in the package document (for publishers) or use them in bookshelves, content
+rendering, etc. (for reading system developers).
+
+## Publisher Implementations
+
+### Meta Properties Vocabulary
+
+The following table lists organizations that have stated that they are currently using
+the [meta properties](https://www.w3.org/TR/epub-34/#app-meta-property-vocab)
+in production.
+
+Meta properties are expressed in the
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-34/#attrdef-meta-property).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-alternate-script">alternate-script</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-authority">authority</a></td>
+            <td>
+            	<ul>
+                    <li>American Academy of Pediatrics</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-belongs-to-collection">belongs-to-collection</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>BookFusion Inc</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-collection-type">collection-type</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+            		<li>Liturgical Press</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-display-seq">display-seq</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>Hachette Book Group</li>
+                    <li>KADOKAWA</li>
+                    <li>Macmillan Learning</li>
+                    <li>Moody Publishers</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>University of Minnesota Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-file-as">file-as</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>Amnet</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Chicago Distribution Center</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>Hachette Book Group</li>
+                    <li>KADOKAWA</li>
+                    <li>Lerner Publishing Group</li>
+                    <li>Moody Publishers</li>
+            		<li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>University of Minnesota Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-group-position">group-position</a></td>
+            <td>
+            	<ul>
+                    <li>BookFusion Inc</li>
+            		<li>Liturgical Press</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-identifier-type">identifier-type</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>Amnet</li>
+                    <li>BroadStreet Publishing Group LLC</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Charisma Media</li>
+                    <li>Chicago Distribution Center</li>
+                    <li>Consonance</li>
+            		<li>Hachette Book Group</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lerner Publishing Group</li>
+                    <li>Macmillan Learning</li>
+                    <li>new harbinger publications</li>
+                    <li>Pearson</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>The Quarto Group</li>
+                    <li>University of Minnesota Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>Westchester Publishing Services</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-meta-auth"><s>meta-auth</s></a></td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-role">role</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>Amnet</li>
+                    <li>BroadStreet Publishing Group LLC</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Charisma Media</li>
+                    <li>Chicago Distribution Center</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>Hachette Book Group</li>
+                    <li>Industrial Press, Inc.</li>
+                    <li>KADOKAWA</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Moody Publishers</li>
+            		<li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>PRH UK</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>Teacher Created Materials</li>
+                    <li>University of Minnesota Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>Westchester Publishing Services</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-source-of">source-of</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>BookFusion Inc</li>
+                    <li>Chicago Distribution Center</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Macmillan Learning</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>Westchester Publishing Services</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-term">term</a></td>
+            <td>
+            	<ul>
+                    <li>American Academy of Pediatrics</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-title-type">title-type</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>Amnet</li>
+                    <li>BroadStreet Publishing Group LLC</li>
+                    <li>Charisma Media</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>Hachette Book Group</li>
+                    <li>House of Anansi Press/Groundwood Books</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>The Quarto Group</li>
+                    <li>University of Minnesota Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>Westchester Publishing Services</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Link Vocabulary
+#### Link Relationships
+
+The following table lists organizations that have stated that they are currently using
+the [link relationships](https://www.w3.org/TR/epub-34/#sec-link-rel)
+in production.
+
+Link relationships are expressed in the
+[`link` element's `rel` attribute](https://www.w3.org/TR/epub-34/#attrdef-link-rel).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-alternate">alternate</a></td>
+            <td>
+            	<ul>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-marc21xml-record"><s>marc21xml-record</s></a></td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-mods-record"><s>mods-record</s></a></td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-onix-record"><s>onix-record</s></a></td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-record">record</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Taylor &amp; Francis</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-voicing">voicing</a></td>
+            <td>
+            	<ul>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>CYPAC/Voice of DAISY 5 version 5.7</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-xml-signature"><s>xml-signature</s></a></td>
+            <td>
+            	<p>This property deprecated and is no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-xmp-record"><s>xmp-record</s></a></td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### Link Properties
+
+The following table lists organizations that have stated that they are currently using
+the [link properties](https://www.w3.org/TR/epub-34/#sec-link-properties)
+in production.
+
+Link properties are expressed in the
+[`link` element's `properties` attribute](https://www.w3.org/TR/epub-34/#attrdef-properties).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-onix">onix</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Taylor &amp; Francis</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Package Rendering Vocabulary
+#### General Properties
+
+The following table lists organizations that have stated that they are currently using
+the [general package rendering properties](https://www.w3.org/TR/epub-34/#sec-rendering-general)
+in production.
+
+General package rendering properties are expressed both globally in the
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-34/#attrdef-meta-property)
+and as overrides in the
+[`itemref` element's `properties` attribute](https://www.w3.org/TR/epub-34/#attrdef-properties).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-flow">rendition:flow</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+            		<li>Pearson</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#flow-auto">rendition:flow-auto</a></td>
+            <td>
+            	<ul>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#flow-paginated">rendition:flow-paginated</a></td>
+            <td>
+            	<ul>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#flow-scrolled-continuous">rendition:flow-scrolled-continuous</a></td>
+            <td>
+            	<ul>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#flow-scrolled-doc">rendition:flow-scrolled-doc</a></td>
+            <td>
+            	<ul>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-align-x-center">rendition:align-x-center</a></td>
+            <td>
+            	<ul>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### Fixed-Layout Properties
+
+The following table lists organizations that have stated that they are currently using
+the [fixed-layout rendering properties](https://www.w3.org/TR/epub-34/#sec-rendering-fxl)
+in production.
+
+Fixed-layout properties are expressed both globally in the
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-34/#attrdef-meta-property)
+and as overrides in the
+[`itemref` element's `properties` attribute](https://www.w3.org/TR/epub-34/#attrdef-properties).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#layout">rendition:layout</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>Hachette Book Group</li>
+                    <li>House of Anansi Press/Groundwood Books</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lee & Low Books</li>
+                    <li>Lerner Publishing Group</li>
+            		<li>Liturgical Press</li>
+                    <li>Moody Publishers</li>
+                    <li>Penguin Random House North America</li>
+                    <li>PRH UK</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#layout-pre-paginated">rendition:layout-pre-paginated</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>Hachette Book Group</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Moody Publishers</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Teacher Created Materials</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#layout-reflowable">rendition:layout-reflowable</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Penguin Random House North America</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#orientation">rendition:orientation</a></td>
+            <td>
+            	<ul>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>Hachette Book Group</li>
+                    <li>House of Anansi Press/Groundwood Books</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lerner Publishing Group</li>
+                    <li>Moody Publishers</li>
+                    <li>PRH UK</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>Westchester Publishing Services</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#orientation-auto">rendition:orientation-auto</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>Hachette Book Group</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Teacher Created Materials</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#orientation-landscape">rendition:orientation-landscape</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#orientation-portrait">rendition:orientation-portrait</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#spread">rendition:spread</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>Hachette Book Group</li>
+                    <li>House of Anansi Press/Groundwood Books</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lee & Low Books</li>
+                    <li>Lerner Publishing Group</li>
+                    <li>Moody Publishers</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>PRH UK</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Teacher Created Materials</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>Westchester Publishing Services</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#spread-auto">rendition:spread-auto</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>Hachette Book Group</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Moody Publishers</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#spread-both">rendition:spread-both</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Penguin Random House North America</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#spread-landscape">rendition:spread-landscape</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#spread-none">rendition:spread-none</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Moody Publishers</li>
+                    <li>Penguin Random House North America</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#spread-portrait"><s>rendition:spread-portrait</s></a></td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#page-spread-center">rendition:page-spread-center</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Penguin Random House North America</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#page-spread-left">rendition:page-spread-left</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Penguin Random House North America</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#page-spread-right">rendition:page-spread-right</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Penguin Random House North America</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#viewport"><s>rendition:viewport</s></a></td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Manifest Properties Vocabulary
+
+The following table lists organizations that have stated that they are currently using
+the [manifest properties](https://www.w3.org/TR/epub-34/#app-item-properties-vocab)
+in production.
+
+Manifest properties are expressed in the
+[`item` element's `properties` attribute](https://www.w3.org/TR/epub-34/#attrdef-properties).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-cover-image">cover-image</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Charisma Media</li>
+                    <li>Chicago Distribution Center</li>
+                    <li>Consonance</li>
+                    <li>CYPAC/Voice of DAISY 5 version 5.7</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>Hachette Book Group</li>
+                    <li>House of Anansi Press/Groundwood Books</li>
+                    <li>Industrial Press, Inc.</li>
+                    <li>KADOKAWA</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lee & Low Books</li>
+                    <li>Lerner Publishing Group</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Moody Publishers</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>PRH UK</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>Teacher Created Materials</li>
+                    <li>The Quarto Group</li>
+                    <li>University of Minnesota Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>W. W. Norton & Company, Inc. (Educational)</li>
+                    <li>Westchester Publishing Services</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-mathml">mathml</a></td>
+            <td>
+            	<ul>
+                    <li>Amnet</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Macmillan Learning</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>Westchester Publishing Services</li>
+            		<li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-nav">nav</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>American Academy of Pediatrics</li>
+                    <li>Amnet</li>
+                    <li>Beaufort Books</li>
+                    <li>BookFusion Inc</li>
+                    <li>Carson Dellosa Education</li>
+                    <li>Charisma Media</li>
+                    <li>Chicago Distribution Center</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>Hachette Book Group</li>
+                    <li>House of Anansi Press/Groundwood Books</li>
+                    <li>Industrial Press, Inc.</li>
+                    <li>KADOKAWA</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lerner Publishing Group</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Moody Publishers</li>
+                    <li>Pearson</li>
+                    <li>Penguin Random House North America</li>
+                    <li>PRH UK</li>
+                    <li>Simon &amp; Schuster</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>Teacher Created Materials</li>
+                    <li>The Quarto Group</li>
+                    <li>University of Minnesota Press</li>
+                    <li>University of Nebraska Press</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>Westchester Publishing Services</li>
+                    <li>W. W. Norton & Company, Inc. (Educational)</li>
+                    <li>Wiley</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-remote-resources">remote-resources</a></td>
+            <td>
+            	<ul>
+                    <li>Carson Dellosa Education</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Macmillan Learning</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>W. W. Norton & Company, Inc. (Educational)</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-scripted">scripted</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Hachette Book Group</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Moody Publishers</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>W. W. Norton & Company, Inc. (Educational)</li>
+                    <li>Westchester Publishing Services</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-svg">svg</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>Consonance</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KADOKAWA</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+            		<li>Liturgical Press</li>
+                    <li>Macmillan Learning</li>
+                    <li>Moody Publishers</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Taylor &amp; Francis</li>
+                    <li>VitalSource Technologies, LLC</li>
+                    <li>Westchester Publishing Services</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-switch"><s>switch</s></a></td>
+            <td>
+            	<p>This property indicates that the deprecated switch element is present.
+                    It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Spine properties vocabulary
+
+The following table lists organizations that have stated that they are currently using
+the [spine properties](https://www.w3.org/TR/epub-34/#app-itemref-properties-vocab)
+in production.
+
+Spine properties are expressed in the
+[`itemref` element's `properties` attribute](https://www.w3.org/TR/epub-34/#attrdef-properties).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-page-spread-left">page-spread-left</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lee & Low Books</li>
+                    <li>Lerner Publishing Group</li>
+            		<li>Liturgical Press</li>
+                    <li>Penguin Random House North America</li>
+                    <li>PRH UK</li>
+                    <li>Teacher Created Materials</li>
+                    <li>VitalSource Technologies, LLC</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-page-spread-right">page-spread-right</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>Consonance</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KADOKAWA</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lee & Low Books</li>
+                    <li>Lerner Publishing Group</li>
+            		<li>Liturgical Press</li>
+                    <li>Penguin Random House North America</li>
+                    <li>PRH UK</li>
+                    <li>Teacher Created Materials</li>
+                    <li>VitalSource Technologies, LLC</li>
+             	</ul>
+           </td>
+        </tr>
+    </tbody>
+</table>
+
+### Media Overlays Vocabulary
+
+The following table lists organizations that have stated that they are currently using
+the [Media Overlays properties](https://www.w3.org/TR/epub-34/#app-overlays-vocab)
+in production.
+
+Media Overlays properties are expressed in the
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-34/#attrdef-meta-property).
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-active-class">active-class</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>Kaplan North America, LLC</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lerner Publishing Group</li>
+            		<li>Liturgical Press</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Teacher Created Materials</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-duration">duration</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+            		<li>House of Anansi Press/Groundwood Books</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Lerner Publishing Group</li>
+                    <li>Penguin Random House North America</li>
+                    <li>Teacher Created Materials</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-narrator">narrator</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>Amnet</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Penguin Random House North America</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://www.w3.org/TR/epub-34/#sec-playback-active-class">playback-active-class</a></td>
+            <td>
+            	<ul>
+                    <li>Advantage | ForbesBooks</li>
+                    <li>BookFusion Inc</li>
+                    <li>EDRLab (Thorium Reader)</li>
+                    <li>KnowledgeWorks Global Ltd.</li>
+                    <li>Penguin Random House North America</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+## Validation and Authoring Tool Implementations
+
+Where machine-testable assertions are made about the use of this metadata, conformance is checked by EPUBCheck.
+In particular, it is able to determine if authors have not set manifest properties correctly.
+

--- a/epub34/reports/exit_criteria.html
+++ b/epub34/reports/exit_criteria.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>EPUB 3.4 Testing Strategies and CR Exit Criteria</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style>
+      .todo {
+        background-color: yellow;
+        color: #900;
+      }
+
+    </style>
+    <script class="remove">
+        var respecConfig = {
+            specStatus: "base",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/exit_criteria.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/exit_criteria.html",
+            noRecTrack: true,
+            editors: [{
+                name: "Ivan Herman",
+                url: "https://www.w3.org/People/Ivan/",
+                company: "W3C",
+                w3cid: 7382,
+                orcid: "0000-0003-0782-2704",
+                companyURL: "https://www.w3.org",
+            }],
+            github: {
+                repoURL: "https://github.com/w3c/epub-specs",
+                branch: "main"
+            },
+            shortName: "exit-criteria",
+            xref: {
+              profile: "web-platform",
+              specs: ["epub-rs-34","epub-34"]
+            },
+        };
+    </script>
+</head>
+
+<body>
+    <section id="abstract">
+        <p>
+            This document outlines the testing strategies, reporting, and specifies the <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation (CR)</a> exit criteria for the EPUB 3.4 specifications. The three Recommendation-track specifications that are subject to testing and PR review are:
+        </p>
+        <ol>
+            <li>EPUB Reading Systems 3.3 [[epub-rs-34]]</li>
+            <li>EPUB 3.4 [[epub-34]]</li>
+            <li>EPUB Accessibility 1.1 [[epub-a11y-11]]</li>
+        </ol>
+    </section>
+    <section id="sotd">
+    </section>
+
+    <section>
+        <h1 id="introduction">Introduction</h1>
+        <p>
+          At the core, an EPUB 3.4 publication consists of a number of [=publication resources=] that are in XHTML, SVG, CSS, or various media formats. Beyond these publication resources the EPUB publication includes some EPUB-specific files (e.g, a [=package document=]) whose formats are defined by the EPUB 3.4 standard family. Accordingly, an EPUB 3.4 reading system has to:
+        </p>
+
+        <ul>
+            <li>interpret and render these standard formats, much like web browsers do; and</li>
+            <li>provide some additional features <em>“on top”</em> of that renderer.</li>
+        </ul>
+
+        <p>See also the the EPUB 3 Overview [[epub-overview-33]] for more details on the structure of EPUB 3.4 publications.</p>
+        <p>
+          As a consequence of this particular structure, the validity and conformance of an EPUB 3.4 publication, as well as of a reading system implementation, <em>includes</em> the requirement of valid and conformant publication resources, and the conformant rendering thereof.
+          Comprehensive testing would therefore require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.4 specific features. The standard checking tools that are widely used by the publishing community, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE</a>, indeed include externally developed HTML, CSS, or accessibility checkers, which would check the validity or conformance of the publication resources. Also, today’s reading systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a “WebView” implementation) that can be assumed to conform to the relevant W3C specifications.
+        </p>
+
+        <p>
+          This means that these additional tests would be quite unnecessary for the purpose of testing the EPUB 3.4 specification (which is the main purpose of a <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation</a>). As a consequence, the <em><strong>testing strategy of EPUB 3.4 concentrates on the unique EPUB 3.4 features only</strong></em>, and considers the publication resources, as well as the reading systems, to conform to the relevant Open Web Platform  specifications.
+        </p>
+    </section>
+
+    <section>
+        <h1 id="testing-strategies">Testing strategies</h1>
+
+        <p>EPUB 3.4 consists of three recommendation-track documents:</p>
+
+        <ol type="1">
+          <li>EPUB Reading Systems 3.3 [[epub-rs-34]]</li>
+          <li>EPUB 3.4 [[epub-34]]</li>
+          <li>EPUB Accessibility 1.1 [[epub-a11y-11]]</li>
+      </ol>
+
+        <p>Due to the specificities of these documents the strategy, exit criteria, and reporting are different. These are detailed below.</p>
+
+        <section>
+            <h2 id="epub-3.3-reading-systems">EPUB 3.4 Reading Systems</h2>
+
+            <p>
+              Implementers of the <a href="https://www.w3.org/TR/epub-rs-34/">EPUB 3.4 Reading Systems</a> specification are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the Web Platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for <em>all</em> <em style="font-variant: small-caps;">must</em> statements, as well as for many <em style="font-variant: small-caps;">should</em> and for some <em style="font-variant: small-caps;">may</em> statements, that appear in the <a href="https://www.w3.org/TR/epub-rs-34/">EPUB 3.4 Reading Systems</a> specification.
+            </p>
+
+            <p>
+              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <a href="https://w3c.github.io/epub-specs/epub33/rs/"><em>editors’ draft</em></a> (as opposed to the official, published version) of the specification has a pull-down menu attached to each <em style="font-variant: small-caps;">must</em> statement providing the references to the relevant tests.
+            </p>
+            <section>
+                <h3 id="exit-criteria-rs">Exit criteria</h3>
+
+                <p>
+                  The <a href="https://www.w3.org/TR/epub-rs-34/">EPUB 3.4 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em style="font-variant: small-caps;">must</em> statement in the specification.
+                </p>
+                <p>                  
+                  The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
+                </p>
+            </section>
+        </section>
+
+        <section>
+            <h2 id="epub-3.3-core">EPUB 3.4 (Core)</h2>
+            <p>
+              The normative features of the <a href="https://www.w3.org/TR/epub-34/">EPUB 3.4</a> specification can be divided, roughly, into the following categories:
+            </p>
+
+            <ol>
+                <li>
+                    <p>
+                      Features that have a direct effect on the reading system behavior, and whose behavioral details are mostly specified by <a href="https://www.w3.org/TR/epub-rs-34/">EPUB 3.4 Reading Systems</a>. Examples are the list of <a href="https://www.w3.org/TR/epub-34/#sec-core-media-types">supported media types</a>, semantics of some <a href="https://www.w3.org/TR/epub-34/#attrdef-dir">internationalization features</a>, or the <a href="https://www.w3.org/TR/epub-34/#sec-container-iri">specificities of URLs</a> in the case of packaged contents. These features have their counterpart in the <a href="https://www.w3.org/TR/epub-rs-34/">EPUB 3.4 Reading Systems</a> document and they share the relevant tests. In other words, some of the aforementioned tests, and their implementations, are also relevant for the core <a href="https://www.w3.org/TR/epub-34/">EPUB 3.4</a> document.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Structural constraints on a the EPUB-specific files of the publication; examples include the <a href="https://www.w3.org/TR/epub-34/#sec-ocf">structure of the container format (OCF)</a> or of the <a href="https://www.w3.org/TR/epub-34/#sec-package-doc">package document</a>.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Extra restrictions concerning content documents such as the <a href="https://www.w3.org/TR/epub-34/#sec-xhtml-deviations">restrictions on XHTML</a>, the <a href="https://www.w3.org/TR/epub-34/#sec-nav">format of an XHTML navigation document</a>, or the <a href="https://www.w3.org/TR/epub-34/#sec-xml-constraints">requirements on XML conformance</a>.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Vocabulary items which serve as metadata for the publication, and added to the <a href="https://www.w3.org/TR/epub-34/#sec-package-doc">EPUB 3.4 package document</a>. Although only few of those vocabulary items are <em>required</em> for a conformant EPUB specification, their formats, value constraints, etc., are normatively specified in the standard and these <em>must</em> be followed for a publication to be valid if they are used.
+                    </p>
+                </li>
+            </ol>
+            <section>
+                <h3 id="exit-criteria-core">Exit criteria</h3>
+                <p>The criteria are different for each category of the normative features:</p>
+                <ol>
+                    <li id="exit-criteria-core-1">
+                        <p>
+                          Features in category 1 share the testing methodology, exit criteria, as well as the <a href="https://w3c.github.io/epub-tests/">tests</a> and <a href="https://w3c.github.io/epub-tests/results">implementation results</a>, with the <a href="#exit-criteria-rs">criteria</a> of <a href="https://www.w3.org/TR/epub-rs-34/">EPUB 3.4 Reading Systems</a>. This includes the mechanism whereby the tests are referenced from the <a href="https://w3c.github.io/epub-specs/epub33/core/"><em>editors’ draft</em></a> via pull-down menus.
+                        </p>
+                    </li>
+                    <li id="exit-criteria-core-2-3">
+                        <p>
+                          Testing the features in categories 2 and 3 concentrates on whether these restrictions are <em>feasible</em> in practice, i.e., whether they are enforceable when checking validity. 
+                        </p>
+                        <p>  
+                          The latest version of <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>, namely <a href="https://github.com/w3c/epubcheck/releases/tag/v5.0.0">EPUBCheck 5</a>, validates EPUB 3.4. Earlier versions of EPUBCheck are extensively used throughout the industry for several years now, and act as “gatekeepers” in the publication workflow for the major EPUB platforms; it is to be expected that all these platforms will upgrade their workflow for EPUB 3.4.
+                        </p>
+
+                        <p>
+                          EPUBCheck has its own <a href="https://github.com/w3c/epubcheck/tree/w3c/epub-33-cr-report/src/test/resources">test suite</a>; the exit criteria for testing categories 2 and 3 features is therefore formulated by requiring that each relevant <em style="font-variant: small-caps;">must</em> statement in <a href="https://www.w3.org/TR/epub-34/">EPUB 3.4</a> is covered by at least one EPUBCheck test.
+                        </p>
+
+                        <p>
+                          The results of testing is shown in a <a href="https://w3c.github.io/epub-structural-tests/">separate document</a>, providing a short description, and reference, for each relevant EPUBCheck test. The test descriptions are grouped using the structure of <a href="https://www.w3.org/TR/epub-34/">EPUB 3.4</a>, and these groups are referenced, via pull-down menus, from the section headers of the <a href="https://w3c.github.io/epub-specs/epub33/core/"><em>editors’ draft</em></a> of the specification.
+                        </p>
+                            
+                    </li>
+                    <li id="exit-criteria-core-4">
+                        <p>
+                          Testing the features in category 4 concentrates on vocabulary term <em>usage</em>, i.e., whether real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production.
+                        </p>
+                        <p>
+                          The results of testing are available in the separate <a href="epub-properties-use.html">EPUB 3.4 Metadata Usage Report</a>.
+                        </p>
+                    </li>
+                </ol>
+            </section>
+        </section>
+        <section>
+            <h2 id="epub-accessibility-1.1">EPUB Accessibility 1.1</h2>
+            <p>
+              The goals of the <a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility 1.1</a> document is to define accessibility conformance of EPUB publications beyond the accessibility requirements defined by WCAG for publication resources. The normative features of this specification can be divided, roughly, into the following categories:
+            </p>
+            <ol>
+                <li>
+                    <p>
+                      Additional structural constraints on a publication; examples include the <a href="https://www.w3.org/TR/epub-a11y-111/#sec-page-list">requirement on page lists</a> or <a href="https://www.w3.org/TR/epub-a11y-111/#sec-mo-order">reading order</a>. Through those constraints the document defines accessibility <a href="https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting-pub">conformance requirements</a> on top of the conformance levels defined by <a href="https://www.w3.org/TR/WCAG21/">WCAG</a>.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Vocabulary items which serve as metadata for reporting; for example, <a href="https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting-pub">conformance levels</a>, or disclosing the <a href="https://www.w3.org/TR/epub-a11y-111/#sec-disc-package">accessibility features</a> related to this publication.
+                    </p>
+                </li>
+            </ol>
+            <section>
+                <h3 id="exit-criteria-a11y">Exit criteria</h3>
+                <ol>
+                    <li id="exit-criteria-a11y-1">
+                        <p>
+                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB publication each that conform to <a href="https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.
+                        </p> 
+                          
+                        <p>
+                          Note that these conformance levels rely on each publication resource to conform to WCAG 2.0 AA, when applicable; there are only a few EPUB specific features like page numbering. At least two independent publishers should be fulfilling that conformance level.
+                        </p>
+                          
+                        <p>
+                          The separate <a href="a11y-usage">EPUB Accessibility 1.1 Usage Report</a> shows the conformance table.
+                        </p>
+                    </li>
+                    <li id="exit-criteria-a11y-2">
+                        <p>
+                          Testing the features in category 2 concentrates on vocabulary term <em>usage</em>, i.e., that real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production.
+                        </p>
+                        <p>
+                          The separate <a href="a11y-properties-use">EPUB Accessibility 1.1 Metadata Usage Report</a> shows the implementation table.
+                        </p>
+                    </li>
+                </ol>
+            </section>
+        </section>
+    </section>
+</body>
+
+</html>

--- a/epub34/reports/exit_criteria.html
+++ b/epub34/reports/exit_criteria.html
@@ -2,6 +2,8 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
+
     <title>EPUB 3.4 Testing Strategies and CR Exit Criteria</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>

--- a/epub34/reports/index.html
+++ b/epub34/reports/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>EPUB 3.4 Implementation reports</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>
@@ -60,13 +61,13 @@
               <p>
                 <a href="exit_criteria.html#exit-criteria-core-1">Category 1</a>: each <em>required</em> feature define by [[epub-34]], that has a direct effect on the reading system behavior, and whose behavioral details are mostly specified by [[epub-rs-34]], must have at least two, mutually independent implementations.
               </p>
-              <p>See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a> document.</p>
+              <p>See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.4 Test Results</a> document.</p>
             </li>
             <li>
               <p>
                 <a href="exit_criteria.html#exit-criteria-core-2-3">Categories 2 and 3</a>: each <em>required</em> constraint on EPUB-specific files, as well as restrictions on [=publication resources=], must be enforceable when checking validity through <a href="https://github.com/w3c/epubcheck/releases/tag/v5.0.0">EPUBCheck 5</a>.
               </p> 
-              <p>See the <a href="https://w3c.github.io/epub-structural-tests/">EPUB 3.3 Structural Test Results</a> document.</p>
+              <p>See the <a href="https://w3c.github.io/epub-structural-tests/">EPUB 3.4 Structural Test Results</a> document.</p>
             </li>
             <li>
               <p>

--- a/epub34/reports/index.html
+++ b/epub34/reports/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>EPUB 3.3 Implementation reports</title>
+    <title>EPUB 3.4 Implementation reports</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>
       .todo {
@@ -17,8 +17,8 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/",
-            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/index.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub34/reports/",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub34/reports/index.html",
             noRecTrack: true,
             editors: [{
                 name: "Ivan Herman",
@@ -34,7 +34,7 @@
             },
             xref: {
               profile: "web-platform",
-              specs: ["epub-rs-33","epub-33"]
+              specs: ["epub-rs-34","epub-34"]
             },
 
         };
@@ -44,7 +44,7 @@
 <body>
     <section id="abstract">
         <p>
-            This document gives an overview of the various implementation reports corresponding to the testing strategies, and CR exit criteria, of EPUB 3.3 as described in a <a href="exit_criteria.html">separate document</a>.
+            This document gives an overview of the various implementation reports corresponding to the testing strategies, and CR exit criteria, of EPUB 3.4 as described in a <a href="exit_criteria.html">separate document</a>.
     </section>
     <section id="sotd">
     </section>
@@ -53,14 +53,14 @@
       <h1 id="reports-per-criteria">Reports per documents and criteria</h1>
 
       <dl>
-        <dt><a href="exit_criteria.html#exit-criteria-core">EPUB 3.3 (Core)</a> [[epub-33]]</dt>
+        <dt><a href="exit_criteria.html#exit-criteria-core">EPUB 3.4 (Core)</a> [[epub-34]]</dt>
         <dd>
           <ul>
             <li>
               <p>
-                <a href="exit_criteria.html#exit-criteria-core-1">Category 1</a>: each <em>required</em> feature define by [[epub-33]], that has a direct effect on the reading system behavior, and whose behavioral details are mostly specified by [[epub-rs-33]], must have at least two, mutually independent implementations.
+                <a href="exit_criteria.html#exit-criteria-core-1">Category 1</a>: each <em>required</em> feature define by [[epub-34]], that has a direct effect on the reading system behavior, and whose behavioral details are mostly specified by [[epub-rs-34]], must have at least two, mutually independent implementations.
               </p>
-              <p>See the <a href="https://w3c.github.io/epub-tests/epub33/results">EPUB 3.3 Test Results</a> document.</p>
+              <p>See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a> document.</p>
             </li>
             <li>
               <p>
@@ -70,22 +70,22 @@
             </li>
             <li>
               <p>
-                <a href="exit_criteria.html#exit-criteria-core-4">Category 4</a>: each metadata item defined and required in the [=package document=] defined by [[epub-33]] has sufficient usage by the target communities, i.e., at least two organizations regularly include the metadata in the package document (for publishers) or use them in bookshelves, content rendering, etc. (for reading system developers).
+                <a href="exit_criteria.html#exit-criteria-core-4">Category 4</a>: each metadata item defined and required in the [=package document=] defined by [[epub-34]] has sufficient usage by the target communities, i.e., at least two organizations regularly include the metadata in the package document (for publishers) or use them in bookshelves, content rendering, etc. (for reading system developers).
               </p>
               <p>
-                See the <a href="epub-properties-use.html">EPUB 3.3 Metadata Usage Report</a> document.
+                See the <a href="epub-properties-use.html">EPUB 3.4 Metadata Usage Report</a> document.
               </p>
             </li>
           </ul>
         </dd>
       </dl>
 
-      <dt><a href="exit_criteria.html#exit-criteria-rs">EPUB 3.3 Reading Systems</a> [[epub-rs-33]]</dt>
+      <dt><a href="exit_criteria.html#exit-criteria-rs">EPUB 3.4 Reading Systems</a> [[epub-rs-34]]</dt>
       <dd>
         <ul>
           <li> 
             <p>
-              Each <em>required</em> feature, whose behavior is specified by [[epub-rs-33]], must have at least two, mutually independent implementations.
+              Each <em>required</em> feature, whose behavior is specified by [[epub-rs-34]], must have at least two, mutually independent implementations.
             </p>
             <p>
               See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a> document.


### PR DESCRIPTION
Two steps

- Modified the index file in the 3.3 version of the report to refer to a frozen version of the 3.3 implementation report. The 3.3 test result are then cast in concrete. See also https://github.com/w3c/epub-tests/pull/301
- Made a copy of all the report files into a epub34/reports directory, and modified every occurrence of 3.3 (and 1.1) to 3.4, resp. 1.1.1.

This PR should be merged after https://github.com/w3c/epub-tests/pull/301 which, on its turn, should be merged only after the 3.4 specs are published (expected on March 27).