### PR TITLE
Clarify the purpose of the reserved prefixes

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10157,12 +10157,10 @@ html.my-document-playing * {
 						an OPTIONAL prefix separated from a reference by a colon.</p>
 
 					<table class="productionset">
-						<caption>
-							<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-									14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
-								to U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
-								<code>xsd:</code>.</caption>
-						</caption>
+						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+							<code>xsd:</code>.</caption>
 						<tbody>
 							<tr>
 								<td id="property.ebnf.property">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -12022,6 +12022,9 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>26-June-2025: Added the <code>xsd</code>, <code>msv</code>, and <code>prism</code> reserved
+						prefixes to the deprecated features section. See <a
+							href="https://github.com/w3c/epub-specs/issues/2739">issue 2739</a>.</li>
 					<li>05-June-2025: Consolidated all deprecated features under the deprecated features section to
 						remove the appearance that they should still be authored. See the comments in <a
 							href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035">pull request

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -12022,7 +12022,7 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-					<li>26-June-2025: Added the <code>xsd</code>, <code>msv</code>, and <code>prism</code> reserved
+					<li>26-June-2025: Moved the <code>xsd</code>, <code>msv</code>, and <code>prism</code> reserved
 						prefixes to the deprecated features section. See <a
 							href="https://github.com/w3c/epub-specs/issues/2739">issue 2739</a>.</li>
 					<li>05-June-2025: Consolidated all deprecated features under the deprecated features section to

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10157,9 +10157,12 @@ html.my-document-playing * {
 						an OPTIONAL prefix separated from a reference by a colon.</p>
 
 					<table class="productionset">
-						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).</caption>
+						<caption>
+							<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+									14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
+								to U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+								<code>xsd:</code>.</caption>
+						</caption>
 						<tbody>
 							<tr>
 								<td id="property.ebnf.property">
@@ -10276,7 +10279,8 @@ html.my-document-playing * {
 					<table class="productionset">
 						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
 							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).</caption>
+							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+							<code>xsd:</code>.</caption>
 						<tbody>
 							<tr>
 								<td id="prefix.ebnf.def">
@@ -10429,40 +10433,68 @@ html.my-document-playing * {
 									<tr>
 										<th>Prefix</th>
 										<th>URL</th>
+										<th>Usage</th>
 									</tr>
 								</thead>
 								<tbody>
 									<tr>
 										<td>a11y</td>
 										<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
+										<td>To declare properties from them EPUB Accessibility namespace. These are
+											typically defined in <a data-cite="epub-a11y-111#app-a11y-vocab">EPUB
+												Accessibility 1.1.1</a> [[epub-a11y-111]].</td>
 									</tr>
 									<tr>
 										<td>dcterms</td>
 										<td>http://purl.org/dc/terms/</td>
+										<td>To declare properties from the <a data-cite="dcterms#section-2">Dublin Core
+												/terms/ namespace</a> [[dcterms]].</td>
 									</tr>
 									<tr>
 										<td>marc</td>
 										<td>http://id.loc.gov/vocabulary/</td>
+										<td>Primarily used in the <a href="#attrdef-scheme"><code>scheme</code>
+												attribute</a> to indicate that creator and contributor roles are defined
+											in the the <a href="https://www.loc.gov/marc/relators/relaterm.html">MARC
+												relators code list</a>. Can be used to reference other vocabularies
+											published by the Library of Congress.</td>
 									</tr>
 									<tr>
 										<td>media</td>
 										<td>http://www.idpf.org/epub/vocab/overlays/#</td>
+										<td>To declare properties from the <a href="#app-overlays-vocab">Media Overlays
+												vocabulary</a>.</td>
 									</tr>
 									<tr>
 										<td>onix</td>
-										<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
+										<td>http://www.editeur.org/ONIX/book/codelists/<wbr />current.html#</td>
+										<td>Used in the <code>scheme</code> attribute to identify the <a
+												href="https://ns.editeur.org/onix/en">ONIX code list</a> a value
+											corresponds to.</td>
 									</tr>
 									<tr>
 										<td>rendition</td>
 										<td>http://www.idpf.org/vocab/rendition/#</td>
+										<td>To declare properties from the <a href="#app-rendering-vocab">Package
+												rendering vocabulary</a>.</td>
 									</tr>
 									<tr>
 										<td>schema</td>
 										<td>http://schema.org/</td>
+										<td>To declare properties from the <a href="https://schema.org">Schema.org
+												vocabulary</a>.</td>
 									</tr>
 									<tr>
 										<td>xsd</td>
 										<td>http://www.w3.org/2001/XMLSchema#</td>
+										<td>
+											<p>To identify XML Schema datatypes [[xmlschema-2]]. Previously used in the
+													<code>scheme</code> attribute to indicate that <a
+													href="#sec-identifier-type"><code>identifier-type</code></a> values
+												were strings.</p>
+											<p><strong>No longer advised for use</strong> as the <code>scheme</code>
+												attribute is not intended for scheme-less values.</p>
+										</td>
 									</tr>
 								</tbody>
 							</table>
@@ -10478,16 +10510,34 @@ html.my-document-playing * {
 									<tr>
 										<th>Prefix</th>
 										<th>URL</th>
+										<th>Usage</th>
 									</tr>
 								</thead>
 								<tbody>
 									<tr>
 										<td>msv</td>
 										<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
+										<td>
+											<p>Used to specify <a
+													href="http://www.idpf.org/epub/vocab/structure/magazine/">magazine
+													semantics</a> for the <a
+													href="https://idpf.org/epub/renditions/region-nav/">region-based
+													navigation</a>.</p>
+											<p><strong>No longer advised for use</strong> as the specification is not
+												implemented in [=reading systems=] and no further work is expected on
+												it.</p>
+										</td>
 									</tr>
 									<tr>
 										<td>prism</td>
-										<td>http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#</td>
+										<td>http://www.prismstandard.org/specifications/3.0/<wbr />PRISM_CV_Spec_3.0.htm#</td>
+										<td>
+											<p>Used to reference magazine semantics from the unmaintained <a
+													href="https://www.w3.org/submissions/prism/prism-cvm.html">PRISM
+													Controlled Vocabulary Markup Specification</a>.</p>
+											<p><strong>No longer advised for use</strong> as the vocabulary is no longer
+												maintained.</p>
+										</td>
 									</tr>
 								</tbody>
 							</table>
@@ -10504,7 +10554,8 @@ html.my-document-playing * {
 				<dl>
 					<dt>Allowed Values</dt>
 					<dd>
-						<p>Specifies the REQUIRED type of value using [[!xmlschema-2]] datatypes.</p>
+						<p>Specifies the REQUIRED type of value using [[!xmlschema-2]] datatypes. Datatypes are declared
+							using the <code>xsd:</code> prefix.</p>
 					</dd>
 
 					<dt>Applies To</dt>
@@ -10941,7 +10992,6 @@ html.my-document-playing * {
 							<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
 									14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
 								to U+007F).</caption>
-
 							<tbody>
 								<tr>
 									<td id="viewport.ebnf.def">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10518,7 +10518,7 @@ html.my-document-playing * {
 										<td>
 											<p>Used to specify <a
 													href="http://www.idpf.org/epub/vocab/structure/magazine/">magazine
-													semantics</a> for the <a
+													semantics</a> for <a
 													href="https://idpf.org/epub/renditions/region-nav/">region-based
 													navigation</a>.</p>
 											<p><strong>No longer advised for use</strong> as the specification is not
@@ -10530,7 +10530,7 @@ html.my-document-playing * {
 										<td>prism</td>
 										<td>http://www.prismstandard.org/specifications/3.0/<wbr />PRISM_CV_Spec_3.0.htm#</td>
 										<td>
-											<p>Used to reference magazine semantics from the unmaintained <a
+											<p>Used to reference magazine semantics from the <a
 													href="https://www.w3.org/submissions/prism/prism-cvm.html">PRISM
 													Controlled Vocabulary Markup Specification</a>.</p>
 											<p><strong>No longer advised for use</strong> as the vocabulary is no longer

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -9776,6 +9776,20 @@ html.my-document-playing * {
 						</ul>
 					</dd>
 
+					<dt>Vocabulary association mechanisms</dt>
+					<dd>
+						<ul>
+							<li>
+								<p><a data-cite="epub-33#tbl-pkg-reserved-prefixes"><code>xsd</code> reserved prefix</a>
+									[[epub-33]] for package metadata.</p>
+							</li>
+							<li>
+								<p><a data-cite="epub-33#tbl-reserved-prefixes"><code>msv</code> and <code>prism</code>
+										reserved prefixes</a> [[epub-33]] for structural semantics.</p>
+							</li>
+						</ul>
+					</dd>
+
 					<dt>Meta properties vocabulary</dt>
 					<dd>
 						<ul>
@@ -10481,61 +10495,6 @@ html.my-document-playing * {
 										<td>http://schema.org/</td>
 										<td>To declare properties from the <a href="https://schema.org">Schema.org
 												vocabulary</a>.</td>
-									</tr>
-									<tr>
-										<td>xsd</td>
-										<td>http://www.w3.org/2001/XMLSchema#</td>
-										<td>
-											<p>To identify XML Schema datatypes [[xmlschema-2]]. Previously used in the
-													<code>scheme</code> attribute to indicate that <a
-													href="#sec-identifier-type"><code>identifier-type</code></a> values
-												were strings.</p>
-											<p><strong>No longer advised for use</strong> as the <code>scheme</code>
-												attribute is not intended for scheme-less values.</p>
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</dd>
-
-						<dt id="sec-content-reserved-prefixes">Structural Semantics</dt>
-						<dd>
-							<p>EPUB creators MAY use the following reserved prefixes in the <a
-									href="#app-structural-semantics"><code>epub:type</code> attribute</a> without having
-								to declare them.</p>
-							<table id="tbl-reserved-prefixes" class="prefix">
-								<thead>
-									<tr>
-										<th>Prefix</th>
-										<th>URL</th>
-										<th>Usage</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>msv</td>
-										<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
-										<td>
-											<p>Used to specify <a
-													href="http://www.idpf.org/epub/vocab/structure/magazine/">magazine
-													semantics</a> for <a
-													href="https://idpf.org/epub/renditions/region-nav/">region-based
-													navigation</a>.</p>
-											<p><strong>No longer advised for use</strong> as the specification is not
-												implemented in [=reading systems=] and no further work is expected on
-												it.</p>
-										</td>
-									</tr>
-									<tr>
-										<td>prism</td>
-										<td>http://www.prismstandard.org/specifications/3.0/<wbr />PRISM_CV_Spec_3.0.htm#</td>
-										<td>
-											<p>Used to reference magazine semantics from the <a
-													href="https://www.w3.org/submissions/prism/prism-cvm.html">PRISM
-													Controlled Vocabulary Markup Specification</a>.</p>
-											<p><strong>No longer advised for use</strong> as the vocabulary is no longer
-												maintained.</p>
-										</td>
 									</tr>
 								</tbody>
 							</table>


### PR DESCRIPTION
This pull request adds an additional usage column to the reserved prefixes tables to explain the purpose of each.

Despite my personal loathing of the dead prefixes, I've left them for now with an advisory against further use of them.

For the xsd: prefixes, I noticed that the property definitions are covered by the [allowed values definition](http://localhost:120/epub34/authoring/#sec-property-field-definitions). It called out xmlschemas-2 but didn't mention the prefix, so I've added a reference to it there. The other place we reference xsd datatypes is in the ebnf definitions. For those, I've added an additional line to source the datatypes. That should cover all cases so we aren't just dropping in xsd:* values without any context.

I don't figure this counts as a substantive change, so I'm not recording it in the change log.

Fixes #2739


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2742.html" title="Last updated on Jun 27, 2025, 12:29 AM UTC (c509460)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2742/6556f5d...c509460.html" title="Last updated on Jun 27, 2025, 12:29 AM UTC (c509460)">Diff</a>