### PR TITLE
Remove the examples comparing evaluator to publisher

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1267,41 +1267,10 @@
 								this can diminish the trust users have in the claim.</p>
 						</div>
 
-						<aside id="pub-ex" class="example" title="An EPUB publication evaluated by the publisher">
-							<p>In this example, the publisher is stating they self-evaluated the EPUB publication (the
-								values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property are
-								the same).</p>
-
+						<aside class="example" title="Evaluator's name metadata">
+							<p>The evaluator's name is linked to the conformance statement using the
+									<code>refines</code> attribute.</p>
 							<pre>&lt;metadata …>
-  …
-  &lt;dc:publisher>
-     Acme Publishing Inc.
-  &lt;/dc:publisher>
-  …
-  &lt;meta
-      property="dcterms:conformsTo"
-      id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
-  &lt;/meta>
-  
-  &lt;meta
-      property="a11y:certifiedBy"
-      refines="#conf">
-     Acme Publishing Inc.
-  &lt;/meta>
-  …
-&lt;/metadata></pre>
-						</aside>
-
-						<aside class="example" title="An EPUB publication evaluated by a third-party">
-							<p>In this example, a third party has evaluated the EPUB 3 publication (the values of the
-									<code>dc:publisher</code> and <code>a11y:certifiedBy</code> property differ).</p>
-
-							<pre>&lt;metadata …>
-  …
-  &lt;dc:publisher>
-     Acme Publishing Inc.
-  &lt;/dc:publisher>
   …
   &lt;meta
       property="dcterms:conformsTo"
@@ -1313,53 +1282,6 @@
       refines="#conf">
      Foo's Accessibility Testing
   &lt;/meta>
-  …
-&lt;/metadata></pre>
-						</aside>
-
-						<aside class="example" title="An EPUB publication evaluated by the author">
-							<p>In this example, the author is stating they self-evaluated the EPUB publication (the
-								values of the <code>dc:creator</code> and <code>a11y:certifiedBy</code> property are the
-								same).</p>
-
-							<pre>&lt;metadata …>
-  …
-  &lt;dc:creator>
-     Jane Doe
-  &lt;/dc:creator>
-  …
-  &lt;meta
-      property="dcterms:conformsTo"
-      id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
-  &lt;/meta>
-  
-  &lt;meta
-      property="a11y:certifiedBy"
-      refines="#conf">
-     Jane Doe
-  &lt;/meta>
-  …
-&lt;/metadata></pre>
-						</aside>
-
-						<aside class="example" title="A self-evaluated EPUB 2 Publication">
-							<p>This example is the same as the <a href="#pub-ex">publisher example</a>, but expressed in
-								an EPUB 2 package document.</p>
-
-							<pre>&lt;metadata …>
-  …
-  &lt;dc:publisher>
-     Acme Publishing Inc.
-  &lt;/dc:publisher>
-  …
-  &lt;meta
-      name="dcterms:conformsTo"
-      content="EPUB Accessibility 1.1 - WCAG 2.2 Level AA"/>
-  
-  &lt;meta
-      name="a11y:certifiedBy"
-      content="Acme Publishing Inc."/>
   …
 &lt;/metadata></pre>
 						</aside>
@@ -1918,8 +1840,8 @@
 				<summary>Substantive changes since <a href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility
 					1.1</a></summary>
 				<ul>
-					<li>26-June-2025: Changed accessMode to a recommended property and accessModeSufficient to required to
-						better reflect their usefulness is determining if a book will be readable. See <a
+					<li>26-June-2025: Changed accessMode to a recommended property and accessModeSufficient to required
+						to better reflect their usefulness is determining if a book will be readable. See <a
 							href="https://github.com/w3c/epub-specs/issues/2679">issue 2679</a>.</li>
 					<li>02-June-2025: Make explicit that the evaluation date has to conform to iso 8601. Refer to <a
 							href="https://github.com/w3c/epub-specs/issues/2725">issue 2725</a>.</li>


### PR DESCRIPTION
As discussed on the accessibility task force call today, this pull request removes the examples comparing the evaluator to the publisher/creator in an attempt to infer whether the publication is self-evaluated or third-party evaluated.

If knowledge of the evaluator relationship is needed in the future, we'll reassess how to establish this more reliably.

To the folks on the call, it was mentioned a few times that certifier isn't often specified but according to the standard it's required metadata. Is that another issue we should look at?

Fixes #2721 

***

[Preview](https://raw.githack.com/w3c/epub-specs/a11y/cert-type/epub34/a11y/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/a11y/cert-type/epub34/a11y/index.html)
