### PR TITLE
Update the relationship to html section

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -213,8 +213,8 @@
 					<h4>Relationship to HTML</h4>
 
 					<p>The [[html]] standard is continuously evolving — there are no longer versioned releases of it.
-						That standard, in turn, references various technologies that continue to evolve, such as MathML,
-						SVG, CSS, and JavaScript.</p>
+						That standard, in turn, references various technologies that also continue to evolve, such as
+						MathML, SVG, CSS, and JavaScript.</p>
 
 					<p>The benefit of this approach for EPUB is that [=EPUB publications=] always keep pace with changes
 						to the web without the need for new revisions. [=EPUB creators=], however, must keep track of

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -527,8 +527,7 @@
 							<p>EPUB 3 previously supported only the XML syntax of [[html]] via what were called XHTML
 								content documents. The change of name to HTML content documents is not to give priority
 								to the HTML syntax but to better reflect that [[html]] is the common standard for both
-								syntaxes. XHTML has not been a separate standalone technology since [[xhtml11]] and the
-								XML syntax has replaced it in [[html]].</p>
+								syntaxes. The term "XHTML" used to refer to [[xhtml11]], but that was replaced by the XML syntax of [[html]] in 2011, which also officially superceded [[xhtml11]] in 2018.</p>
 						</div>
 						<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
 							<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. It is important

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -521,7 +521,7 @@
 					<dd>
 						<p>An [=EPUB content document=] that conforms to the profile of [[html]] defined in <a
 								href="#sec-xhtml"></a>.</p>
-						<p>HTML content documents can be authored in either the <a data-cite="html#syntax">HTML
+						<p>HTML content documents can be expressed in either the <a data-cite="html#syntax">HTML
 								syntax</a> or the <a data-cite="html#the-xhtml-syntax">XML syntax</a> [[html]].</p>
 						<div class="note">
 							<p>EPUB 3 previously supported only the XML syntax of [[html]] via what were called XHTML

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -223,19 +223,18 @@
 
 					<p>The [[html]] standard defines a single content model with rules for expressing a tag set using
 						either the <a data-cite="html#syntax">HTML syntax</a> (what has always been considered HTML) or
-						the <a data-cite="html#the-xhtml-syntax">XML syntax</a> (what was known as XHTML). Up until
-						[[epub-33]], EPUB 3 only supported the XML syntax via what were called "XHTML content
-						documents." It now allows the authoring of both syntaxes under the common name of [=HTML content
-						documents=].</p>
+						the <a data-cite="html#the-xhtml-syntax">XML syntax</a> (what was formerly known as XHTML). EPUB
+						3 allows authoring of content documents using either syntax even though the [[html]] standard <a
+							data-cite="html/xhtml.html#the-xhtml-syntax">no longer recommends the use of the XML
+							syntax</a>. The Working Group recognizes that XML remains an integral technology in the
+						publishing ecosystem and will not remove support for the XML syntax from EPUB 3. Regardless,
+						publishers that prefer to keep using the XML syntax will need to monitor future support for it,
+						and may have to adapt to the HTML syntax to gain access to some features of [[html]].</p>
 
 					<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
 						<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. The above paragraph
 							was added to help explain the change, but would be reverted if the HTML syntax is not
 							adopted.</p>
-
-						<p>It is important to note that the change is only to allow another syntax of [[html]]. Because
-							EPUB 2's XHTML content documents were implemented using [[xhtml11]], some authors mistakenly
-							assume EPUB 3's XHTML content documents use the same.</p>
 					</div>
 
 					<p>The <a href="#sec-xhtml">HTML profile defined by this specification</a> inherits all definitions
@@ -514,14 +513,31 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" data-lt="xhtml content document|xhtml content documents">HTML content
-							document</dfn>
+						<dfn class="export">HTML content document</dfn>
+					</dt>
+					<dt>
+						<small>(formerly <dfn class="export">XHTML content document</dfn>)</small>
 					</dt>
 					<dd>
 						<p>An [=EPUB content document=] that conforms to the profile of [[html]] defined in <a
 								href="#sec-xhtml"></a>.</p>
 						<p>HTML content documents can be authored in either the <a data-cite="html#syntax">HTML
-								syntax</a> or <a data-cite="html#the-xhtml-syntax">XML syntax</a> [[html]].</p>
+								syntax</a> or the <a data-cite="html#the-xhtml-syntax">XML syntax</a> [[html]].</p>
+						<div class="note">
+							<p>EPUB 3 previously supported only the XML syntax of HTML via what were called XHTML
+								content documents. The change of name to HTML content documents is not to give priority
+								to the HTML syntax but to better reflect that HTML is the common standard for both
+								syntaxes. XHTML has not been a separate standalone technology since [[xhtml11]] and the
+								XML syntax has replaced it in [[html]].</p>
+						</div>
+						<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
+							<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. It is important
+								to note that EPUB 3 is already based on [[html]] and this change only makes the HTML
+								syntax valid to use. Because EPUB 2's XHTML content documents were implemented using
+								[[xhtml11]], some authors mistakenly assume EPUB 3's XHTML content documents use the
+								same technology and that this change represents a move to a new standard.</p>
+							<p>This new definition will be reverted if the HTML syntax is not adopted.</p>
+						</div>
 					</dd>
 
 					<dt>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -221,10 +221,7 @@
 						the various changes to HTML and the technologies it references to ensure they keep their
 						processes up to date.</p>
 
-					<p>The [[html]] standard also combines what used to be two separate technologies: [[?html401]] and
-						[[?xhtml11]]. These two standards differed not only in their syntaxes, but also in what elements
-						and attributes authors could use, as well as how the syntaxes were identified (their
-							<code>DOCTYPE</code> declarations).</p>
+					
 
 					<p>The [[html]] standard now defines a single content model with rules for expressing this tag set
 						using either the <a data-cite="html#syntax">HTML syntax</a> (what has always been considered

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -238,7 +238,7 @@
 					</div>
 
 					<p>The <a href="#sec-xhtml">HTML profile defined by this specification</a> inherits all definitions
-						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
+						of semantics, structure and processing behaviors from [[html]] unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
 						to the [[html]] document model that EPUB creators may include in [=HTML content documents=].</p>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -524,9 +524,9 @@
 						<p>HTML content documents can be authored in either the <a data-cite="html#syntax">HTML
 								syntax</a> or the <a data-cite="html#the-xhtml-syntax">XML syntax</a> [[html]].</p>
 						<div class="note">
-							<p>EPUB 3 previously supported only the XML syntax of HTML via what were called XHTML
+							<p>EPUB 3 previously supported only the XML syntax of [[html]] via what were called XHTML
 								content documents. The change of name to HTML content documents is not to give priority
-								to the HTML syntax but to better reflect that HTML is the common standard for both
+								to the HTML syntax but to better reflect that [[html]] is the common standard for both
 								syntaxes. XHTML has not been a separate standalone technology since [[xhtml11]] and the
 								XML syntax has replaced it in [[html]].</p>
 						</div>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -527,7 +527,9 @@
 							<p>EPUB 3 previously supported only the XML syntax of [[html]] via what were called XHTML
 								content documents. The change of name to HTML content documents is not to give priority
 								to the HTML syntax but to better reflect that [[html]] is the common standard for both
-								syntaxes. The term "XHTML" used to refer to [[xhtml11]], but that was replaced by the XML syntax of [[html]] in 2011, which also officially superceded [[xhtml11]] in 2018.</p>
+								syntaxes. The term "XHTML" used to refer to [[xhtml11]], but that was replaced by the
+								XML syntax of [[html]] in 2011, which also officially superseded [[xhtml11]] in
+								2018.</p>
 						</div>
 						<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
 							<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. It is important

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -223,7 +223,7 @@
 
 					
 
-					<p>The [[html]] standard now defines a single content model with rules for expressing this tag set
+					<p>The [[html]] standard defines a single content model with rules for expressing a tag set
 						using either the <a data-cite="html#syntax">HTML syntax</a> (what has always been considered
 						HTML) or the <a data-cite="html#the-xhtml-syntax">XML syntax</a> (what was known as XHTML). Up
 						until [[epub-33]], EPUB 3 only supported the XML syntax via what were called "XHTML content

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -222,9 +222,9 @@
 						processes up to date.</p>
 
 					<p>The [[html]] standard defines a single content model with rules for expressing a tag set using
-						either the <a data-cite="html#syntax">HTML syntax</a> (what has always been considered HTML) or
-						the <a data-cite="html#the-xhtml-syntax">XML syntax</a> (what was formerly known as XHTML). EPUB
-						3 allows authoring of content documents using either syntax even though the [[html]] standard <a
+						either the <a data-cite="html#syntax">HTML syntax</a> or the <a
+							data-cite="html#the-xhtml-syntax">XML syntax</a>. EPUB 3 allows authoring of content
+						documents using either of these syntaxes even though the [[html]] standard <a
 							data-cite="html/xhtml.html#the-xhtml-syntax">no longer recommends the use of the XML
 							syntax</a>. The Working Group recognizes that XML remains an integral technology in the
 						publishing ecosystem and will not remove support for the XML syntax from EPUB 3. Regardless,

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -536,7 +536,7 @@
 								syntax valid to use. Because EPUB 2's XHTML content documents were implemented using
 								[[xhtml11]], some authors mistakenly assume EPUB 3's XHTML content documents use the
 								same technology and that this change represents a move to a new standard.</p>
-							<p>This new definition will be reverted if the HTML syntax is not adopted.</p>
+							<p>This new definition will be amended if the HTML syntax is not adopted.</p>
 						</div>
 					</dd>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -221,14 +221,22 @@
 						the various changes to HTML and the technologies it references to ensure they keep their
 						processes up to date.</p>
 
-					
-
-					<p>The [[html]] standard defines a single content model with rules for expressing a tag set
-						using either the <a data-cite="html#syntax">HTML syntax</a> (what has always been considered
-						HTML) or the <a data-cite="html#the-xhtml-syntax">XML syntax</a> (what was known as XHTML). Up
-						until [[epub-33]], EPUB 3 only supported the XML syntax via what were called "XHTML content
+					<p>The [[html]] standard defines a single content model with rules for expressing a tag set using
+						either the <a data-cite="html#syntax">HTML syntax</a> (what has always been considered HTML) or
+						the <a data-cite="html#the-xhtml-syntax">XML syntax</a> (what was known as XHTML). Up until
+						[[epub-33]], EPUB 3 only supported the XML syntax via what were called "XHTML content
 						documents." It now allows the authoring of both syntaxes under the common name of [=HTML content
 						documents=].</p>
+
+					<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
+						<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. The above paragraph
+							was added to help explain the change, but would be reverted if the HTML syntax is not
+							adopted.</p>
+
+						<p>It is important to note that the change is only to allow another syntax of [[html]]. Because
+							EPUB 2's XHTML content documents were implemented using [[xhtml11]], some authors mistakenly
+							assume EPUB 3's XHTML content documents use the same.</p>
+					</div>
 
 					<p>The <a href="#sec-xhtml">HTML profile defined by this specification</a> inherits all definitions
 						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
@@ -5896,21 +5904,21 @@ No Entry</pre>
 								both are natively supported.</p>
 						</div>
 					</section>
-					
+
 					<section id="sec-xhtml-its">
 						<h5>Internationalization tag set (ITS)</h5>
-						
+
 						<p>The [[its20]] specification defines a set of attributes that [=EPUB creators=] MAY use in
 							[=XHTML content documents=] to add support for internationalization, translation, and
 							localization.</p>
-						
+
 						<p>EPUB creators MUST only use ITS attributes as they are defined in <a
 								data-cite="its20#html5-markup">Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does
 							not support the namespaced attributes).</p>
-						
+
 						<p>The use of these attributes MUST conform to the requirements defined in [[its20]].</p>
 					</section>
-					
+
 					<section id="sec-xhtml-custom-attributes" data-epubcheck="true"
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L790,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L795">
 						<h5>Custom attributes</h5>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -221,12 +221,23 @@
 						the various changes to HTML and the technologies it references to ensure they keep their
 						processes up to date.</p>
 
+					<p>The [[html]] standard also combines what used to be two separate technologies: [[?html401]] and
+						[[?xhtml11]]. These two standards differed not only in their syntaxes, but also in what elements
+						and attributes authors could use, as well as how the syntaxes were identified (their
+							<code>DOCTYPE</code> declarations).</p>
+
+					<p>The [[html]] standard now defines a single content model with rules for expressing this tag set
+						using either the <a data-cite="html#syntax">HTML syntax</a> (what has always been considered
+						HTML) or the <a data-cite="html#the-xhtml-syntax">XML syntax</a> (what was known as XHTML). Up
+						until [[epub-33]], EPUB 3 only supported the XML syntax via what were called "XHTML content
+						documents." It now allows the authoring of both syntaxes under the common name of [=HTML content
+						documents=].</p>
+
 					<p>The <a href="#sec-xhtml">HTML profile defined by this specification</a> inherits all definitions
 						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the [[html]] document model that EPUB creators may include in [=XHTML content
-						documents=].</p>
+						to the [[html]] document model that EPUB creators may include in [=HTML content documents=].</p>
 				</section>
 
 				<section id="sec-overview-relations-svg">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -233,7 +233,7 @@
 
 					<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
 						<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. The above paragraph
-							was added to help explain the change, but would be reverted if the HTML syntax is not
+							was added to help explain the change, but would be amended if the HTML syntax is not
 							adopted.</p>
 					</div>
 


### PR DESCRIPTION
As a complement to #2756, this pull request updates the Relationship to HTML section to describe the integration of both syntaxes in the HTML standard we refer to.

I've skipped noting the change is still a proposal since this section links to the html docs section where we already have an extensive note about the status.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2757.html" title="Last updated on Jul 5, 2025, 1:06 PM UTC (2abf806)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2757/5fe557b...2abf806.html" title="Last updated on Jul 5, 2025, 1:06 PM UTC (2abf806)">Diff</a>