### PR TITLE
Allow ITS attributes in content documents

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5888,7 +5888,21 @@ No Entry</pre>
 								both are natively supported.</p>
 						</div>
 					</section>
-
+					
+					<section id="sec-xhtml-its">
+						<h5>International tag set (ITS)</h5>
+						
+						<p>The [[its20]] specification defines a set of attributes that [=EPUB creators=] MAY use in
+							[=XHTML content documents=] to add support for internationalization, translation, and
+							localization.</p>
+						
+						<p>EPUB creators MUST only use ITS attributes as they are defined in <a
+								data-cite="its20#html5-markup">Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does
+							not support the namespaced attributes).</p>
+						
+						<p>The use of these attributes MUST conform to the requirements defined in [[its20]].</p>
+					</section>
+					
 					<section id="sec-xhtml-custom-attributes" data-epubcheck="true"
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L790,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L795">
 						<h5>Custom attributes</h5>
@@ -5911,20 +5925,6 @@ No Entry</pre>
 								intended for use by other reading systems. This specification should be extended to
 								provide extensions that multiple independent reading systems can use.</p>
 						</div>
-					</section>
-
-					<section id="sec-xhtml-its">
-						<h5>International tag set (ITS)</h5>
-
-						<p>The [[its20]] specification defines a set of attributes that [=EPUB creators=] MAY use in
-							[=XHTML content documents=] to add support for internationalization, translation, and
-							localization.</p>
-
-						<p>EPUB creators MUST only use ITS attributes as they are defined in <a
-								data-cite="its20#html5-markup">Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does
-							not support the namespaced attributes).</p>
-
-						<p>The use of these attributes MUST conform to the requirements defined in [[its20]].</p>
 					</section>
 				</section>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -12038,7 +12038,7 @@ EPUB/images/cover.png</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
 					<li>04-June-2025: Added support for Internationalization Tag Set. See <a
-							href="https://github.com/w3c/epub-specs/issues/2732">issue 2732</a></li>
+							href="https://github.com/w3c/epub-specs/issues/2732">issue 2732</a>.</li>
 					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for
 						identifying TTF fonts. See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>. </li>
 					<li>08-Apr-2025: Added early support for HTML syntax. See <a

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5978,6 +5978,20 @@ No Entry</pre>
 								provide extensions that multiple independent reading systems can use.</p>
 						</div>
 					</section>
+
+					<section id="sec-xhtml-its">
+						<h5>International tag set (ITS)</h5>
+
+						<p>The [[its20]] specification defines a set of attributes that [=EPUB creators=] MAY use in
+							[=XHTML content documents=] to add support for internationalization, translation, and
+							localization.</p>
+
+						<p>EPUB creators MUST only use ITS attributes as they are defined in <a
+								data-cite="its20#html5-markup">Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does
+							not support the namespaced attributes).</p>
+
+						<p>The use of these attributes MUST conform to the requirements defined in [[its20]].</p>
+					</section>
 				</section>
 
 				<section id="sec-xhtml-deviations" data-epubcheck="true"
@@ -12023,12 +12037,12 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for identifying TTF fonts. 
-					    See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>.
-					</li>
-					<li>08-Apr-2025: Added early support for HTML syntax.
-						See <a href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a>.
-					</li>
+					<li>04-June-2025: Added support for Internationalization Tag Set. See <a
+							href="https://github.com/w3c/epub-specs/issues/2732">issue 2732</a></li>
+					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for
+						identifying TTF fonts. See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>. </li>
+					<li>08-Apr-2025: Added early support for HTML syntax. See <a
+							href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a>.</li>
 					<li>08-Apr-2025: Moved the paragraphs on authoring the navigation document in the spine from the
 						general restrictions to the existing section on this use and clarified that reading systems do
 						not suppress list styling in the spine. See <a

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1065,6 +1065,13 @@
 						<p>Reading systems MAY support custom attributes provided the attributes do not modify the
 							requirements of this specification.</p>
 					</section>
+
+					<section id="sec-xhtml-its">
+						<h5>Internationalization Tag Set (ITS)</h5>
+
+						<p>Reading system support for <a data-cite="its20#conformance-product-html5-its">processing ITS
+								markup</a> [[its20]] is OPTIONAL.</p>
+					</section>
 				</section>
 
 				<section id="sec-xhtml-deviations">
@@ -1201,9 +1208,10 @@
 								Recommendation</a> status [[w3cprocess]] (and are widely implemented).</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts_ot, #cnt-css-fonts_tt, #cnt-css-fonts_woff, #cnt-css-fonts_woff2">MUST support [[truetype]],
-							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
-								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+						<p id="confreq-css-rs-fonts"
+							data-tests="#cnt-css-fonts_ot, #cnt-css-fonts_tt, #cnt-css-fonts_woff, #cnt-css-fonts_woff2"
+							>MUST support [[truetype]], [[opentype]], [[woff]], and [[woff2]] font resources referenced
+							from <a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>
@@ -1465,10 +1473,12 @@
 								none</code> property</a> [[csssnapshot]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-hidden" data-tests="#nav-spine_in-spine-hidden-toc-html,#nav-spine_in-spine-hidden-toc-css">MUST ignore markup and styling intended to hide elements of the
-						navigation document from rendering in the spine (e.g., the [[html]] [^html-global/hidden^]
-						attribute and CSS <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"
-								><code>display</code> property</a> [[csssnapshot]]).</p>
+					<p id="confreq-nav-hidden"
+						data-tests="#nav-spine_in-spine-hidden-toc-html,#nav-spine_in-spine-hidden-toc-css">MUST ignore
+						markup and styling intended to hide elements of the navigation document from rendering in the
+						spine (e.g., the [[html]] [^html-global/hidden^] attribute and CSS <a
+							href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
+							property</a> [[csssnapshot]]).</p>
 				</li>
 			</ul>
 
@@ -2719,6 +2729,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
+					<li>04-June-2025: Added section on optional ITS markup support. See <a
+							href="https://github.com/w3c/epub-specs/issues/2732">issue 2732</a>.</li>
 					<li>08-Apr-2025: Added a requirement that reading systems ignore markup and styling intended to hide
 						content in the EPUB navigation document when it is included in the spine. See <a
 							href="https://github.com/w3c/epub-specs/issues/2687">issue 2687</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1038,19 +1038,19 @@
 						<p>Reading system support for the <a data-cite="rdfa-core#s_model">attribute processing
 								model</a> [[rdfa-core]] is OPTIONAL.</p>
 					</section>
-
+					
+					<section id="sec-xhtml-its">
+						<h5>Internationalization Tag Set (ITS)</h5>
+						
+						<p>Reading system support for <a data-cite="its20#conformance-product-html5-its">processing ITS
+								markup</a> [[its20]] is OPTIONAL.</p>
+					</section>
+					
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom attributes</h5>
 
 						<p>Reading systems MAY support custom attributes provided the attributes do not modify the
 							requirements of this specification.</p>
-					</section>
-
-					<section id="sec-xhtml-its">
-						<h5>Internationalization Tag Set (ITS)</h5>
-
-						<p>Reading system support for <a data-cite="its20#conformance-product-html5-its">processing ITS
-								markup</a> [[its20]] is OPTIONAL.</p>
 					</section>
 				</section>
 


### PR DESCRIPTION
With optional reading system processing support.

We should wait on merging this until the group has a say, though.

Fixes #2732 

***

Reading Systems: [Preview](https://raw.githack.com/w3c/epub-specs/feature/issue-2732/epub34/rs/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/feature/issue-2732/epub34/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2735.html" title="Last updated on Jun 25, 2025, 7:27 PM UTC (0e1ff55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2735/39712aa...0e1ff55.html" title="Last updated on Jun 25, 2025, 7:27 PM UTC (0e1ff55)">Diff</a>