### PR TITLE
Add more accessibility document references

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1489,6 +1489,67 @@
 						widest possible audience.</p>
 				</section>
 			</section>
+
+			<section id="sec-a11y-resources" class="informative">
+				<h3>Additional resources</h3>
+
+				<p>The following documents provide additional information on how to author accessible <a
+						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>:</p>
+
+				<dl>
+					<dt><a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility Techniques 1.1.1</a></dt>
+					<dd>
+						<p>The EPUB Accessibility techniques [[epub-a11y-tech-111]] provide specific guidance on how to
+							apply WCAG techniques to EPUB publications as well a guidance on how to meet the
+							EPUB-specific objectives of this document.</p>
+					</dd>
+
+					<dt><a href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 Understanding Docs</a></dt>
+					<dd>
+						<p>The WCAG Understanding Docs provide detailed explanations of the purpose and goals of the
+							WCAG success criteria.</p>
+					</dd>
+
+					<dt><a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG (Quick Reference)</a></dt>
+					<dd>
+						<p>The WCAG quick reference guide provides links to techniques showing ways to meet each WCAG
+							success critierion.</p>
+					</dd>
+
+					<dt><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a></dt>
+					<dd>
+						<p>The ARIA standard [[wai-aria]] defines roles, states, and properties for making dynamic
+							content that does not use native HTML elements and attributes accessible. It also provides a
+							set of landmarks for navigating web pages.</p>
+					</dd>
+
+					<dt><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a></dt>
+					<dd>
+						<p>ARIA in HTML [[html-aria]] specifies how the roles, states, and properties defined ARIA and
+							DPUB-ARIA can be used in HTML documents.</p>
+					</dd>
+
+					<dt><a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices Guide (APG)</a></dt>
+					<dd>
+						<p>The ARIA Authoring Practices guide provides examples of how to use ARIA roles, states, and
+							properties to make dynamic content more accessible.</p>
+					</dd>
+
+					<dt><a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module
+						(DPUB-ARIA)</a></dt>
+					<dd>
+						<p>The [[dpub-aria]] specification is an extension of [[wai-aria]] that provides additional
+							roles specific to identifying common publishing structures.</p>
+					</dd>
+
+					<dt><a href="https://www.w3.org/TR/epub-aria-authoring/">EPUB Type to ARIA Role Authoring
+						Guide</a></dt>
+					<dd>
+						<p>The EPUB Type to ARIA Role authoring guide provides mappings from the semantics used in the
+								<code>epub:type</code> attribute to ARIA and DPUB-ARIA role equivalents.</p>
+					</dd>
+				</dl>
+			</section>
 		</section>
 		<section id="sec-optimized-pubs" class="informative">
 			<h2>Optimized publications</h2>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -9470,14 +9470,40 @@ html.my-document-playing * {
 			<p>EPUB 3 builds upon the Open Web Platform expressly so that it can leverage the structure, semantics and,
 				by extension, accessibility built into its underlying technologies.</p>
 
-			<p>The requirements and practices for creating accessible web content have already been documented in the
-				W3C's <a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a> [[wcag2]].
-				These guidelines also form the basis for defining accessibility in [=EPUB publications=].</p>
+			<p>Some of the key standards for authoring accessible web content include:</p>
 
-			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
-					data-cite="epub-a11y-111#">EPUB Accessibility</a> [[epub-a11y-111]], defines how to apply the
-				standard to EPUB publications. It also adds EPUB-specific requirements and recommendations for metadata,
-				pagination, and media overlays.</p>
+			<dl>
+				<dt><a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a></dt>
+				<dd>
+					<p>The requirements and practices for creating accessible web content are documented in the
+						[[wcag2]].</p>
+				</dd>
+
+				<dt><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a></dt>
+				<dd>
+					<p>The [[wai-aria]] specification defines roles, states, and properties for making dynamic content
+						that does not use native HTML elements and attributes accessible. It also provides a set of
+						landmarks for navigating web pages.</p>
+				</dd>
+
+				<dt><a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a></dt>
+				<dd>
+					<p>The [[dpub-aria]] specification is an extension of [[wai-aria]] that provides additional roles
+						specific to identifying common publishing structures.</p>
+				</dd>
+
+				<dt><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a></dt>
+				<dd>
+					<p>[[html-aria]] specifies how the roles, states, and properties defined ARIA and DPUB-ARIA can be
+						used in HTML documents.</p>
+				</dd>
+			</dl>
+
+			<p>These standards also form the basis for making [=EPUB publications=] accessible. As the current WCAG
+				guidelines (version 2) are heavily focused on web pages, however, the <a data-cite="epub-a11y-111#">EPUB
+					Accessibility</a> standard [[epub-a11y-111]] defines how to apply these standards to EPUB
+				publications and adds EPUB-specific requirements and recommendations for metadata, pagination, and media
+				overlays.</p>
 
 			<p>This specification recommends that EPUB publications <a href="#confreq-a11y">conform to the accessibility
 					requirements</a> defined in&#160;[[epub-a11y-111]]. A benefit of following this recommendation is

--- a/epub34/authoring/vocab/meta-property.html
+++ b/epub34/authoring/vocab/meta-property.html
@@ -547,7 +547,7 @@
 		</table>
 		
 		<div class="note">
-			<p>The <code>pageBreakSource</code> property replaces the <a href="#source-of"><code>source-of</code> 
+			<p>The <code>pageBreakSource</code> property replaces the <a href="#sec-source-of"><code>source-of</code> 
 					property</a> for identifying the source of static pagination for an EPUB publication.</p>
 			
 			<p>Refer to [[epub-a11y-tech-11]] for information on how to provide accessible page navigation.</p>


### PR DESCRIPTION
Breaks out and adds references to WCAG, ARIA, DPUB-ARIA and ARIA in HTML in the accessibility section of the authoring spec.

Adds an "additional resources" section to the accessibility specification to provide a more comprehensive list of resources for authoring accessible content.

If I've missed any documents or if you think the descriptions need more detail, let me know.

(Also fixes a unrelated broken link on a reference to the source-of property.)

Fixes #2720 

***

[Accessibility Preview](https://raw.githack.com/w3c/epub-specs/editorial/issue-2720/epub34/a11y/index.html) | [ Accessibility Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/editorial/issue-2720/epub34/a11y/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2770.html" title="Last updated on Aug 4, 2025, 4:40 PM UTC (08752fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2770/0698f95...08752fe.html" title="Last updated on Aug 4, 2025, 4:40 PM UTC (08752fe)">Diff</a>