### PR TITLE
Move all deprecated features to the appendix

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -9692,7 +9692,7 @@ html.my-document-playing * {
 					Although it lacks the necessary reading system support, it is integral to the content model on which
 					EPUB is built (i.e., for internationalization support in the package document).</p>
 
-				<p>EPUB creators MAY use this features as described.</p>
+				<p>EPUB creators MAY use this feature as described.</p>
 
 				<div class="note">
 					<p>[=EPUB conformance checkers=] should alert EPUB creators to the presence of under-implemented

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3592,15 +3592,6 @@
 								</p>
 							</li>
 							<li>
-								<p>
-									<a href="#sec-opf-bindings">
-										<code>bindings</code>
-									</a>
-									<code>[0 or 1]</code>
-									<a href="#deprecated" class="deprecated">(deprecated)</a>
-								</p>
-							</li>
-							<li>
 								<p> [^collection^] <code>[0 or more]</code>
 								</p>
 							</li>
@@ -5337,20 +5328,6 @@ No Entry</pre>
 						</aside>
 					</section>
 				</section>
-
-				<section id="sec-opf-bindings">
-					<h4>The <code>bindings</code> element (deprecated)</h4>
-
-					<p>The <code>bindings</code> element defines a set of custom handlers for media types not supported
-						by this specification.</p>
-
-					<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
-
-					<p>Refer to the <a
-							href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
-								><code>bindings</code> element definition</a> in [[epubpublications-301]] for more
-						information.</p>
-				</section>
 			</section>
 
 			<section id="sec-pkg-spine">
@@ -5705,19 +5682,6 @@ No Entry</pre>
 &lt;/collection&gt;</pre>
 					</aside>
 				</section>
-
-				<section id="sec-defining-collection-types">
-					<h4>Defining collection types (deprecated)</h4>
-
-					<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated"
-							>deprecated</a>.</p>
-
-					<p>Refer to the <a
-							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
-								><code>collection</code> element definition</a> in [[epubpackages-32]] for more
-						information about the creation of specialized collections, including the requirements and
-						restrictions on their use.</p>
-				</section>
 			</section>
 
 			<section id="sec-pkg-legacy">
@@ -5923,36 +5887,6 @@ No Entry</pre>
 									data-cite="json-ld11#">linked data</a> [[json-ld11]] in XHTML content documents as
 								both are natively supported.</p>
 						</div>
-					</section>
-
-					<section id="sec-xhtml-content-switch">
-						<h5>Content switching (deprecated)</h5>
-
-						<p>The <code>switch</code> element provides a simple mechanism through which [=EPUB creators=]
-							can tailor the content displayed to users, one that is not dependent on the scripting
-							capabilities of the [=EPUB reading system=].</p>
-
-						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
-									><code>switch</code> element definition</a> in&#160;[[epubcontentdocs-301]] for more
-							information.</p>
-					</section>
-
-					<section id="sec-xhtml-epub-trigger">
-						<h5>The <code>epub:trigger</code> element (deprecated)</h5>
-
-						<p>The <code>trigger</code> element enables the creation of markup-defined user interfaces for
-							controlling multimedia objects, such as audio and video playback, in both scripted and
-							non-scripted contexts.</p>
-
-						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
-									><code>epub:trigger</code> element definition</a> in&#160;[[epubcontentdocs-301]]
-							for more information.</p>
 					</section>
 
 					<section id="sec-xhtml-custom-attributes" data-epubcheck="true"
@@ -7309,14 +7243,6 @@ No Entry</pre>
 									orientation.</p>
 							</dd>
 
-							<dt>portrait (deprecated)</dt>
-							<dd>
-								<p>The use of spreads only in portrait orientation is <a href="#deprecated"
-										>deprecated</a>.</p>
-								<p>EPUB creators should use the value "<code>both</code>" instead, as spreads that are
-									readable in portrait orientation are also readable in landscape.</p>
-							</dd>
-
 							<dt>both</dt>
 							<dd>
 								<p>Render a synthetic spread regardless of device orientation.</p>
@@ -7558,15 +7484,6 @@ No Entry</pre>
 								<dt id="spread-none">rendition:spread-none</dt>
 								<dd>Specifies the reading system should not render a synthetic spread for the spine
 									item.</dd>
-
-								<dt id="spread-portrait">rendition:spread-portrait</dt>
-								<dd>
-									<p>The <code>rendition:spread-portrait</code> property is <a href="#deprecated"
-											>deprecated</a>.</p>
-									<p></p>Refer to the <a
-										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
-											><code>spread-portrait</code> property definition</a>
-									in&#160;[[epubpublications-301]] for more information.</dd>
 							</dl>
 
 							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
@@ -7733,23 +7650,6 @@ No Entry</pre>
    …
 &lt;/package&gt;</pre>
 						</aside>
-					</section>
-
-					<section id="viewport" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L187">
-						<h5>Viewport dimensions (deprecated)</h5>
-
-						<p>The <code>rendition:viewport</code> property allows [=EPUB creators=] to express the CSS
-							initial containing block (ICB) [[css2]] for [=XHTML content document | XHTML=] and [=SVG
-							content documents=] whose <code>rendition:layout</code> property has been set to
-								<code>pre-paginated</code>.</p>
-
-						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
-									><code>rendition:viewport</code> property definition</a>
-							in&#160;[[epubpublications-301]] for more information.</p>
 					</section>
 
 					<section id="sec-fxl-content-dimensions" data-epubcheck="true"
@@ -9818,12 +9718,137 @@ html.my-document-playing * {
 			<section id="deprecated">
 				<h3>Deprecated features</h3>
 
-				<p>A <strong>deprecated</strong> feature is one the Working Group no longer recommends for use in this
-					version of the specification. Deprecated features typically have limited or no support in [=reading
-					systems=] and/or usage in [=EPUB publications=].</p>
+				<p>[=EPUB creators=] SHOULD NOT use the following <strong>deprecated</strong> features in their [=EPUB
+					publications=]. These features have limited or no support in [=reading systems=] and/or usage in
+					[=EPUB publications=].</p>
 
-				<p>If this specification designates a feature as deprecated, [=EPUB creators=] SHOULD NOT use the
-					feature in their EPUB publications.</p>
+				<p>When used, their usage MUST conform to their referenced definitions.</p>
+
+				<dl>
+					<dt>Package document</dt>
+					<dd>
+						<ul>
+							<li>
+								<p id="sec-opf-bindings"><a
+										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
+											><code>bindings</code> element</a> [[epubpublications-301]]</p>
+							</li>
+
+							<li>
+								<p id="sec-defining-collection-types"><a
+										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
+										>new collection types</a> [[epubpackages-32]]</p>
+							</li>
+						</ul>
+					</dd>
+
+					<dt>XHTML content documents</dt>
+					<dd>
+						<ul>
+							<li id="sec-xhtml-content-switch">
+								<p><a
+										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
+											><code>switch</code> element</a> [[epubcontentdocs-301]]</p>
+							</li>
+
+							<li>
+								<p id="sec-xhtml-epub-trigger"><a
+										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
+											><code>epub:trigger</code> element</a> [[epubcontentdocs-301]]</p>
+							</li>
+						</ul>
+					</dd>
+
+					<dt>Fixed layouts</dt>
+					<dd>
+						<ul>
+							<li>
+								<p><a href="https://idpf.org/epub/301/spec/epub-publications.html#fxl-property-spread"
+											><code>rendition:spread</code> property with the value
+										<code>portrait</code></a> [[epubpublications-301]] &#8212; use the value
+										"<code>both</code>" instead.</p>
+							</li>
+							<li>
+								<p id="spread-portrait"><a
+										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
+											><code>spread-portrait</code> property</a> [[epubpublications-301]] &#8212;
+									use the property "<code>rendition:spread-both</code>" instead.</p>
+							</li>
+							<li>
+								<p id="viewport" data-epubcheck="true"
+									data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L187"
+										><a
+										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
+											><code>rendition:viewport</code> property</a> [[epubpublications-301]]</p>
+							</li>
+						</ul>
+					</dd>
+
+					<dt>Meta properties vocabulary</dt>
+					<dd>
+						<ul>
+							<li>
+								<p id="sec-meta-auth"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
+											><code>meta-auth</code> property</a> [[!epubpublications-30]]</p>
+							</li>
+						</ul>
+					</dd>
+
+					<dt>Link relationships vocabulary</dt>
+					<dd>
+						<ul>
+							<li>
+								<p id="sec-marc21xml-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"
+											><code>marc21xml-record</code> property</a> [[!epubpublications-30]] &#8212;
+									It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+										"<code>application/marcxml+xml</code>".</p>
+							</li>
+
+							<li>
+								<p id="sec-mods-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"
+											><code>mods-record</code> property</a> [[!epubpublications-30]] &#8212; It
+									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+										"<code>application/mods+xml</code>".</p>
+							</li>
+
+							<li>
+								<p id="sec-onix-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"
+											><code>onix-record</code> property</a> [[!epubpublications-30]] &#8212; It
+									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+										href="#attrdef-properties">properties attribute</a> value <a href="#onix"
+											><code>onix</code></a>.</p>
+							</li>
+
+							<li>
+								<p id="sec-xml-signature"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"
+											><code>xml-signature</code> property</a> [[!epubpublications-30]]</p>
+							</li>
+
+							<li>
+								<p id="sec-xmp-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"
+											><code>xmp-record</code> property</a> [[!epubpublications-30]]</p>
+							</li>
+						</ul>
+					</dd>
+
+					<dt>Prefixed CSS properties</dt>
+					<dd>
+						<ul>
+							<li>
+								<p><a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
+											><code>-epub-text-combine</code></a> [[epub-33]]</p>
+							</li>
+						</ul>
+					</dd>
+				</dl>
 
 				<div class="note">
 					<p>[=EPUB conformance checkers=] should alert EPUB creators to the presence of deprecated features
@@ -10626,13 +10651,11 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-writing-modes-text-combine" data-tests="#css-epub-text-combine-horizontal">
-					<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>
-						properties</h6>
+					<h6>The <code>-epub-text-combine-horizontal</code> property</h6>
 
-					<p>These properties are prefixed versions of the <a
+					<p>This property is a prefixed version of the <a
 							data-cite="css-writing-modes-3#text-combine-upright"><code>text-combine-upright</code>
-							property</a> [[css-writing-modes-3]], although <code>-epub-text-combine</code> is
-						deprecated.</p>
+							property</a> [[css-writing-modes-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10647,22 +10670,9 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td><code>-epub-text-combine</code> (deprecated)</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> none | horizontal | horizontal &lt;number&gt; </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>For compatibility with existing content, the <code>-epub-text-combine-horizontal</code> and
-							<code>-epub-text-combine</code> properties also support a number of deprecated keywords. The
-						following table specifies the effect these have when specified.</p>
+					<p>For compatibility with existing content, the <code>-epub-text-combine-horizontal</code> property
+						also supports a number of deprecated keywords. The following table specifies the effect these
+						have when specified.</p>
 
 					<table class="data">
 						<thead>
@@ -10679,18 +10689,6 @@ html.my-document-playing * {
 							<tr>
 								<td><code>-epub-text-combine-horizontal: all</code></td>
 								<td><code>text-combine-upright: all</code></td>
-							</tr>
-							<tr>
-								<td><code>-epub-text-combine: none</code></td>
-								<td><code>text-combine-upright: none</code></td>
-							</tr>
-							<tr>
-								<td><code>-epub-text-combine: horizontal</code></td>
-								<td><code>text-combine-upright: all</code></td>
-							</tr>
-							<tr>
-								<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
-								<td><em>no equivalent</em></td>
 							</tr>
 						</tbody>
 					</table>
@@ -12023,12 +12021,14 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for identifying TTF fonts. 
-					    See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>.
-					</li>
-					<li>08-Apr-2025: Added early support for HTML syntax.
-						See <a href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a>.
-					</li>
+					<li>05-June-2025: Consolidate all deprecated features under the deprecated features section to
+						remove the appearance that they should still be authored. See the comments in <a
+							href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035">pull request
+							2735</a>.</li>
+					<li>26-May-2025: Added <code>application/x-font-ttf</code> to the list of core media types for
+						identifying TTF fonts. See <a href="https://github.com/w3c/epub-specs/issues/667">issue 667</a>. </li>
+					<li>08-Apr-2025: Added early support for HTML syntax. See <a
+							href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a>. </li>
 					<li>08-Apr-2025: Moved the paragraphs on authoring the navigation document in the spine from the
 						general restrictions to the existing section on this use and clarified that reading systems do
 						not suppress list styling in the spine. See <a

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -9683,17 +9683,16 @@ html.my-document-playing * {
 			<section id="under-implemented">
 				<h3>Under-implemented features</h3>
 
-				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.4 for which the
-					Working Group has not been able to establish enough <a
+				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.3 [[epub-33]]
+					for which the Working Group has not been able to establish enough <a
 						href="https://www.w3.org/policies/process/#adequate-implementation">implementation
 						experience</a>.</p>
 
-				<p>These features are considered important to retain despite this limitation because they are known to
-					be implemented by [=EPUB creators=] (i.e., their deprecation would invalidate existing content)
-					and/or they are integral to the content model on which EPUB is built.</p>
+				<p>Only the <a href="#attrdef-dir"><code>dir</code> attribute</a> is designated as under-implemented.
+					Although it lacks the necessary reading system support, it is integral to the content model on which
+					EPUB is built (i.e., for internationalization support in the package document).</p>
 
-				<p>If this specification designates a feature as under-implemented, EPUB creators MAY use the features
-					as described.</p>
+				<p>EPUB creators MAY use this features as described.</p>
 
 				<div class="note">
 					<p>[=EPUB conformance checkers=] should alert EPUB creators to the presence of under-implemented
@@ -9701,15 +9700,8 @@ html.my-document-playing * {
 						of the standard (i.e., not emit errors or warnings).</p>
 				</div>
 
-				<div class="caution">
-					<p>Whether under-implemented labels are removed or replaced by deprecation in a future version of
-						the standard cannot be determined at this time. EPUB creators should strongly consider the
-						interoperability problems that may arise both now and in the future when using these
-						features.</p>
-				</div>
-
 				<div class="note">
-					<p>The marking of features as under-implemented is a one-time event to account for the different
+					<p>The marking of features as under-implemented was a one-time event to account for the different
 						process under which EPUB was developed prior to being brought into W3C. This label will not be
 						used for new features developed under W3C processes.</p>
 				</div>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -12021,7 +12021,7 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-					<li>05-June-2025: Consolidate all deprecated features under the deprecated features section to
+					<li>05-June-2025: Consolidated all deprecated features under the deprecated features section to
 						remove the appearance that they should still be authored. See the comments in <a
 							href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035">pull request
 							2735</a>.</li>

--- a/epub34/authoring/vocab/link.html
+++ b/epub34/authoring/vocab/link.html
@@ -62,38 +62,6 @@
 			</table>
 		</section>
 		
-		<section id="sec-marc21xml-record">
-			<h5>marc21xml-record (deprecated)</h5>
-			
-			<p id="marc2xml-record">Use of the <code>marc21xml-record</code> keyword is <a href="#deprecated">deprecated</a>.
-				It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-				"<code>application/marcxml+xml</code>".</p>
-			
-			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
-				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
-		</section>
-		
-		<section id="sec-mods-record">
-			<h5>mods-record (deprecated)</h5>
-			
-			<p id="mods-record">Use of the <code>mods-record</code> keyword is <a href="#deprecated">deprecated</a>. It
-				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-				"<code>application/mods+xml</code>".</p>
-			
-			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
-				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
-		</section>
-		
-		<section id="sec-onix-record">
-			<h5>onix-record (deprecated)</h5>
-			
-			<p id="onix-record">Use of the <code>onix-record</code> keyword is <a href="#deprecated">deprecated</a>. It
-				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a href="#attrdef-properties">properties attribute</a> value <a href="#onix"><code>onix</code></a>.</p>
-			
-			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
-				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
-		</section>
-		
 		<section id="sec-record" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L69,https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L75">
 			<h5>record</h5>
 			
@@ -179,25 +147,6 @@
 					</tr>
 				</tbody>
 			</table>
-		</section>
-		
-		<section id="sec-xml-signature">
-			<h5>xml-signature (deprecated)</h5>
-			
-			<p id="xml-signature">Use of the <code>xml-signature</code> keyword is <a href="#deprecated">deprecated</a>.
-				It is not replaced by another linking method.</p>
-			
-			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
-				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
-		</section>
-		
-		<section id="sec-xmp-record">
-			<h5>xmp-record (deprecated)</h5>
-			
-			<p id="xmp-record">Use of the <code>xmp-record</code> keyword is <a href="#deprecated">deprecated</a>.</p>
-			
-			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
-				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
 		</section>
 	</section>
 	

--- a/epub34/authoring/vocab/meta-property.html
+++ b/epub34/authoring/vocab/meta-property.html
@@ -505,14 +505,6 @@
 &lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-meta-auth">
-		<h5>meta-auth (deprecated)</h5>
-		
-		<p id="meta-auth">Use of this property is <a href="#deprecated">deprecated</a>.</p>
-		
-		<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"><code>meta-auth</code> property definition</a> in&nbsp;[[!epubpublications-30]] for more
-			information.</p>
-	</section>
 	<section id="sec-role" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L155,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L160">
 		<h5>role</h5>
 		<table class="tabledef" id="role">

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -55,7 +55,6 @@
 						<li><code>rendition:spread-both</code></li>
 						<li><code>rendition:spread-landscape</code></li>
 						<li><code>rendition:spread-none</code></li>
-						<li><code>rendition:spread-portrait</code> (Deprecated)</li>
 					</ul>
 				</td>
 				<td><a href="#spread"></a></td>
@@ -70,11 +69,6 @@
 					</ul>
 				</td>
 				<td><a href="#page-spread"></a></td>
-			</tr>
-			<tr>
-				<td><code>rendition:viewport</code> (Deprecated)</td>
-				<td>—</td>
-				<td><a href="#viewport"></a></td>
 			</tr>
 			<tr>
 				<td><code>rendition:flow</code></td>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1043,22 +1043,6 @@
 								model</a> [[rdfa-core]] is OPTIONAL.</p>
 					</section>
 
-					<section id="sec-xhtml-content-switch">
-						<h5>Content switching (deprecated)</h5>
-
-						<p>Use of the <code>switch</code> element is <a data-cite="epub-34#deprecated">deprecated</a>
-							[[epub-34]]. Refer to its definition in [[epubcontentdocs-301]] for implementation
-							information.</p>
-					</section>
-
-					<section id="sec-xhtml-epub-trigger">
-						<h5>The <code>epub:trigger</code> element (deprecated)</h5>
-
-						<p>Use of the <code>trigger</code> element is <a data-cite="epub-34#deprecated">deprecated</a>
-							[[epub-34]]. Refer to its definition in [[epubcontentdocs-301]] for implementation
-							information.</p>
-					</section>
-
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom attributes</h5>
 
@@ -1201,9 +1185,10 @@
 								Recommendation</a> status [[w3cprocess]] (and are widely implemented).</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts_ot, #cnt-css-fonts_tt, #cnt-css-fonts_woff, #cnt-css-fonts_woff2">MUST support [[truetype]],
-							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
-								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+						<p id="confreq-css-rs-fonts"
+							data-tests="#cnt-css-fonts_ot, #cnt-css-fonts_tt, #cnt-css-fonts_woff, #cnt-css-fonts_woff2"
+							>MUST support [[truetype]], [[opentype]], [[woff]], and [[woff2]] font resources referenced
+							from <a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>
@@ -1465,10 +1450,12 @@
 								none</code> property</a> [[csssnapshot]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-hidden" data-tests="#nav-spine_in-spine-hidden-toc-html,#nav-spine_in-spine-hidden-toc-css">MUST ignore markup and styling intended to hide elements of the
-						navigation document from rendering in the spine (e.g., the [[html]] [^html-global/hidden^]
-						attribute and CSS <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"
-								><code>display</code> property</a> [[csssnapshot]]).</p>
+					<p id="confreq-nav-hidden"
+						data-tests="#nav-spine_in-spine-hidden-toc-html,#nav-spine_in-spine-hidden-toc-css">MUST ignore
+						markup and styling intended to hide elements of the navigation document from rendering in the
+						spine (e.g., the [[html]] [^html-global/hidden^] attribute and CSS <a
+							href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
+							property</a> [[csssnapshot]]).</p>
 				</li>
 			</ul>
 
@@ -1579,11 +1566,6 @@
 							<dd>
 								<p>Reading systems SHOULD render a synthetic spread for spine items only when the device
 									is in landscape orientation.</p>
-							</dd>
-							<dt id="def-spread-portrait">portrait (deprecated)</dt>
-							<dd>
-								<p>Reading systems SHOULD treat the value "<code>portrait</code>" as a synonym of
-										"<code>both</code>" and create spreads regardless of orientation.</p>
 							</dd>
 							<dt id="def-spread-both" data-tests="#lay-fxl-spread-both">both</dt>
 							<dd>
@@ -1962,9 +1944,6 @@
 			<section id="sec-behaviors-interaction">
 				<h4>Interacting with the EPUB content document</h4>
 
-				<p class="note">Earlier versions of this specification included some information about embedded audio
-					and video [[epubmediaoverlays-32]]. This feature has been deprecated.</p>
-
 				<section id="sec-rsconf-navigation">
 					<h5>Navigation</h5>
 
@@ -1995,13 +1974,6 @@
 							synchronized with user navigation of table rows and cells. The reading system might also
 							play the corresponding table header preceding the contents of the cell.</p>
 					</div>
-				</section>
-
-				<section id="sec-embedded-media">
-					<h4>Embedded audio and video (deprecated)</h4>
-					<p>Guidance for automatic playback of embedded audio and video is now <a
-							data-cite="epub-34#deprecated">deprecated</a>.</p>
-					<p>Refer to its definition in [[epubmediaoverlays-32]] for more information.</p>
 				</section>
 
 				<section id="sec-text-to-speech">
@@ -2521,7 +2493,36 @@
 			<h2>Unsupported features</h2>
 
 			<p id="confreq-rs-deprecated">[=reading systems=] MAY support <a data-cite="epub-34#deprecated">deprecated
-					features</a> [[epub-34]].</p>
+					authoring features</a> [[epub-34]].</p>
+
+			<p id="sec-embedded-media">In addition, the following reading system features are now deprecated:</p>
+
+			<dl>
+				<dt>Media overlays processing</dt>
+				<dd>
+					<ul>
+						<li>
+							<p><a href="https://www.w3.org/publishing/epub32/epub-mediaoverlays.html#sec-embedded-media"
+									>Automatic playback of embedded audio and video</a> [[epubmediaoverlays-32]]</p>
+						</li>
+					</ul>
+				</dd>
+
+				<dt><code>epubReadingSystem</code> object</dt>
+				<dd>
+					<ul>
+						<li>
+							<p><a href="https://idpf.org/epub/301/spec/epub-contentdocs.html#app-ers-properties"
+										><code>layoutStyle</code> property</a> [[epubcontentdocs-301]]</p>
+						</li>
+						<li>
+							<p><a href="https://www.w3.org/publishing/epub32/epub-contentdocs.html#app-ers-properties"
+										><code>name</code> and <code>version</code> properties</a>
+								[[epubcontentdocs-32]]</p>
+						</li>
+					</ul>
+				</dd>
+			</dl>
 
 			<div class="note">
 				<p>Developers should consider the unlikelihood of encountering content with deprecated features before
@@ -2581,19 +2582,6 @@ partial interface Navigator {
 						reading system must ensure they consistently maintain the object's state — as reflected by the
 						values of its properties and methods — across all copied instances.</p>
 				</div>
-			</section>
-
-			<section id="app-ers-properties">
-				<h3>Properties</h3>
-
-				<p>This specification used to define the <code>name</code>, <code>version</code>, and the
-						<code>layoutStyle</code> properties, but these are now <a data-cite="epub-34#deprecated"
-						>deprecated</a> [[epub-34]]. For more information refer to their definitions
-					in [[epubcontentdocs-32]] (for <a
-						href="https://www.w3.org/publishing/epub32/epub-contentdocs.html#app-ers-properties"
-							><code>name</code> and <code>version</code></a>) and in [[epubcontentdocs-301]] (for <a
-						href="https://idpf.org/epub/301/spec/epub-contentdocs.html#app-ers-properties"
-							><code>layoutStyle</code></a>).</p>
 			</section>
 
 			<section id="app-ers-methods">
@@ -2719,6 +2707,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
+					<li>05-June-2025: Consolidated all deprecated features under the unsupported features section. See
+						the comments in <a href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035"
+							>pull request 2735</a>.</li>
 					<li>08-Apr-2025: Added a requirement that reading systems ignore markup and styling intended to hide
 						content in the EPUB navigation document when it is included in the spine. See <a
 							href="https://github.com/w3c/epub-specs/issues/2687">issue 2687</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -792,13 +792,9 @@
 					of [[bidi]].</p>
 
 				<div class="note">
-					<p>Although <a data-cite="epub-34#attrdef-dir">setting the directionality of package document
-							metadata</a> is marked as <a data-cite="epub-34#under-implemented">under-implemented</a> in
-						[[epub-34]], reading system with an international audience, or that claim support for
-						international content, are strongly advised to implement this feature when exposing that
-						metadata to users. Ignoring the directionality of text can cause readability issues.</p>
-					<p>The under-implemented label will be removed when the necessary baseline of support in reading
-						systems has been achieved.</p>
+					<p>Reading system with an international audience, or that claim support for international content,
+						are strongly advised to implement this feature when exposing that metadata to users. Ignoring
+						the directionality of text can cause readability issues.</p>
 				</div>
 			</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -797,8 +797,8 @@
 						[[epub-34]], reading system with an international audience, or that claim support for
 						international content, are strongly advised to implement this feature when exposing that
 						metadata to users. Ignoring the directionality of text can cause readability issues.</p>
-					<p>The under-implemented label will be removed from [[epub-34]] when the necessary baseline of
-						support in reading systems has been achieved.</p>
+					<p>The under-implemented label will be removed when the necessary baseline of support in reading
+						systems has been achieved.</p>
 				</div>
 			</section>
 


### PR DESCRIPTION
As noted in https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035, it would make the specifications cleaner if we removed the deprecated features from the body of the specification.

This pull request moves all the authoring features into the deprecated features section. All I've retained are the names of the features and the links/references to where they were last defined. If there is a replacement to use instead, I've kept that, too.

A couple of changes that people might disagree with are:

- I took bindings out of the content model definition for the package element in addition to removing the section about them. I've added that features must be used as they were last defined, so this still allows bindings to appear between the spine and any collections.
- I removed -epub-text-combine and left -epub-text-combine-horizontal since only the former is deprecated. They seem to have both been spun out of text-combine-upright, but I assume we can live without the deprecated one being mentioned anymore.

For the reading system specification, I've only kept the features that were unique to that document listed. It's easier to refer across to the authoring specification for all the other features, especially since any reading system requirements will also be linked from their references since they generally all predate the split we did in 3.3.

***

Reading Systems: [Preview](https://raw.githack.com/w3c/epub-specs/reorg/deprecated-features/epub34/rs/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/reorg/deprecated-features/epub34/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2736.html" title="Last updated on Jun 9, 2025, 1:05 AM UTC (bbc3079)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2736/266bd71...bbc3079.html" title="Last updated on Jun 9, 2025, 1:05 AM UTC (bbc3079)">Diff</a>