### PR TITLE
Remove redundant last modified date requirements

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
-		<meta name="color-scheme" content="light dark"/>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
@@ -4507,11 +4507,14 @@
 					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one <dfn
 							class="export" data-lt-no-plural=""><code>dcterms:modified</code></dfn> property [[dcterms]]
 						containing the last modification date. The [=value=] of this property MUST be an [[iso8601-1]]
-						complete representation of a date and time of day matching the extended format:
-							<code>YYYY-MM-DDThh:mm:ssZ</code></p>
+						complete representation of a date and time of day matching the extended format:</p>
 
-					<p>[=EPUB creators=] MUST express the last modification date in Coordinated Universal Time (UTC) and
-						MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
+					<pre><code>YYYY-MM-DDThh:mm:ssZ</code></pre>
+
+					<div class="note">
+						<p>The required "Z" (Zulu) time indicator at the end of the pattern means the last modification
+							date is always expressed in Coordinated Universal Time (UTC).</p>
+					</div>
 
 					<aside class="example" title="Expressing a last modification date">
 						<pre>&lt;metadata …&gt;
@@ -11928,6 +11931,9 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>08-Apr-2025: Replaced the redundant requirements on the last modified date with a note about the
+						date and time always being in UTC. See <a href="https://github.com/w3c/epub-specs/issues/2662"
+							>issue 2662</a>.</li>
 					<li>19-Feb-2025: Clarified that resources referenced from <code>script</code> elements are exempt.
 						See <a href="https://github.com/w3c/epub-specs/issues/2649">issue 2649</a>.</li>
 					<li>19-Feb-2025: Clarified that script modules, such as WebAssembly, fall under the existing


### PR DESCRIPTION
Implements the change in #2662 to make the point about the last modified date being in UTC a note rather than a repetition of the requirements of the date format.

Fixes #2662


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2707.html" title="Last updated on Apr 10, 2025, 5:04 PM UTC (71a847a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2707/f3ad165...71a847a.html" title="Last updated on Apr 10, 2025, 5:04 PM UTC (71a847a)">Diff</a>