### PR TITLE
Fix typo in a11y-tech note

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -422,7 +422,7 @@
 
 					<p>For example, a publication with media overlays that has text and images (with text alternatives)
 						would only declare the following sufficient access modes: "<code>textual</code>",
-							"<code>auditory</code>, and "<code>textual,visual</code>".</p>
+							"<code>auditory</code>", and "<code>textual,visual</code>".</p>
 
 					<p>It would <strong>not</strong> declare "<code>textual,auditory</code>" or
 							"<code>textual,visual,auditory</code>".</p>


### PR DESCRIPTION
Found a typo in the accessibility techniques document (missing closing quote), this PR is a fix.