### PR TITLE
Remove greater than sign from date range

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1842,7 +1842,7 @@
 					publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed in this version, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-A11yTechniques%20closed%3A%3E2025-02-11..2027-02-11%20"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-A11yTechniques%20closed%3A2025-02-11..2027-02-11%20"
 					>working group's issue tracker</a>.</p>
 
 			<ul>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1892,7 +1892,7 @@
 				conformance of EPUB publications.</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-Accessibility%20closed%3A%3E2025-02-11..2027-02-11%20"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-Accessibility%20closed%3A2025-02-11..2027-02-11%20"
 					>working group's issue tracker</a>.</p>
 
 			<details id="changes-epub-a11y-11" open="open">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -12009,7 +12009,7 @@ EPUB/images/cover.png</pre>
 				publications=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A%3E2025-02-11..2027-02-11%20-label%3AErrata"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A2025-02-11..2027-02-11%20-label%3AErrata"
 					>Working Group's issue tracker</a>.</p>
 
 			<details id="changes-epub-33" open="open">

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2696,7 +2696,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				[=EPUB reading systems=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-ReadingSystems%20closed%3A%3E2025-02-11%20..2027-02-11"
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-ReadingSystems%20closed%3A2025-02-11%20..2027-02-11"
 					>working group's issue tracker</a>.</p>
 
 			<details id="changes-epub-rs-33" open="open">


### PR DESCRIPTION
While upating the SSV, I noticed that our change log links to the github repository had an extra greater than sign (%3E) before the date range. Looks like a typo from when I first set them up to be any time after Feb. 11.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2745.html" title="Last updated on Jun 25, 2025, 1:50 PM UTC (f35799b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2745/3580e60...f35799b.html" title="Last updated on Jun 25, 2025, 1:50 PM UTC (f35799b)">Diff</a>