### PR TITLE
Added a uc for portions of images

### DIFF
--- a/wg-notes/annotations-ucr/index.html
+++ b/wg-notes/annotations-ucr/index.html
@@ -60,6 +60,12 @@
 				He selects the image and triggers the annotation affordance. 
 				The annotation feature is then identical to the one associated with a textual selection.
 			</p>
+			<p>
+				A user consults an EPUB publication that includes detailed diagrams (e.g., in SVG) and images (e.g., in JPG or PNG) visualizing 
+				a research data set. 
+				She analyses the data by annotating <em>portions</em> of the diagrams and/or images by selecting rectangular area of 
+				the data visualization and shares these annotations with her colleagues.
+			</p>
 		</section>
 		<section>
 			<h2>Bookmarking</h2>

--- a/wg-notes/annotations-ucr/index.html
+++ b/wg-notes/annotations-ucr/index.html
@@ -63,7 +63,7 @@
 			<p>
 				A user consults an EPUB publication that includes detailed diagrams (e.g., in SVG) and images (e.g., in JPG or PNG) visualizing 
 				a research data set. 
-				She analyses the data by annotating <em>portions</em> of the diagrams and/or images by selecting rectangular area of 
+				She analyses the data by annotating <em>portions</em> of the diagrams and/or images by selecting rectangular areas of 
 				the data visualization and shares these annotations with her colleagues.
 			</p>
 		</section>


### PR DESCRIPTION
(Per https://github.com/w3c/epub-specs/pull/2767#pullrequestreview-3071761744, I believe each new UC should be in a separate section, but I did not do it for now. We can do it uniformly in a later step.)

---

See:

* For EPUB Annotations Use Cases and Requirements:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/anno-ucr-image-portion/wg-notes/annotations-ucr/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/wg-notes/annotations-ucr/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/anno-ucr-image-portion/wg-notes/annotations-ucr/index.html)
