### PR TITLE
Specify the format of the evaluation date

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1909,8 +1909,8 @@
 				<summary>Substantive changes since <a href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility
 					1.1</a></summary>
 				<ul>
-					<li>02-June-2025: Make explicit that the evaluation date has to match a year-month-day pattern.
-						Refer to <a href="https://github.com/w3c/epub-specs/issues/2725">issue 2725</a>.</li>
+					<li>02-June-2025: Make explicit that the evaluation date has to conform to iso 8601. Refer to <a
+							href="https://github.com/w3c/epub-specs/issues/2725">issue 2725</a>.</li>
 				</ul>
 			</details>
 		</section>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1369,7 +1369,7 @@
 							expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
 							machine readable.</p>
 
-						<div class="issue" data-number="1725">
+						<div class="issue" data-number="1725" title="Evaluation date format">
 							<p>The change to require the form of the evaluation date depends on the standard version
 								number changing, and as a consequence there being new conformance identifiers.
 								Otherwise, this change could invalidate existing content. The requirement could be

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1370,11 +1370,11 @@
 
 						<dl>
 							<dt><code>YYYY-MM-DD</code></dt>
-							<dd> The year, month, and date of the evalation. This format is preferred. </dd>
+							<dd>The year, month, and day of the evaluation. This format is preferred.</dd>
 							<dt><code>YYYY-MM</code></dt>
-							<dd> If only the year and month of the evaluation are known. </dd>
+							<dd>If only the year and month of the evaluation are known.</dd>
 							<dt><code>YYYY</code></dt>
-							<dd> If only the year of the evaluation is known. </dd>
+							<dd>If only the year of the evaluation is known.</dd>
 						</dl>
 
 						<aside class="example" title="Expressing the evaluation date">

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1365,17 +1365,16 @@
 								href="https://www.w3.org/TR/epub/#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
-						<p>For human readability and localization purposes, the value of the property MUST be a string
-							that matches one of the following [[iso8601-1]] patterns:</p>
+						<p>It is REQUIRED that the date string conform to [[iso8601-1]], particularly the subset
+							expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
+							machine readable.</p>
 
-						<dl>
-							<dt><code>YYYY-MM-DD</code></dt>
-							<dd>The year, month, and day of the evaluation. This format is preferred.</dd>
-							<dt><code>YYYY-MM</code></dt>
-							<dd>If only the year and month of the evaluation are known.</dd>
-							<dt><code>YYYY</code></dt>
-							<dd>If only the year of the evaluation is known.</dd>
-						</dl>
+						<div class="issue" data-number="1725">
+							<p>The change to require the form of the evaluation date depends on the standard version
+								number changing, and as a consequence there being new conformance identifiers.
+								Otherwise, this change could invalidate existing content. The requirement could be
+								lowered to a recommendation in a future update if a version change is opposed.</p>
+						</div>
 
 						<aside class="example" title="Expressing the evaluation date">
 							<pre>&lt;metadata …>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1365,6 +1365,18 @@
 								href="https://www.w3.org/TR/epub/#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
+						<p>For human readability and localization purposes, the value of the property MUST be a string
+							that matches one of the following [[iso8601-1]] patterns:</p>
+
+						<dl>
+							<dt><code>YYYY-MM-DD</code></dt>
+							<dd> The year, month, and date of the evalation. This format is preferred. </dd>
+							<dt><code>YYYY-MM</code></dt>
+							<dd> If only the year and month of the evaluation are known. </dd>
+							<dt><code>YYYY</code></dt>
+							<dd> If only the year of the evaluation is known. </dd>
+						</dl>
+
 						<aside class="example" title="Expressing the evaluation date">
 							<pre>&lt;metadata …>
    …
@@ -1898,7 +1910,8 @@
 				<summary>Substantive changes since <a href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility
 					1.1</a></summary>
 				<ul>
-					<li>No substantive changes have been made. </li>
+					<li>02-June-2025: Make explicit that the evaluation date has to match a year-month-day pattern.
+						Refer to <a href="https://github.com/w3c/epub-specs/issues/2725">issue 2725</a>.</li>
 				</ul>
 			</details>
 		</section>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1369,7 +1369,7 @@
 							expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
 							machine readable.</p>
 
-						<div class="issue" data-number="1725" title="Evaluation date format">
+						<div class="issue" data-number="2725" title="Evaluation date format">
 							<p>The change to require the form of the evaluation date depends on the standard version
 								number changing, and as a consequence there being new conformance identifiers.
 								Otherwise, this change could invalidate existing content. The requirement could be


### PR DESCRIPTION
This pull request clarifies that the dc:date value for the evaluation has to <strike>match one of the patterns: YYYY-MM-DD, YYYY-MM, or YYYY</strike> be an iso 8601 conformant datetime.

***

Accessibility 1.1.1: [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2725/epub34/a11y/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/issue-2725/epub34/a11y/index.html)
