### PR TITLE
Remove the reference to the swf and clean up spec references

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -873,8 +873,8 @@
 				</ul>
 
 				<p>Other techniques could apply depending on the content of the EPUB publication (e.g., the <a
-						href="https://www.w3.org/WAI/WCAG22/Techniques/#pdf">PDF Tecnhiques</a> would apply if there is
-					are embedded PDF forms).</p>
+						href="https://www.w3.org/WAI/WCAG22/Techniques/#pdf">PDF Tecnhiques</a> would apply if there are
+					embedded PDF forms).</p>
 
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.1.1</title>
-		<meta name="color-scheme" content="light dark"/>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -55,11 +55,6 @@
 				},
 				profile: "web-platform",
 				localBiblio: {
-					"epub-a11y-111": {
-						"title": "EPUB Accessibility 1.1.1",
-						"href": "https://w3c.github.io/epub-specs/epub34/a11y/",
-						"publisher": "W3C"
-					},
 					"a11y-discov-vocab": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
 						"href": "https://www.w3.org/2021/a11y-discov-vocab/latest/",
@@ -96,11 +91,6 @@
 						"title": "SVG",
 						"href": "https://www.w3.org/TR/SVG/",
 						"publisher": "W3C"
-					},
-					"swf": {
-						"title": "SWF File Format Specification Version 19",
-						"href": "https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf",
-						"date": "2012"
 					},
 					"wai-aria": {
 						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
@@ -145,8 +135,8 @@
 
 				<p>This document is not intended to be read in isolation, in other words, as it does not define
 					conformance requirements for making accessibility claims or cover every method for producing
-					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1.1 to
-					make a claim of accessibility. Verifying only the techniques in this document does not mean an <a
+					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1.1
+					to make a claim of accessibility. Verifying only the techniques in this document does not mean an <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> can claim conformance to
 					EPUB Accessibility 1.1.1.</p>
 			</section>
@@ -856,34 +846,35 @@
 				<ul>
 					<li>
 						<p>
-							<a href="https://www.w3.org/WAI/WCAG21/Techniques/#general">General Techniques</a>
+							<a href="https://www.w3.org/WAI/WCAG22/Techniques/#general">General Techniques</a>
 						</p>
 					</li>
 					<li>
 						<p>
-							<a href="https://www.w3.org/WAI/WCAG21/Techniques/#html">HTML and XHTML Techniques</a>
+							<a href="https://www.w3.org/WAI/WCAG22/Techniques/#html">HTML Techniques</a>
 						</p>
 					</li>
 					<li>
 						<p>
-							<a href="https://www.w3.org/WAI/WCAG21/Techniques/#css">CSS Techniques</a>
+							<a href="https://www.w3.org/WAI/WCAG22/Techniques/#css">CSS Techniques</a>
 						</p>
 					</li>
 					<li>
 						<p>
-							<a href="https://www.w3.org/WAI/WCAG21/Techniques/#client-side-script">Client-Side Scripting
+							<a href="https://www.w3.org/WAI/WCAG22/Techniques/#client-side-script">Client-Side Scripting
 								Techniques</a>
 						</p>
 					</li>
 					<li>
 						<p>
-							<a href="https://www.w3.org/WAI/WCAG21/Techniques/#aria">ARIA Techniques</a>
+							<a href="https://www.w3.org/WAI/WCAG22/Techniques/#aria">ARIA Techniques</a>
 						</p>
 					</li>
 				</ul>
 
-				<p>Other techniques will apply depending on the technologies used (e.g., a [[swf]] video in EPUB 2) or
-					any alternative formats embedded in the EPUB publication (e.g., a PDF form).</p>
+				<p>Other techniques could apply depending on the content of the EPUB publication (e.g., the <a
+						href="https://www.w3.org/WAI/WCAG22/Techniques/#pdf">PDF Tecnhiques</a> would apply if there is
+					are embedded PDF forms).</p>
 
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>
@@ -1427,7 +1418,7 @@
 					</aside>
 
 					<p>For more information about titles, see <a
-							href="https://www.w3.org/WAI/WCAG21/Techniques/html/H25">Technique H25</a>.</p>
+							href="https://www.w3.org/WAI/WCAG22/Techniques/html/H25">Technique H25</a>.</p>
 				</section>
 
 				<section id="heading-hierarchy">
@@ -1443,7 +1434,7 @@
 								><code>h1</code> element</a>, each chapter that belongs to the part will have an <a
 							data-lt="h2"><code>h2</code></a> heading).</p>
 
-					<p>Technique <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G141">G141: Organizing a page
+					<p>Technique <a href="https://www.w3.org/WAI/WCAG22/Techniques/general/G141">G141: Organizing a page
 							using headings</a> instructs <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB
 							creators</a> on correctly using numbered headings within a document, but with EPUB
 						publications the numbered headings also need to remain consistent across documents. Practically,
@@ -1521,7 +1512,7 @@
 
 					<p>After discussion in the <a href="https://github.com/w3c/wcag/issues/2039">Accessibility
 							Guidelines Working Group's issue tracker</a>, it is clear that the <a
-							href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels">understanding
+							href="https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels">understanding
 							document for 2.4.6</a> captures the intent of the success criterion better than the current
 						wording &#8212; namely, that the requirement for headings is only that they establish a unique
 						context for the content.</p>
@@ -2486,8 +2477,8 @@
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="http://w3c.org/TR/epub-a11y-tech-11/">EPUB Accessibility Techniques 1.1</a> &#8212; those
-				that affect the conformance of <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
+					href="http://w3c.org/TR/epub-a11y-tech-11/">EPUB Accessibility Techniques 1.1</a> &#8212; those that
+				affect the conformance of <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
 					publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed in this version, refer to the <a

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1.1</title>
-		<meta name="color-scheme" content="light dark"/>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -199,8 +199,8 @@
 					WCAG [[wcag2]] separates its accessibility guidelines from the techniques to achieve them. This
 					approach allows the guidelines to remain stable even as the format evolves.</p>
 
-				<p>To facilitate this approach, the companion <a data-cite="epub-a11y-tech-11#">EPUB Accessibility
-						Techniques</a> [[epub-a11y-tech-11]] document outlines conformance techniques. These techniques
+				<p>To facilitate this approach, the companion <a data-cite="epub-a11y-tech-111#">EPUB Accessibility
+						Techniques</a> [[epub-a11y-tech-111]] document outlines conformance techniques. These techniques
 					explain how to meet the requirements of this specification for different versions of EPUB.</p>
 
 				<section id="sec-sc-i18n">
@@ -377,10 +377,10 @@
 				</div>
 
 				<div class="note">
-					<p>See <a data-cite="epub-a11y-tech-11#sec-discovery">Discovery Metadata Techniques</a>
-						[[epub-a11y-tech-11]] for more information on these properties and how to include them in
-						different versions of EPUB. See also <a data-cite="epub-a11y-tech-11#dist-a11y-metadata">Include
-							accessibility metadata in distribution records</a> [[epub-a11y-tech-11]] for more
+					<p>See <a data-cite="epub-a11y-tech-111#sec-discovery">Discovery Metadata Techniques</a>
+						[[epub-a11y-tech-111]] for more information on these properties and how to include them in
+						different versions of EPUB. See also <a data-cite="epub-a11y-tech-111#dist-a11y-metadata"
+							>Include accessibility metadata in distribution records</a> [[epub-a11y-tech-111]] for more
 						information on including accessibility metadata in other formats.</p>
 				</div>
 			</section>
@@ -448,7 +448,7 @@
 					publications. (Each requirement explains its relationship to WCAG in its respective section.)</p>
 
 				<p>The same is true of the techniques in the EPUB Accessibility Techniques document
-					[[epub-a11y-tech-11]]. It provides coverage of techniques that are unique to EPUB publications, or
+					[[epub-a11y-tech-111]]. It provides coverage of techniques that are unique to EPUB publications, or
 					that need clarification in the context of an EPUB publication. It does not mean that the rest of the
 					WCAG techniques are not applicable.</p>
 
@@ -562,7 +562,7 @@
 							understandable, and robust against the full EPUB publication, not only against each EPUB
 							content document within it.</p>
 
-						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-11]] provide more information about
+						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-111]] provide more information about
 							applying these guidelines to EPUB publications.</p>
 					</section>
 
@@ -638,9 +638,9 @@
 							meet the Multiple Ways success criterion.</p>
 
 						<div class="note">
-							<p>Refer to <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-epub-page-navigation">Page
-									navigation</a> [[epub-a11y-tech-11]] for more information on the inclusion of page
-								navigation in EPUB publications.</p>
+							<p>Refer to <a href="https://www.w3.org/TR/epub-a11y-tech-111/#sec-epub-page-navigation"
+									>Page navigation</a> [[epub-a11y-tech-111]] for more information on the inclusion of
+								page navigation in EPUB publications.</p>
 						</div>
 					</section>
 
@@ -709,8 +709,8 @@
 											href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a>
 										metadata.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#pageSource">Identifying the
-												pagination source</a> [[epub-a11y-tech-11]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-111#pageSource">Identifying the
+												pagination source</a> [[epub-a11y-tech-111]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -753,8 +753,8 @@
 									<p>EPUB creators should include links for all pages in the source whether they are
 										reproduced or not, but this is not a requirement.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#pageList">Provide a page list</a>
-											[[epub-a11y-tech-11]] for more information on meeting this objective.</p>
+										<p>Refer to <a data-cite="epub-a11y-tech-111#pageList">Provide a page list</a>
+											[[epub-a11y-tech-111]] for more information on meeting this objective.</p>
 									</div>
 								</dd>
 							</dl>
@@ -800,9 +800,9 @@
 										of the content (e.g., EPUB 3 media overlays [[?epub-3]]), EPUB creators MUST
 										identify the page numbers in the markup that controls the playback.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#pageBreakMarkers">Provide page break
-												markers</a> [[epub-a11y-tech-11]] for more information on meeting this
-											objective.</p>
+										<p>Refer to <a data-cite="epub-a11y-tech-111#pageBreakMarkers">Provide page
+												break markers</a> [[epub-a11y-tech-111]] for more information on meeting
+											this objective.</p>
 									</div>
 								</dd>
 							</dl>
@@ -892,8 +892,8 @@
 										provide synchronized audio playback for all visible textual content as well as
 										all textual alternatives for visual media.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-coverage">Ensuring complete
-												text coverage</a> [[epub-a11y-tech-11]] for more information on meeting
+										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-coverage">Ensuring complete
+												text coverage</a> [[epub-a11y-tech-111]] for more information on meeting
 											this objective.</p>
 									</div>
 								</dd>
@@ -952,8 +952,8 @@
 									<p>If EPUB creators use a different ordering, that ordering MUST still result in a
 										logical playback of the content.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-reading-order">Specifying the
-												reading order</a> [[epub-a11y-tech-11]] for more information on meeting
+										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-reading-order">Specifying the
+												reading order</a> [[epub-a11y-tech-111]] for more information on meeting
 											this objective.</p>
 									</div>
 								</dd>
@@ -993,8 +993,8 @@
 								<dd>
 									<p>EPUB creators SHOULD identify all skippable structures.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-skippability">Identifying
-												skippable structures</a> [[epub-a11y-tech-11]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-skippability">Identifying
+												skippable structures</a> [[epub-a11y-tech-111]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -1034,8 +1034,8 @@
 								<dd>
 									<p>EPUB creators SHOULD identify all escapable structures.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-escapability">Identifying
-												escapable structures</a> [[epub-a11y-tech-11]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-escapability">Identifying
+												escapable structures</a> [[epub-a11y-tech-111]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -1074,8 +1074,8 @@
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
 											document</a> [[epub-3]].</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-nav">Synchronizing the
-												navigation document</a> [[epub-a11y-tech-11]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-nav">Synchronizing the
+												navigation document</a> [[epub-a11y-tech-111]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>

--- a/epub34/authoring/biblio.js
+++ b/epub34/authoring/biblio.js
@@ -13,16 +13,6 @@ var biblio = {
 		"href": "https://www.w3.org/TR/dpub-aria/",
 		"publisher": "W3C"
 	},
-	"epub-a11y-111": {
-		"title": "EPUB Accessibility 1.1.1",
-		"href": "https://w3c.github.io/epub-specs/epub34/a11y/",
-		"publisher": "W3C"
-	},
-	"epub-rs-34": {
-		"title": "EPUB Reading Systems 3.4",
-		"href": "https://w3c.github.io/epub-specs/epub34/rs/",
-		"publisher": "W3C"
-	},
 	"epubcontentdocs-301": {
 		"authors":[
 		"Markus Gylling",

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -124,7 +124,7 @@
 					specification, are nonetheless available for [=EPUB creators=] and reading system developers to
 					use.</p>
 
-				<p>The non-normative <a data-cite="epub-overview-33#">EPUB 3 Overview</a> [[epub-overview-33]] provides
+				<p>The non-normative <a data-cite="epub-overview-34#">EPUB 3 Overview</a> [[epub-overview-34]] provides
 					a general introduction to EPUB 3. A list of technical changes from the previous version is also
 					available in the <a href="#change-log">change log</a>.</p>
 			</section>
@@ -187,7 +187,7 @@
 					dependent assets in a ZIP package as presented here. Additional information about the primary
 					features and functionality that EPUB publications provide to enhance the reading experience is
 					available from the referenced specifications, and a more general introduction to the features of
-					EPUB 3 is provided in the non-normative [[epub-overview-33]].</p>
+					EPUB 3 is provided in the non-normative [[epub-overview-34]].</p>
 
 				<p>Refer to [[epub-rs-34]] for the processing requirements for reading systems. Although it is not
 					necessary that [=EPUB creators=] read that document to create EPUB publications, an understanding of
@@ -7051,9 +7051,9 @@ No Entry</pre>
 
 					<p>[=EPUB publications=], unlike print books or PDF files, are designed to change. The content
 						flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a
-							data-cite="epub-overview-33#sec-rendering">Rendering and CSS</a> "content presentation
+							data-cite="epub-overview-34#sec-rendering">Rendering and CSS</a> "content presentation
 						adapts to the user, rather than the user having to adapt to a particular presentation of
-						content." [[epub-overview-33]]</p>
+						content." [[epub-overview-34]]</p>
 
 					<p>But this principle does not work for all types of documents. Sometimes content and design are so
 						intertwined it is not possible to separate them. Any change in appearance risks changing the

--- a/epub34/index-page/index.html
+++ b/epub34/index-page/index.html
@@ -81,12 +81,7 @@
 						"title": "EPUB Reading Systems 3.4",
 						"href": "https://w3c.github.io/epub-specs/epub34/rs/",
 						"publisher": "W3C"
-					},
-					"epub-overview-34": {
-						"title": "EPUB 3 Overview",
-						"href": "https://w3c.github.io/epub-specs/epub34/overview/",
-						"publisher": "W3C"
-					},
+					}
                 }
             };
         </script>

--- a/epub34/reports/exit_criteria.html
+++ b/epub34/reports/exit_criteria.html
@@ -65,7 +65,7 @@
             <li>provide some additional features <em>“on top”</em> of that renderer.</li>
         </ul>
 
-        <p>See also the the EPUB 3 Overview [[epub-overview-33]] for more details on the structure of EPUB 3.4 publications.</p>
+        <p>See also the the EPUB 3 Overview [[epub-overview-34]] for more details on the structure of EPUB 3.4 publications.</p>
         <p>
           As a consequence of this particular structure, the validity and conformance of an EPUB 3.4 publication, as well as of a reading system implementation, <em>includes</em> the requirement of valid and conformant publication resources, and the conformant rendering thereof.
           Comprehensive testing would therefore require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.4 specific features. The standard checking tools that are widely used by the publishing community, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE</a>, indeed include externally developed HTML, CSS, or accessibility checkers, which would check the validity or conformance of the publication resources. Also, today’s reading systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a “WebView” implementation) that can be assumed to conform to the relevant W3C specifications.

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -92,11 +92,6 @@
 						"date": "08 May 2019",
 						"publisher": "EPUB 3 Community Group"
 					},
-					"epub-34": {
-						"title": "EPUB 3.4",
-						"href": "https://w3c.github.io/epub-specs/epub34/authoring/",
-						"publisher": "W3C"
-					},
 					"h264": {
 						"title": "H.264 : Advanced video coding for generic audiovisual services",
 						"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",


### PR DESCRIPTION
I started this off with only the intention of fixing #2711 but then ran into some outdated references to WCAG 2.1 techniques that needed fixing which in turn made me realize we had references to the old EPUB techniques and overviews from before the recent republish. And then I noticed that we still had the temp biblio entries for the 3.4 releases from before the FPWDs to make the cross-references work.

In other words, lots of little fixes along with removing the reference to SWF. The Flash techniques were removed from the WCAG document a number of years back, so more justification for dropping that reference entirely.

Fixes #2711 

Accessibility Techniques: [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2711/epub34/a11y-tech/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/issue-2711/epub34/a11y-tech/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2718.html" title="Last updated on May 2, 2025, 3:25 PM UTC (a2af852)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2718/8c0dff5...a2af852.html" title="Last updated on May 2, 2025, 3:25 PM UTC (a2af852)">Diff</a>