### PR TITLE
Media type contact should be the PM WG...

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11237,7 +11237,7 @@ html.my-document-playing * {
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is listed in the [[EPUB spine | spine=]. It is a
+						<p>The resource is an XHTML document. It is listed in the [=EPUB spine | spine=]. It is a
 							[=publication resource=] on the manifest plane, a [=container resource=], an [=EPUB content
 							document=] on the [=spine plane=], and is not present on the [=content plane=]. No fallback
 							is necessary.</p>
@@ -11818,8 +11818,8 @@ EPUB/images/cover.png</pre>
 					<dt>Published specification:</dt>
 					<dd>
 						<p>This media type registration is for the EPUB package document, as described by the EPUB 3
-							specification located at <a href="https://www.w3.org/TR/epub-33/"
-								>https://www.w3.org/TR/epub-33/</a>.</p>
+							specification located at <a href="https://www.w3.org/TR/epub-34/"
+								>https://www.w3.org/TR/epub-34/</a>.</p>
 						<p>The EPUB 3 specification supersedes the Open Packaging Format 2.0.1 specification, which is
 							located at <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
 								>https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm</a> and which also uses the <code
@@ -11864,7 +11864,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>EPUB 3 Working Group (public-epub-wg@w3.org)</p>
+						<p>Publishing Maintenance Working Group (public-pm-wg@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>
@@ -11945,8 +11945,8 @@ EPUB/images/cover.png</pre>
 					<dt>Published specification:</dt>
 					<dd>
 						<p>This media type registration is for the EPUB Open Container Format (OCF), as described by the
-							EPUB 3 specification located at <a href="https://www.w3.org/TR/epub-33/"
-									><code>https://www.w3.org/TR/epub-33/</code></a>.</p>
+							EPUB 3 specification located at <a href="https://www.w3.org/TR/epub-34/"
+									><code>https://www.w3.org/TR/epub-34/</code></a>.</p>
 						<p>The EPUB 3 specification supersedes both <a
 								href="https://datatracker.ietf.org/doc/html/rfc4839">RFC 4839</a> and the Open Container
 							Format 2.0.1 specification, which is located at <a
@@ -11993,7 +11993,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>EPUB 3 Working Group (public-epub-wg@w3.org)</p>
+						<p>Publishing Maintenace Working Group (public-pm-wg@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11818,8 +11818,8 @@ EPUB/images/cover.png</pre>
 					<dt>Published specification:</dt>
 					<dd>
 						<p>This media type registration is for the EPUB package document, as described by the EPUB 3
-							specification located at <a href="https://www.w3.org/TR/epub-34/"
-								>https://www.w3.org/TR/epub-34/</a>.</p>
+							specification located at <a href="https://www.w3.org/TR/epub/"
+								>https://www.w3.org/TR/epub/</a>.</p>
 						<p>The EPUB 3 specification supersedes the Open Packaging Format 2.0.1 specification, which is
 							located at <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
 								>https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm</a> and which also uses the <code
@@ -11864,7 +11864,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>Publishing Maintenance Working Group (public-pm-wg@w3.org)</p>
+						<p>Publishing Maintenance Working Group (epub-maintenanceg@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>
@@ -11945,8 +11945,8 @@ EPUB/images/cover.png</pre>
 					<dt>Published specification:</dt>
 					<dd>
 						<p>This media type registration is for the EPUB Open Container Format (OCF), as described by the
-							EPUB 3 specification located at <a href="https://www.w3.org/TR/epub-34/"
-									><code>https://www.w3.org/TR/epub-34/</code></a>.</p>
+							EPUB 3 specification located at <a href="https://www.w3.org/TR/epub/"
+									><code>https://www.w3.org/TR/epub/</code></a>.</p>
 						<p>The EPUB 3 specification supersedes both <a
 								href="https://datatracker.ietf.org/doc/html/rfc4839">RFC 4839</a> and the Open Container
 							Format 2.0.1 specification, which is located at <a
@@ -11993,7 +11993,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>Publishing Maintenace Working Group (public-pm-wg@w3.org)</p>
+						<p>Publishing Maintenace Working Group (epub-maintenanceg@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11864,7 +11864,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>Publishing Maintenance Working Group (epub-maintenanceg@w3.org)</p>
+						<p>Publishing Maintenance Working Group (epub-maintenance@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>
@@ -11993,7 +11993,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>Publishing Maintenace Working Group (epub-maintenanceg@w3.org)</p>
+						<p>Publishing Maintenance Working Group (epub-maintenance@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>


### PR DESCRIPTION
... instead of the EPUB WG. Also, the reference in the registration should be epub 3.4 and not 3.3.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2737.html" title="Last updated on Jun 25, 2025, 6:55 AM UTC (b6e7d9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2737/266bd71...b6e7d9c.html" title="Last updated on Jun 25, 2025, 6:55 AM UTC (b6e7d9c)">Diff</a>