### PR TITLE
Remove the draft edupub terms

### DIFF
--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -2423,32 +2423,32 @@
 				publications=]. Each term links to its last full definition.</p>
 
 			<ul>
-				<li id="subchapter"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#subchapter"
-						>subchapter</a></li>
+				<li id="annoref"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#annoref"
+						>annoref</a></li>
+				<li id="annotation"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#annotation"
+						>annotation</a></li>
 				<li id="biblioentry"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#biblioentry"
 						>biblioentry</a></li>
+				<li id="bridgehead"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#bridgehead"
+						>bridgehead</a></li>
+				<li id="endnote"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#endnote"
+						>endnote</a></li>
 				<li id="help"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#help">help</a> - replaced
 					by <a href="#tip">tip</a>.</li>
 				<li id="marginalia"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#marginalia"
 						>marginalia</a></li>
-				<li id="sidebar"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#sidebar">sidebar</a> -
-					replaced by the [[html]] [^aside^] element.</li>
-				<li id="warning"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#warning">warning</a> -
-					replaced by <a href="#notice">notice</a></li>
-				<li id="bridgehead"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#bridgehead"
-						>bridgehead</a></li>
-				<li id="annotation"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#annotation"
-						>annotation</a></li>
-				<li id="endnote"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#endnote"
-					>endnote</a></li>
 				<li id="note"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#note">note</a> - replaced
 					by <a href="#footnote">footnote</a></li>
 				<li id="rearnote"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#rearnote"
-					>rearnote</a></li>
+						>rearnote</a></li>
 				<li id="rearnotes"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#rearnotes"
 						>rearnotes</a> - replaced by <a href="#endnotes">endnotes</a></li>
-				<li id="annoref"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#annoref"
-					>annoref</a></li>
+				<li id="sidebar"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#sidebar">sidebar</a> -
+					replaced by the [[html]] [^aside^] element.</li>
+				<li id="subchapter"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#subchapter"
+						>subchapter</a></li>
+				<li id="warning"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#warning">warning</a> -
+					replaced by <a href="#notice">notice</a></li>
 			</ul>
 		</section>
 		<section id="change-log" class="appendix informative">

--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Structural Semantics Vocabulary 1.1</title>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>

--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -265,17 +265,6 @@
 					</p>
 				</dd>
 
-				<dt id="subchapter">subchapter<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>A major sub-division of a chapter.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=section=], <a
-							data-cite="html#the-body-element">body</a>
-					</p>
-				</dd>
-
 				<dt id="part">part</dt>
 				<dd>
 					<p>A major structural division in a work that contains a set of related sections dealing with a
@@ -621,31 +610,6 @@
 				<h3 id="h_bibliographies">Bibliographies</h3>
 
 				<dl>
-					<dt id="biblioentry">biblioentry [DEPRECATED]</dt>
-					<dd>
-						<p>A single reference to an external source in a <a href="#bibliography">bibliography</a>. A
-							biblioentry typically provides more detailed information than its reference(s) in the
-							content (e.g., full title, author(s), publisher, publication date, etc.).</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#bibliography">bibliography</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">DPUB-ARIA role: </span>
-							<a data-cite="dpub-aria-1.1#doc-biblioentry">doc-biblioentry</a> (Deprecated)</p>
-					</dd>
 					<dt id="bibliography">bibliography</dt>
 					<dd>
 						<p>A list of external references cited in the work, which may be to print or digital
@@ -1739,55 +1703,6 @@
 			<h2>Complementary content</h2>
 
 			<dl>
-				<dt id="help">help<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>Helpful information that clarifies some aspect of the content or assists in its
-						comprehension.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=aside=], [=phrasing content=] </p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref">
-							<a href="#tip">tip</a>
-						</span>
-					</p>
-				</dd>
-
-				<dt id="marginalia">marginalia<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>Content, both textual and graphical, that is offset in the margin.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=aside=], [=phrasing content=] </p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref"> [=aside=] </span>
-					</p>
-				</dd>
-
 				<dt id="notice">notice</dt>
 				<dd>
 					<p>Notifies the user of consequences that might arise from an action or event. Examples include
@@ -1830,29 +1745,6 @@
 					</p>
 				</dd>
 
-				<dt id="sidebar">sidebar<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>Secondary or supplementary content, typically formatted as an inset or box.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=aside=] </p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref"> [=aside=] </span>
-					</p>
-				</dd>
-
 				<dt id="tip">tip</dt>
 				<dd>
 					<p>Helpful information that clarifies some aspect of the content or assists in its
@@ -1876,42 +1768,12 @@
 						<a data-cite="dpub-aria-1.1#doc-tip">doc-tip</a>
 					</p>
 				</dd>
-
-				<dt id="warning">warning<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>A warning.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=section=], <a
-							data-cite="html#grouping-content">grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref">
-							<a href="#notice">notice</a>
-						</span>
-					</p>
-				</dd>
 			</dl>
 		</section>
 		<section id="sec-titles">
 			<h2>Titles and headings</h2>
 
 			<dl>
-				<dt id="bridgehead">bridgehead <span class="status deprecated">[deprecated]</span></dt>
-				<dd>
-					<p>A structurally insignificant heading that does not contribute to the hierarchical structure of
-						the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=flow content=], typically [=p=],
-						[=div=] or [=span=] </p>
-				</dd>
-
 				<dt id="covertitle">covertitle</dt>
 				<dd>
 					<p>The title of the work as displayed on the work's cover.</p>
@@ -2158,57 +2020,6 @@
 			<h2>Notes and annotations</h2>
 
 			<dl>
-				<dt id="annotation">annotation<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>Explanatory information about passages in the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=aside=], [=phrasing content=] </p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref">
-							<a href="http://idpf.org/epub/oa">Open Annotation in EPUB</a>
-						</span>
-					</p>
-				</dd>
-
-				<dt id="endnote">endnote [DEPRECATED]</dt>
-				<dd>
-					<p>One of a collection of notes that occur at the end of a work, or a section within it, that
-						provides additional context to a referenced passage of text.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">See also:</span>
-						<span class="subpropref">
-							<a href="#endnotes">endnotes</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>On the <a
-							data-cite="html#the-aside-element">aside</a> element when identifying a single endnote, or
-						on descendants of sectioning content when identifying individual endnotes in a group (refer to
-							<a href="#footnotes">footnotes</a> and <a href="#endnotes">endnotes</a>).</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a data-cite="dpub-aria-1.1#doc-endnote">doc-endnote</a> (Deprecated)</p>
-				</dd>
-
 				<dt id="endnotes">endnotes</dt>
 				<dd>
 					<p>A collection of notes at the end of a work or a section within it.</p>
@@ -2275,122 +2086,12 @@
 					<p>
 						<span class="subproplabel">HTML usage context: </span> [=sectioning content=] </p>
 				</dd>
-
-				<dt id="note">note<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>A note. This property does not carry spatial positioning semantics, as do the <a href="#footnote"
-							>footnote</a> and <a href="#endnote">endnote</a> properties. It can be used to identify
-						footnotes, endnotes, marginal notes, inline notes, and similar when legacy naming conventions
-						are not desired.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>On the <a
-							data-cite="html#the-aside-element">aside</a> element when identifying a single note, or on
-						descendants of sectioning content when identifying individual notes in a group (refer to <a
-							href="#footnotes">footnotes</a> and <a href="#endnotes">endnotes</a>).</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref">
-							<a href="#footnote">footnote</a>, <a href="#endnote">endnote</a>
-						</span>
-					</p>
-				</dd>
-
-				<dt id="rearnote">rearnote<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>A note appearing in the rear (backmatter) of the work, or at the end of a section.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">See also:</span>
-						<span class="subpropref">
-							<a href="#rearnotes">rearnotes</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>On the <a
-							data-cite="html#the-aside-element">aside</a> element when identifying a single rearnote, or
-						on descendants of sectioning content when identifying individual rearnotes in a group (refer to
-							<a href="#footnotes">footnotes</a> and <a href="#rearnotes">rearnotes</a>).</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref">
-							<a href="#endnote">endnote</a>
-						</span>
-					</p>
-				</dd>
-
-				<dt id="rearnotes">rearnotes<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>A collection of notes appearing at the rear (backmatter) of the work, or at the end of a
-						section.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">See also:</span>
-						<span class="subpropref">
-							<a href="#rearnote">rearnote</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=sectioning content=] </p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref">
-							<a href="#endnotes">endnotes</a>
-						</span>
-					</p>
-				</dd>
 			</dl>
 		</section>
 		<section id="links">
 			<h2>References</h2>
 
 			<dl>
-				<dt id="annoref">annoref<span class="status deprecated"> [deprecated]</span></dt>
-				<dd>
-					<p>A reference to an annotation.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">See also:</span>
-						<span class="subpropref">
-							<a href="#annotation">annotation</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=a=] </p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Replaced by:</span>
-						<span class="subpropref">
-							<a href="http://idpf.org/epub/oa">Open Annotation in EPUB</a>
-						</span>
-					</p>
-				</dd>
-
 				<dt id="backlink">backlink</dt>
 				<dd>
 					<p>A link that allows the user to return to a related location in the content (e.g., from a <a
@@ -2714,6 +2415,41 @@
 						as an escapable or skippable aside.</p>
 				</dd>
 			</dl>
+		</section>
+		<section id="deprecated-terms">
+			<h2>Deprecated terms</h2>
+
+			<p>Although use of the following terms remains valid, they are no longer recommended for use in [=EPUB
+				publications=]. Each term links to its last full definition.</p>
+
+			<ul>
+				<li id="subchapter"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#subchapter"
+						>subchapter</a></li>
+				<li id="biblioentry"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#biblioentry"
+						>biblioentry</a></li>
+				<li id="help"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#help">help</a> - replaced
+					by <a href="#tip">tip</a>.</li>
+				<li id="marginalia"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#marginalia"
+						>marginalia</a></li>
+				<li id="sidebar"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#sidebar">sidebar</a> -
+					replaced by the [[html]] [^aside^] element.</li>
+				<li id="warning"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#warning">warning</a> -
+					replaced by <a href="#notice">notice</a></li>
+				<li id="bridgehead"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#bridgehead"
+						>bridgehead</a></li>
+				<li id="annotation"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#annotation"
+						>annotation</a></li>
+				<li id="endnote"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#endnote"
+					>endnote</a></li>
+				<li id="note"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#note">note</a> - replaced
+					by <a href="#footnote">footnote</a></li>
+				<li id="rearnote"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#rearnote"
+					>rearnote</a></li>
+				<li id="rearnotes"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#rearnotes"
+						>rearnotes</a> - replaced by <a href="#endnotes">endnotes</a></li>
+				<li id="annoref"><a href="https://www.w3.org/TR/2025/NOTE-epub-ssv-11-20250612/#annoref"
+					>annoref</a></li>
+			</ul>
 		</section>
 		<section id="change-log" class="appendix informative">
 			<h2>Change log</h2>

--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -164,6 +164,15 @@
 					designated property. Authors are only required to follow these usage details if they are creating
 					content that conforms to the specified specification, or if the rules apply to all EPUB
 					publications. In all other cases, the properties may be used however needed.</p>
+
+				<div class="note">
+					<p>This vocabulary previously contained draft terms from the <a
+							href="https://docs.google.com/document/d/1_Tzeq5xwdwLhSdaHStvAthhOFu9UuT8yFmK787yw420/edit?tab=t.0#heading=h.a39j7klhkr87"
+							>EDUPUB structural semantics vocabulary</a>. Although those terms will remain available for
+						experimental use in [=EPUB publications=], [=EPUB creators=] should consider that the work on
+						EDUPUB has been abandoned and the likelihood of adoption of any additional terms from that work
+						is low.</p>
+				</div>
 			</section>
 		</section>
 		<section id="sec-partitions">
@@ -303,8 +312,7 @@
 			<p>Sections and components that typically occur in the publication bodymatter.</p>
 
 			<dl>
-				<dt id="abstract-1">abstract<span class="status draft"> [draft]</span>
-				</dt>
+				<dt id="abstract-1">abstract</dt>
 				<dd>
 					<p>A short summary of the principle ideas, concepts, and conclusions of the work, or of a section or
 						excerpt within it.</p>
@@ -551,15 +559,6 @@
 						<span class="subproplabel">Usage details: </span>
 						<a data-cite="epub-33#sec-nav-toc">The <code>toc nav</code> Element</a> [[epub-33]] </p>
 				</dd>
-
-				<dt id="toc-brief">toc-brief<span class="status draft"> [draft]</span></dt>
-				<dd>
-					<p>An abridged version of the table of contents.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=sectioning content=] </p>
-				</dd>
 			</dl>
 		</section>
 		<section id="sec-document-references">
@@ -600,7 +599,7 @@
 					</p>
 				</dd>
 
-				<dt id="credits">credits<span class="status draft"> [draft]</span></dt>
+				<dt id="credits">credits</dt>
 				<dd>
 					<p>A collection of <a href="#credit">credits</a>.</p>
 				</dd>
@@ -616,24 +615,13 @@
 						<a data-cite="dpub-aria-1.1#doc-credits">doc-credits</a>
 					</p>
 				</dd>
-
-				<dt id="keywords">keywords<span class="status draft"> [draft]</span></dt>
-				<dd>
-					<p>A collection of <a href="#keyword">keywords</a>.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=sectioning content=], <a
-							data-cite="html#grouping-content">grouping content</a>
-					</p>
-				</dd>
 			</dl>
 
 			<section id="bibliographies">
 				<h3 id="h_bibliographies">Bibliographies</h3>
 
 				<dl>
-					<dt id="biblioentry">biblioentry</dt>
+					<dt id="biblioentry">biblioentry [DEPRECATED]</dt>
 					<dd>
 						<p>A single reference to an external source in a <a href="#bibliography">bibliography</a>. A
 							biblioentry typically provides more detailed information than its reference(s) in the
@@ -1735,17 +1723,6 @@
 					</p>
 				</dd>
 
-				<dt id="seriespage">seriespage <span class="status draft"> [draft]</span></dt>
-				<dd>
-					<p>Marketing section used to list related publications.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=section=], <a
-							data-cite="html#grouping-content">grouping content</a>
-					</p>
-				</dd>
-
 				<dt id="titlepage">titlepage</dt>
 				<dd>
 					<p>The title page of the work.</p>
@@ -1762,23 +1739,6 @@
 			<h2>Complementary content</h2>
 
 			<dl>
-				<dt id="case-study">case-study<span class="status draft"> [draft]</span></dt>
-				<dd>
-					<p>A detailed analysis of a specific topic.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=sectioning content=] </p>
-				</dd>
-
 				<dt id="help">help<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>Helpful information that clarifies some aspect of the content or assists in its
@@ -1846,7 +1806,7 @@
 					</p>
 				</dd>
 
-				<dt id="pullquote">pullquote<span class="status draft"> [draft]</span></dt>
+				<dt id="pullquote">pullquote</dt>
 				<dd>
 					<p>A distinctively placed or highlighted quotation from the current content designed to draw
 						attention to a topic or highlight a key point.</p>
@@ -2016,45 +1976,6 @@
 						only appear once within the document scope.</p>
 				</dd>
 
-				<dt id="label">label<span class="status draft"> [draft]</span></dt>
-				<dd>
-					<p>The text label that precedes an <a href="#ordinal">ordinal</a> in a component title (e.g.,
-						'Chapter', 'Part', 'Figure', 'Table').</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="#doc-title">title</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=Phrasing content=] descendants of <a
-							data-cite="html#heading-content">heading content</a>, [=li=] and <a
-							data-cite="html#the-figcaption-element">figcaption</a>
-					</p>
-				</dd>
-
-				<dt id="ordinal">ordinal<span class="status draft"> [draft]</span></dt>
-				<dd>
-					<p>An ordinal specifier for a component in a sequence of components (e.g., '1', 'IV', 'B-1').</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="#doc-title">title</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span> [=Phrasing content=] descendants of
-						[=heading content=], [=li=] and [=figcaption=] </p>
-				</dd>
-
 				<dt id="subtitle">subtitle</dt>
 				<dd>
 					<p>An explanatory or alternate title for the work, or a section or component within it.</p>
@@ -2108,38 +2029,6 @@
 							content=] </p>
 					</dd>
 
-					<dt id="learning-objectives">learning-objectives<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A collection of <a href="#learning-objective">learning-objectives</a>.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="learning-outcome">learning-outcome<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>The understanding or ability a student is expected to achieve as a result of a lesson or
-							activity.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=flow content=] </p>
-					</dd>
-
-					<dt id="learning-outcomes">learning-outcomes<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A collection of <a href="#learning-outcome">learning-outcomes</a>.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
 					<dt id="learning-resource">learning-resource</dt>
 					<dd>
 						<p>A resource provided to enhance learning, or a reference to such a resource.</p>
@@ -2148,39 +2037,6 @@
 						<p>
 							<span class="subproplabel">HTML usage context: </span> [=flow content=] </p>
 					</dd>
-
-					<dt id="learning-resources">learning-resources<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A collection of <a href="#learning-resource">learning-resources</a>.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="learning-standard">learning-standard<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A formal set of expectations or requirements typically issued by a government or a standards
-							body.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=], [=phrasing
-							content=] </p>
-					</dd>
-
-					<dt id="learning-standards">learning-standards<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A collection of <a href="#learning-standard">learning-standards</a>.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
 				</dl>
 			</section>
 
@@ -2188,128 +2044,10 @@
 				<h3 id="h_testing">Testing</h3>
 
 				<dl>
-					<dt id="answer">answer<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>The component of a self-assessment problem that provides the answer to the question.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=aside=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="answers">answers<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A collection of <a href="#answer">answers</a>.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
 					<dt id="assessment">assessment</dt>
 					<dd>
 						<p>A test, quiz, or other activity that helps measure a student's understanding of what is being
 							taught.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=] </p>
-					</dd>
-
-					<dt id="assessments">assessments<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A collection of <a href="#assessment">assessments</a>.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=sectioning content=] </p>
-					</dd>
-
-					<dt id="feedback">feedback<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>Instruction to the reader based on the result of an assessment.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a data-cite="html#grouping-content">grouping content</a>, [=phrasing content=] </p>
-					</dd>
-
-					<dt id="fill-in-the-blank-problem">fill-in-the-blank-problem<span class="status draft">
-							[draft]</span></dt>
-					<dd>
-						<p>A problem that requires the reader to input a text answer to complete a sentence, statement
-							or similar.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=aside=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="general-problem">general-problem<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A problem with a free-form solution.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=aside=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="match-problem">match-problem<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A problem that requires the reader to match the contents of one list with the corresponding
-							items in another list.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=aside=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="multiple-choice-problem">multiple-choice-problem<span class="status draft">
-						[draft]</span></dt>
-					<dd>
-						<p>A problem with a set of potential answers to choose from ‒ some, all, or none of which may be
-							correct.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=aside=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="practice">practice<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A review exercise or sample.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">See also:</span>
-							<span class="subpropref">
-								<a href="#practices">practices</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=aside=], <a
-								data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="practices">practices<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A collection of <a href="#practice">practices</a>.</p>
 					</dd>
 					<dd>
 						<p>
@@ -2329,28 +2067,6 @@
 						<p>
 							<span class="subproplabel">DPUB-ARIA role: </span>
 							<a data-cite="dpub-aria-1.1#doc-qna">doc-qna</a>
-						</p>
-					</dd>
-
-					<dt id="question">question<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>The component of a self-assessment problem that identifies the question to be solved.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a data-cite="html#grouping-content">grouping content</a>
-						</p>
-					</dd>
-
-					<dt id="true-false-problem">true-false-problem<span class="status draft"> [draft]</span></dt>
-					<dd>
-						<p>A problem with either a true or false answer.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span> [=aside=], <a
-								data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 				</dl>
@@ -2467,7 +2183,7 @@
 					</p>
 				</dd>
 
-				<dt id="endnote">endnote</dt>
+				<dt id="endnote">endnote [DEPRECATED]</dt>
 				<dd>
 					<p>One of a collection of notes that occur at the end of a work, or a section within it, that
 						provides additional context to a referenced passage of text.</p>
@@ -2675,7 +2391,7 @@
 					</p>
 				</dd>
 
-				<dt id="backlink">backlink<span class="status draft"> [draft]</span></dt>
+				<dt id="backlink">backlink</dt>
 				<dd>
 					<p>A link that allows the user to return to a related location in the content (e.g., from a <a
 							href="#footnote">footnote</a> to its reference or from a <a href="#glossdef">glossary
@@ -2700,7 +2416,7 @@
 					</p>
 				</dd>
 
-				<dt id="biblioref">biblioref<span class="status draft"> [draft]</span></dt>
+				<dt id="biblioref">biblioref</dt>
 				<dd>
 					<p>A reference to a <a href="#biblioentry">bibliography entry</a>.</p>
 				</dd>
@@ -2723,7 +2439,7 @@
 					</p>
 				</dd>
 
-				<dt id="glossref">glossref<span class="status draft"> [draft]</span></dt>
+				<dt id="glossref">glossref</dt>
 				<dd>
 					<p>A reference to a <a href="#glossdef">glossary definition</a>.</p>
 				</dd>
@@ -2794,7 +2510,7 @@
 						<span class="subproplabel">HTML usage context: </span> [=phrasing content=] </p>
 				</dd>
 
-				<dt id="credit">credit<span class="status draft"> [draft]</span></dt>
+				<dt id="credit">credit</dt>
 				<dd>
 					<p>An acknowledgment of the source of integrated content from third-party sources, such as photos.
 						Typically identifies the creator, copyright, and any restrictions on reuse.</p>
@@ -2998,6 +2714,21 @@
 						as an escapable or skippable aside.</p>
 				</dd>
 			</dl>
+		</section>
+		<section id="change-log" class="appendix informative">
+			<h2>Change log</h2>
+
+			<p>Note that this change log only identifies substantive changes to the vocabulary. For a list of all
+				changes, refer to the <a
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-SSV"
+					>Working Group's issue tracker</a>.</p>
+
+			<ul>
+				<li>2025-06-25: Removed all the draft edupub terms, retaining only the terms that are referenced from
+					DPUB-ARIA 1.1. See <a href="https://github.com/w3c/epub-specs/issues/2743">issue 2743</a>.</li>
+				<li>2025-06-25: Deprecated the <code>biblioentry</code> and <code>endnote</code> terms to match their
+					deprecation in DPUB-ARIA 1.1.</li>
+			</ul>
 		</section>
 	</body>
 </html>

--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -2416,7 +2416,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="deprecated-terms">
+		<section id="deprecated-terms" class="appendix">
 			<h2>Deprecated terms</h2>
 
 			<p>Although use of the following terms remains valid, they are no longer recommended for use in [=EPUB


### PR DESCRIPTION
This pull request:

-  Removes all the draft edupub terms except for [the ones that are referenced from DPUB-ARIA](https://github.com/w3c/epub-specs/issues/2743#issue-3165964127). The draft label is removed from the terms being retained.
- Adds a note to the "about this vocabulary" explaining why the terms have been removed but that they remain available for experimental use (we won't change how epubcheck currently handles any of these terms).
- Deprecates endnote and biblioentry to match DPUB-ARIA 1.1
- Moves all the deprecated terms to an appendix to declutter the body of the vocabulary.

Some questions before we merge this pull request are:

- Should we keep any of the other dropped terms? (See https://github.com/w3c/epub-specs/issues/2743#issuecomment-2997996114 for a list of other non-educational terms that edupub added.)
- Should we consider removing all the deprecated terms from the vocabulary?

Fixes #2743 