### PR TITLE
Change accessmodesufficient to required and accessmode to recommended

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -319,9 +319,13 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-schema-accessMode"><a href="https://schema.org/accessMode">accessMode</a> — a
-							human sensory perceptual system or cognitive faculty necessary to process or perceive the
-							content (e.g., textual, visual, auditory, tactile).</p>
+						<p id="confreq-schema-accessModeSufficient"><a href="https://schema.org/accessModeSufficient"
+								>accessModeSufficient</a> — a set of one or more access modes sufficient to consume the
+							content without significant loss of information. An EPUB publication can have more than one
+							set of sufficient access modes for its consumption depending on the types of content it
+							includes (i.e., unlike <a href="#confreq-schema-accessMode">access modes</a>, this property
+							takes into account any alternatives for content that is not broadly accessible, such as the
+							inclusion of transcripts for audio content).</p>
 					</li>
 
 					<li>
@@ -337,25 +341,29 @@
 					</li>
 				</ul>
 
+				<div class="issue" data-number="2679"
+					title="Switch requirements for accessMode and accessModeSufficient">
+					<p>The current draft makes accessModeSufficient a required property and accessMode a recommended
+						one, as accessModeSufficient is the more helpful in determining who can read the content. This
+						change will require the version number of the standard to change, otherwise existing content
+						could become invalid. If the version is not changed, this change will be undone.</p>
+				</div>
+
 				<p>EPUB publications SHOULD include the following [[schema-org]] accessibility metadata:</p>
 
 				<ul class="conformance-list">
+					<li>
+						<p id="confreq-schema-accessMode"><a href="https://schema.org/accessMode">accessMode</a> — a
+							human sensory perceptual system or cognitive faculty necessary to process or perceive the
+							content (e.g., textual, visual, auditory, tactile).</p>
+					</li>
+
 					<li>
 						<p id="confreq-schema-accessibilitySummary"><a href="https://schema.org/accessibilitySummary"
 								>accessibilitySummary</a> — a human-readable summary of the accessibility that
 							complements, but does not duplicate, the other discoverability metadata. The summary also
 							describes any known deficiencies (e.g., lack of extended descriptions, specific
 							hazards).</p>
-					</li>
-
-					<li>
-						<p id="confreq-schema-accessModeSufficient"><a href="https://schema.org/accessModeSufficient"
-								>accessModeSufficient</a> — a set of one or more access modes sufficient to consume the
-							content without significant loss of information. An EPUB publication can have more than one
-							set of sufficient access modes for its consumption depending on the types of content it
-							includes (i.e., unlike <a href="#confreq-schema-accessMode">access modes</a>, this property
-							takes into account any alternatives for content that is not broadly accessible, such as the
-							inclusion of transcripts for audio content).</p>
 					</li>
 				</ul>
 
@@ -1899,7 +1907,9 @@
 				<summary>Substantive changes since <a href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility
 					1.1</a></summary>
 				<ul>
-					<li>No substantive changes have been made. </li>
+					<li>2025-06-26: Changed accessMode to a recommended property and accessModeSufficient to required to
+						better reflect their usefulness is determining if a book will be readable. See <a
+							href="https://github.com/w3c/epub-specs/issues/2679">issue 2679</a>.</li>
 				</ul>
 			</details>
 		</section>


### PR DESCRIPTION
This pull request reverses the requirements for the accessMode and accessModeSufficient properties: accessModeSufficient becomes required because it is more useful in determining if a book will be readable and accessMode becomes recommended.

I've also added an issue box for this pull request because this change would require both a version number change (to bump up the requirement on accessModeSufficient) and an erratum (because accessMode would otherwise still be required in the ISO 1.0 version). I'm going to leave issue #2679 open for feedback.
