### PR TITLE
Updated font test references

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1201,7 +1201,7 @@
 								Recommendation</a> status [[w3cprocess]] (and are widely implemented).</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
+						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts_ot, #cnt-css-fonts_tt, #cnt-css-fonts_woff, #cnt-css-fonts_woff2">MUST support [[truetype]],
 							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
 								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>


### PR DESCRIPTION
Replaced the `cnt-css-fonts` test reference by the four new tests, one per font format. See https://github.com/w3c/epub-tests/pull/307.