### PR TITLE
Add the prefix URL for the structural semantics vocabulary

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10034,7 +10034,7 @@ html.my-document-playing * {
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
 					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The prefix URL for
-					referencing its properties is <code>http://www.idpf.org/epub/vocab/structure/#</code>.</p>
+					referencing its properties is <code>http://idpf.org/epub/vocab/structure/#</code>.</p>
 
 				<p>EPUB creators MAY include unprefixed terms that are not part of this vocabulary, but the preferred
 					method for adding custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10033,10 +10033,12 @@ html.my-document-playing * {
 					document instance.</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. EPUB creators MAY include
-					unprefixed terms that are not part of this vocabulary, but the preferred method for adding custom
-					semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
-						href="#sec-vocab-assoc"></a> for more information.</p>
+					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The prefix URL for
+					referencing its properties is <code>http://www.idpf.org/epub/vocab/structure/#</code>.</p>
+
+				<p>EPUB creators MAY include unprefixed terms that are not part of this vocabulary, but the preferred
+					method for adding custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer
+					to <a href="#sec-vocab-assoc"></a> for more information.</p>
 
 				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
 					<pre>&lt;html
@@ -12023,12 +12025,13 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for identifying TTF fonts. 
-					    See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>.
-					</li>
-					<li>08-Apr-2025: Added early support for HTML syntax.
-						See <a href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a>.
-					</li>
+					<li>04-June-2025: Added the prefix URL for expanding terms from the EPUB Structural Semantics
+						Vocabulary to remove any ambiguity about what it should be. See <a
+							href="https://github.com/w3c/epub-specs/issues/2733">issue 2733</a>.</li>
+					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for
+						identifying TTF fonts. See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>. </li>
+					<li>08-Apr-2025: Added early support for HTML syntax. See <a
+							href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a>. </li>
 					<li>08-Apr-2025: Moved the paragraphs on authoring the navigation document in the spine from the
 						general restrictions to the existing section on this use and clarified that reading systems do
 						not suppress list styling in the spine. See <a

--- a/epub34/authoring/vocab/overlays.html
+++ b/epub34/authoring/vocab/overlays.html
@@ -3,7 +3,7 @@
 	<p>The properties in this vocabulary are usable in the [^meta^] element's
 			<code>property</code> attribute.</p>
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
-			<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
+			<code>http://idpf.org/epub/vocab/overlays/#</code>.</p>
 	<p>The prefix "<code>media:</code>" is <a href="#sec-metadata-reserved-prefixes">reserved for use</a> with
 		properties in this vocabulary and does not have to be declared in the [=package document=].</p>
 	<section id="sec-active-class" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_media-overlays.feature_L16">


### PR DESCRIPTION
Makes the idpf.org URL for expanding terms explicit in the document so there is no confusion about what to use now that the vocabulary is hosted under a W3C URL.

We should probably see about getting http://www.idpf.org/epub/vocab/structure/# to redirect to the new SSV location. It currently goes to the old idpf.github.io location. Even though that document has an obsolete message attached to it, it doesn't need to be accessible anymore.

A simple fix would be to temporarily unarchive that repository and replace that old document with a meta refresh directive so that readers are automatically bumped forward. The more complicated fix would be to get the old idpf.org htaccess file updated.

Fixes #2733


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2734.html" title="Last updated on Jun 9, 2025, 3:35 PM UTC (2925651)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2734/0b5be5d...2925651.html" title="Last updated on Jun 9, 2025, 3:35 PM UTC (2925651)">Diff</a>