### PR TITLE
Use date ranges for change log links

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -2491,7 +2491,7 @@
 					publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed in this version, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-A11yTechniques%20closed%3A%3E2025-02-11%20"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-A11yTechniques%20closed%3A%3E2025-02-11..2027-02-11%20"
 					>working group's issue tracker</a>.</p>
 
 			<ul>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -2491,7 +2491,7 @@
 					publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed in this version, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-A11yTechniques+label%3AAccessibility12+"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-A11yTechniques%20closed%3A%3E2025-02-11%20"
 					>working group's issue tracker</a>.</p>
 
 			<ul>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1891,7 +1891,7 @@
 				conformance of EPUB publications.</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-Accessibility+label%3AAccessibility12"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-Accessibility%20closed%3A%3E2025-02-11%20"
 					>working group's issue tracker</a>.</p>
 
 			<details id="changes-epub-a11y-11" open="open">

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1898,7 +1898,7 @@
 				<summary>Substantive changes since <a href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility
 					1.1</a></summary>
 				<ul>
-					<li>No substantive changes have been made.</li>
+					<li>No substantive changes have been made. </li>
 				</ul>
 			</details>
 		</section>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1891,7 +1891,7 @@
 				conformance of EPUB publications.</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-Accessibility%20closed%3A%3E2025-02-11%20"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-Accessibility%20closed%3A%3E2025-02-11..2027-02-11%20"
 					>working group's issue tracker</a>.</p>
 
 			<details id="changes-epub-a11y-11" open="open">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11922,7 +11922,7 @@ EPUB/images/cover.png</pre>
 				publications=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3AEPUB34%20label%3ASpec-EPUB3%20"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A%3E2025-02-11%20-label%3AErrata"
 					>Working Group's issue tracker</a>.</p>
 
 			<details id="changes-epub-33">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11925,7 +11925,7 @@ EPUB/images/cover.png</pre>
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A%3E2025-02-11..2027-02-11%20-label%3AErrata"
 					>Working Group's issue tracker</a>.</p>
 
-			<details id="changes-epub-33">
+			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
 					<li>19-Feb-2025: Clarified that resources referenced from <code>script</code> elements are exempt.

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11922,7 +11922,7 @@ EPUB/images/cover.png</pre>
 				publications=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A%3E2025-02-11%20-label%3AErrata"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A%3E2025-02-11..2027-02-11%20-label%3AErrata"
 					>Working Group's issue tracker</a>.</p>
 
 			<details id="changes-epub-33">

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2719,7 +2719,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
-					<li>No substantive changes have been made.</li>
+					<li>No substantive changes have been made. </li>
 				</ul>
 			</details>
 		</section>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2712,7 +2712,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				[=EPUB reading systems=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20sort%3Aupdated-desc%20label%3ASpec-ReadingSystems%20%20label%3AEPUB33"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-ReadingSystems%20closed%3A%3E2025-02-11%20"
 					>working group's issue tracker</a>.</p>
 
 			<details id="changes-epub-rs-33" open="open">

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2712,7 +2712,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				[=EPUB reading systems=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-ReadingSystems%20closed%3A%3E2025-02-11%20"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-ReadingSystems%20closed%3A%3E2025-02-11%20..2027-02-11"
 					>working group's issue tracker</a>.</p>
 
 			<details id="changes-epub-rs-33" open="open">


### PR DESCRIPTION
Instead of tagging every issue we close with a revision number label, this PR moves us to using github's date range feature. I've set the range to two years from the revision start, but we may have to adjust this later.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2706.html" title="Last updated on Apr 8, 2025, 2:09 PM UTC (a5c2a8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2706/01d4330...a5c2a8c.html" title="Last updated on Apr 8, 2025, 2:09 PM UTC (a5c2a8c)">Diff</a>