### PR TITLE
Add application/x-font-ttf media type to core contents

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1067,7 +1067,7 @@
 							<td>CSS Style Sheets</td>
 						</tr>
 						<tr>
-							<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
+							<th colspan="3" id="cmt-grp-font" data-tests="#cnt-css-fonts" class="tbl-group">Fonts</th>
 						</tr>
 						<tr>
 							<td id="cmt-sfnt">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1067,7 +1067,7 @@
 							<td>CSS Style Sheets</td>
 						</tr>
 						<tr>
-							<th colspan="3" id="cmt-grp-font" data-tests="#cnt-css-fonts" class="tbl-group">Fonts</th>
+							<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
 						</tr>
 						<tr>
 							<td id="cmt-sfnt">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -978,7 +978,7 @@
 							<td>
 								<a href="#sec-xhtml">HTML content documents</a>
 							</td>
-							<td>HTML documents that use the <a data-cite="html#syntax">HTML syntax</a> [[html]].</td>
+							<td>HTML documents that use the <a data-cite="html#syntax">HTML syntax</a> [[html]]</td>
 						</tr>
 						<tr>
 							<td id="cmt-xhtml">
@@ -988,7 +988,7 @@
 								<a href="#sec-xhtml">HTML content documents</a>
 							</td>
 							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
-								[[html]].</td>
+								[[html]]</td>
 						</tr>
 						<tr>
 							<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
@@ -1064,7 +1064,7 @@
 							<td>
 								<a href="#sec-css">CSS Style Sheets</a>
 							</td>
-							<td>CSS Style Sheets.</td>
+							<td>CSS Style Sheets</td>
 						</tr>
 						<tr>
 							<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
@@ -1074,6 +1074,7 @@
 								<ol class="cmt">
 									<li><code>font/ttf</code></li>
 									<li><code>application/font-sfnt</code></li>
+									<li><code>application/x-font-ttf</code></li>
 								</ol>
 							</td>
 							<td>[[truetype]] </td>
@@ -1126,7 +1127,7 @@
 								<code>application/x-dtbncx+xml</code>
 							</td>
 							<td> [[opf-201]] </td>
-							<td>The <a href="#sec-pkg-legacy-intro">legacy</a> NCX.</td>
+							<td>The <a href="#sec-pkg-legacy-intro">legacy</a> NCX</td>
 						</tr>
 						<tr>
 							<td id="cmt-smil">
@@ -12022,7 +12023,12 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-					<li>08-Apr-2025: Added early support for HTML syntax.</li>
+					<li>26-May-2025: Added support for the <code>application/x-font-ttf</code> media type. 
+					    See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>.
+					</li>
+					<li>08-Apr-2025: Added early support for HTML syntax.
+						See <a href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a>.
+					</li>
 					<li>08-Apr-2025: Moved the paragraphs on authoring the navigation document in the spine from the
 						general restrictions to the existing section on this use and clarified that reading systems do
 						not suppress list styling in the spine. See <a

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -12023,7 +12023,7 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-					<li>26-May-2025: Added support for the <code>application/x-font-ttf</code> media type. 
+					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for identifying TTF fonts. 
 					    See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>.
 					</li>
 					<li>08-Apr-2025: Added early support for HTML syntax.


### PR DESCRIPTION
This PR is to fix #667.

An extra test reference is also added to the font group. ~See also https://github.com/w3c/epub-tests/pull/306.~ (Edited: the test has proven to be irrelevant for this PR, will be closed. 2025-05-28.)

(Minor editorial changes have also been done.)

For dedicated preview,  see:

* For EPUB 3.4:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/add-x-font-ttf/epub34/authoring/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/authoring/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/add-x-font-ttf/epub34/authoring/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2726.html" title="Last updated on May 28, 2025, 7:46 AM UTC (7f51a41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2726/212e127...7f51a41.html" title="Last updated on May 28, 2025, 7:46 AM UTC (7f51a41)">Diff</a>