### PR TITLE
Update editor draft URL-s for notes

### DIFF
--- a/epub34/overview/index.html
+++ b/epub34/overview/index.html
@@ -22,7 +22,7 @@
                 // previousPublishDate: "2021-12-08",
                 // previousMaturity: "NOTE",
 				copyrightStart: "1999",
-				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
+				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
 				editors:[
 				{
 					name: "Matt Garrish",

--- a/wg-notes/a11y-exemption/index.html
+++ b/wg-notes/a11y-exemption/index.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
+		<meta name="color-scheme" content="light dark" />
 		<title>The EPUB Accessibility exemption property</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -12,7 +13,7 @@
 				specStatus: "ED",
 				shortName: "epub-a11y-exemption",
 				noRecTrack: true,
-				edDraftURI: "https://w3c.github.io/epub-specs/epub33/a11y-exemption/",
+				edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/a11y-exemption/",
                 copyrightStart: "2023",
 				editors:[ {
 					name: "Matt Garrish",

--- a/wg-notes/epub-a11y-eaa-mapping/index.html
+++ b/wg-notes/epub-a11y-eaa-mapping/index.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
+		<meta name="color-scheme" content="light dark" />
 		<title>EPUB Accessibility - EU Accessibility Act Mapping</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
@@ -13,8 +14,8 @@
 				specStatus: "ED",
 				noRecTrack: true,
 				shortName: "epub-a11y-eaa-mapping",
-				edDraftURI: "https://w3c.github.io/epub-specs/epub33/epub-a11y-eaa-mapping/",
-				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
+				edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/epub-a11y-eaa-mapping/",
+				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
                 copyrightStart: "2021",
 				editors: [
 					{

--- a/wg-notes/epub-aria-authoring/index.html
+++ b/wg-notes/epub-aria-authoring/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Type to ARIA Role Authoring Guide 1.1</title>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -14,8 +15,8 @@
                 specStatus: "ED",
 				noRecTrack: true,
                 shortName: "epub-aria-authoring-11",
-				edDraftURI: "https://w3c.github.io/epub-specs/epub33/epub-aria-authoring/",
-				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
+				edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/epub-aria-authoring/",
+				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
 				copyrightStart: "2021",
 				editors:[ {
 					name: "Matt Garrish",

--- a/wg-notes/fxl-a11y-tech/index.html
+++ b/wg-notes/fxl-a11y-tech/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility - Fixed Layout Techniques</title>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
@@ -13,15 +14,14 @@
                 wgPublicList: "public-pm-wg",
                 specStatus: "ED",
                 shortName: "epub-fxl-a11y-tech",
-                edDraftURI: "https://w3c.github.io/epub-specs/epub33/fxl-a11y-tech/",
+                edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/fxl-a11y-tech/",
                 previousPublishDate: "2023-10-16",
                 previousMaturity: "NOTE",
                 copyrightStart: "2023",
                 noRecTrack: true,
                 editors:[ {
                     name: "Wendy Reid",
-                    company: "Rakuten Kobo",
-                    companyURL: "https://www.kobo.com",
+                    company: "Invited Expert",
 					w3cid: 102009
                 },
                 {

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
+        <meta name="color-scheme" content="light dark" />
 		<title>EPUB Accessibility - Fixed Layout Challenges and Best Practices</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -13,15 +14,14 @@
                 wgPublicList: "public-pm-wg",
                 specStatus: "ED",
                 shortName: "epub-fxl-a11y",
-                edDraftURI: "https://w3c.github.io/epub-specs/epub33/fxl-a11y/",
+                edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/fxl-a11y/",
                 previousPublishDate: "2021-04-27",
                 previousMaturity: "NOTE",
                 copyrightStart: "2021",
                 noRecTrack: true,
                 editors:[ {
                     name: "Wendy Reid",
-                    company: "Rakuten Kobo",
-                    companyURL: "https://www.kobo.com",
+                    company: "Invited Expert",
 					w3cid: 102009
                 }],
                 includePermalinks: true,

--- a/wg-notes/multi-rend/index.html
+++ b/wg-notes/multi-rend/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Multiple-Rendition Publications 1.1</title>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -14,11 +15,11 @@
                 wgPublicList: "public-pm-wg",
                 specStatus: "ED",
                 shortName: "epub-multi-rend-11",
-                edDraftURI: "https://w3c.github.io/epub-specs/epub33/multi-rend/",
+                edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/multi-rend/",
                 previousPublishDate: "2021-12-08",
                 previousMaturity: "NOTE",
                 copyrightStart: "2015",
-				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
+				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
                 noRecTrack: true,
                 editors:[ {
                     name: "Matt Garrish",

--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Structural Semantics Vocabulary 1.1</title>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -14,8 +15,8 @@
 				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				shortName: "epub-ssv-11",
-				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
-				edDraftURI: "https://w3c.github.io/epub-specs/epub33/ssv/",
+				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
+				edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/ssv/",
 				noRecTrack: true,
 				editors: [
 					{

--- a/wg-notes/tts/index.html
+++ b/wg-notes/tts/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Text-to-Speech Enhancements 1.0</title>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -14,8 +15,8 @@
 				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				shortName: "epub-tts-10",
-				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
-				edDraftURI: "https://w3c.github.io/epub-specs/epub33/tts/",
+				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
+				edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/tts/",
 				editors: [
 					{
 						name: "Matt Garrish",


### PR DESCRIPTION
The editors' drafts still referred to the `epub33` folder on the repo, it shoud refer to `wg-notes`.

While I was at it:

- I added the `<meta>` for dark mode to all specs
- I commented out (where applicable) the reference to errata; it pointed to the epub33 but, for notes, there is no real need for the full errata management while the WG is active.