### PR TITLE
Made the changes on CSS management discussed in the issue 2762 

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6215,6 +6215,22 @@ No Entry</pre>
 									<p>Some types of screens will render animations and transitions poorly (e.g., those
 										with high latency).</p>
 								</li>
+								<li>
+									<p>
+										Creators should be aware that a reading systems may override some aspects of 
+										the creator's style settings; creators may want to consult the reading systems' 
+										user agent style sheets, if publicly available. Furthermore, reading systems may
+										also modify some rendering aspects as a result of user interaction (e.g., choice 
+										of fonts, text justification, or foreground and background colors).
+									</p>
+								</li>
+								<li>
+									<p>
+										Creators should avoid using [[html]] [^html-global/style^] attributes in content documents. 
+										Styling should always be done via CSS files, otherwise a reading system will 
+										not be able to easily override them when interacting with the user.
+									</p>
+								</li>
 							</ul>
 						</div>
 					</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6201,7 +6201,7 @@ No Entry</pre>
 							section, EPUB defers to the W3C to define CSS and expects reading systems to support it at
 							level of major browsers.</p>
 
-						<p>Although [=Reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
+						<p>Although [=reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
 								defined in the CSS snapshot</a>, the reality is that most reading systems currently do
 							not support all desired features of CSS, and often will modify, and allow users to change,
 							the default presentation defined by the [=EPUB creator=]. As a result, EPUB creators will

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6217,7 +6217,7 @@ No Entry</pre>
 								</li>
 								<li>
 									<p>
-										Creators should be aware that a reading systems may override some aspects of 
+										Creators should be aware that a reading systems usually override some aspects of 
 										the creator's style settings; creators may want to consult the reading systems' 
 										user agent style sheets, if publicly available. Furthermore, reading systems may
 										also modify some rendering aspects as a result of user interaction (e.g., choice 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6198,15 +6198,16 @@ No Entry</pre>
 							provided prefixed versions of numerous other properties. Although the CSS Working Group no
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
-							section, EPUB defers to the W3C to define CSS and expects reading systems to support it at
-							level of major browsers.</p>
+							section, EPUB defers to the W3C to define CSS and expects [=reading systems=] to support it
+							at level of major browsers.</p>
 
-						<p>Although [=reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
-								defined in the CSS snapshot</a>, the reality is that most reading systems currently do
-							not support all desired features of CSS, and often will modify, and allow users to change,
-							the default presentation defined by the [=EPUB creator=]. As a result, EPUB creators will
-							need to adapt their styling to these realities. For more information, refer to <a
-								href="#sec-css-rs"></a>.</p>
+						<p>Although reading systems are expected to support <a
+								data-cite="epub-rs-34#confreq-css-rs-support">CSS as defined in the CSS snapshot</a>
+							[[epub-rs-34]], the reality is that most reading systems currently do not support all
+							desired features of CSS, and often will modify, and allow users to change, the default
+							presentation defined by the [=EPUB creator=]. As a result, EPUB creators will need to adapt
+							their styling to these realities. For more information, refer to <a href="#sec-css-rs"
+							></a>.</p>
 					</section>
 
 					<section id="sec-css-req" data-epubcheck="true"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6199,7 +6199,7 @@ No Entry</pre>
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
 							section, EPUB defers to the W3C to define CSS and expects [=reading systems=] to support it
-							at level of major browsers.</p>
+							at the level of major browsers.</p>
 
 						<p>Although reading systems are expected to support <a
 								data-cite="epub-rs-34#confreq-css-rs-support">CSS as defined in the CSS snapshot</a>
@@ -6284,7 +6284,7 @@ No Entry</pre>
 						</ul>
 
 						<p>Reading systems will typically set some aspects of an [=EPUB publication | EPUB
-							publication's=] style (e.g., setting borders appropriate to the application), potentially
+							publication's=] style (e.g., setting margins appropriate to the application), potentially
 							overriding the [=EPUB creator | EPUB creator's=] instructions. To mitigate conflicts, and
 							any potential rendering problems, EPUB creators are advised to consult reading systems' user
 							agent style sheets, when made publicly available, and adapt their styling choices for

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6198,7 +6198,15 @@ No Entry</pre>
 							provided prefixed versions of numerous other properties. Although the CSS Working Group no
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
-							section, EPUB defers to the W3C to define CSS.</p>
+							section, EPUB defers to the W3C to define CSS and expects reading systems to support it at
+							level of major browsers.</p>
+
+						<p>Although [=Reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
+								defined in the CSS snapshot</a>, the reality is that most reading systems currently do
+							not support all desired features of CSS, and often will modify, and allow users to change,
+							the default presentation defined by the [=EPUB creator=]. As a result, EPUB creators will
+							need to adapt their styling to these realities. For more information, refer to <a
+								href="#sec-css-rs"></a>.</p>
 					</section>
 
 					<section id="sec-css-req" data-epubcheck="true"
@@ -6257,10 +6265,10 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-css-rs" class="informative">
-						<h4>Reading system considerations</h4>
+						<h4>Reading system support considerations</h4>
 
-						<p>[=Reading systems=] do not support all desired features of CSS. The following are known to be
-							particularly problematic:</p>
+						<p>Support for the following CSS features are known to be particularly problematic in [=EPUB
+							reading systems=]:</p>
 
 						<ul>
 							<li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6199,40 +6199,6 @@ No Entry</pre>
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
 							section, EPUB defers to the W3C to define CSS.</p>
-
-						<div class="note">
-							<p>Keep in mind that some [=reading systems=] will not support all desired features of CSS.
-								The following are known to be particularly problematic:</p>
-
-							<ul>
-								<li>
-									<p>Reading system-induced pagination can interact poorly with style sheets as
-										reading systems sometimes paginate using columns. This may result in incorrect
-										values for viewport sizes. Fixed and absolute positioning are particularly
-										problematic.</p>
-								</li>
-								<li>
-									<p>Some types of screens will render animations and transitions poorly (e.g., those
-										with high latency).</p>
-								</li>
-								<li>
-									<p>
-										Creators should be aware that a reading systems usually override some aspects of 
-										the creator's style settings; creators may want to consult the reading systems' 
-										user agent style sheets, if publicly available. Furthermore, reading systems may
-										also modify some rendering aspects as a result of user interaction (e.g., choice 
-										of fonts, text justification, or foreground and background colors).
-									</p>
-								</li>
-								<li>
-									<p>
-										Creators should avoid using [[html]] [^html-global/style^] attributes in content documents. 
-										Styling should always be done via CSS files, otherwise a reading system will 
-										not be able to easily override them when interacting with the user.
-									</p>
-								</li>
-							</ul>
-						</div>
 					</section>
 
 					<section id="sec-css-req" data-epubcheck="true"
@@ -6288,6 +6254,40 @@ No Entry</pre>
 								</li>
 							</ul>
 						</div>
+					</section>
+
+					<section id="sec-css-rs" class="informative">
+						<h4>Reading system considerations</h4>
+
+						<p>[=Reading systems=] do not support all desired features of CSS. The following are known to be
+							particularly problematic:</p>
+
+						<ul>
+							<li>
+								<p>Reading system-induced pagination can interact poorly with style sheets as reading
+									systems sometimes paginate using columns. This may result in incorrect values for
+									viewport sizes. Fixed and absolute positioning are particularly problematic.</p>
+							</li>
+							<li>
+								<p>Some types of screens will render animations and transitions poorly (e.g., those with
+									high latency).</p>
+							</li>
+						</ul>
+
+						<p>Reading systems will typically set some aspects of an [=EPUB publication | EPUB
+							publication's=] style (e.g., setting borders appropriate to the application), potentially
+							overriding the [=EPUB creator | EPUB creator's=] instructions. To mitigate conflicts, and
+							any potential rendering problems, EPUB creators are advised to consult reading systems' user
+							agent style sheets, when made publicly available, and adapt their styling choices for
+							optimal display.</p>
+
+						<p>Furthermore, reading systems that allow users to change the appearance (e.g., choice of
+							fonts, text justification, or foreground and background colors) will also modify some CSS
+							rendering directions in an EPUB publication. Due to CSS precedence rules, it is advisable to
+							limit the use of [[html]] [^html-global/style^] attributes in EPUB content documents so that
+							the user experience is not negatively impacted (i.e., the users' style choices not being
+							universally applied). Although some reading systems will override inline styles, such
+							behavior is not guaranteed.</p>
 					</section>
 
 					<section id="sec-css-prefixed">

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1219,13 +1219,16 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD only do so in
-						a way that allow the author's original design to be restored.</p>
+						publication's] styling (e.g., for ergonomic or user interface reasons). Morevoer, they MAY allow
+						users to set default themes and style preferences (e.g., for more accessible reading) that
+						further alter the original design of a publication.</p>
 
-					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
-						any reading system-applied styling, thereby allowing users to view a publication as designed by
-						the author (e.g., so users can check the original design if a publication refers to location,
-						color, etc. that gets overriden by the reading system styling).</p>
+					<p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
+						publication exactly as designed by an author, even if that is what the user wants. To assist
+						users in viewing an EPUB publication as closely as possible to the author intent, however,
+						reading systems MAY provide an affordance that reverts as much reading system-applied styling as
+						feasible. For example, it could reset any user-applied styling and themes back to the reading
+						system defaults.</p>
 				</section>
 			</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1223,12 +1223,11 @@
 						users to set default themes and style preferences (e.g., for more accessible reading) that
 						further alter the original design of a publication.</p>
 
-					<p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
+					<!-- <p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
 						publication exactly as designed by an author, even if that is what the user wants. To assist
 						users in viewing an EPUB publication as closely as possible to the author intent, however,
 						reading systems MAY provide an affordance that reverts as much reading system-applied styling as
-						feasible. For example, it could reset any user-applied styling and themes back to the reading
-						system defaults.</p>
+						feasible.</p> -->
 				</section>
 			</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1205,13 +1205,16 @@
 							[=EPUB content documents=].</p>
 					</li>
 					<li>
-						<p id="confreq-css-overrides">SHOULD NOT override the EPUB creator's style sheets, but SHOULD do
-							so in a way that preserves the Cascade when necessary: through a user agent style sheet, or
-							[[html]] [^html-global/style^] attributes.</p>
+						<p id="confreq-css-overrides">MAY override parts of the creator's style sheets (for, e.g., ergonomic or 
+							user interface reasons). If it does, it SHOULD do so in a way that preserves the cascade model
+							of CSS: through a user agent style sheet, or [[html]] [^html-global/style^] attributes.
+							Reading system developers should also publicly document the user agent style sheets and how they
+							interact with EPUB creator's style settings.</p>
 					</li>
 					<li>
-						<p id="confreq-css-user-styles">It MAY override parts of the EPUB creator's style sheet because
-							of user interaction.</p>
+						<p id="confreq-css-user-styles">MAY override parts of the EPUB creator's style sheet as a result
+							of user interaction.  It MAY also provide additional user interaction to revert to the default
+							style sheets, with or without the effects of the user agent style sheets.</p>
 					</li>
 				</ul>
 
@@ -1219,8 +1222,7 @@
 					system's user agent style sheet SHOULD support the [[html]] <a data-cite="html#rendering">suggested
 						default rendering</a>.</p>
 
-				<p>Reading system developers should implement CSS support at the level of major browsers and publicly
-					document their user agent style sheets and how they interact with EPUB creator's style sheets.</p>
+				<!-- <p>Reading system developers should implement CSS support at the level of major browsers.</p> -->
 			</section>
 
 			<section id="sec-scripted-content">
@@ -2710,6 +2712,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
+					<li>06-August-2025: Updated the <a href="#sec-css">section on handling CSS</a>, in particular 
+						the relationships between the user agent's and the creators' style sheets. 
+						See discussion in <a href="https://github.com/w3c/epub-specs/issues/2762">issue 2762</a>.
+					</li>
 					<li>05-June-2025: Consolidated all deprecated features under the unsupported features section. See
 						the comments in <a href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035"
 							>pull request 2735</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1038,14 +1038,14 @@
 						<p>Reading system support for the <a data-cite="rdfa-core#s_model">attribute processing
 								model</a> [[rdfa-core]] is OPTIONAL.</p>
 					</section>
-					
+
 					<section id="sec-xhtml-its">
 						<h5>Internationalization Tag Set (ITS)</h5>
-						
+
 						<p>Reading system support for <a data-cite="its20#conformance-product-html5-its">processing ITS
 								markup</a> [[its20]] is OPTIONAL.</p>
 					</section>
-					
+
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom attributes</h5>
 
@@ -1205,22 +1205,29 @@
 							[=EPUB content documents=].</p>
 					</li>
 					<li>
-						<p id="confreq-css-overrides">MAY override parts of the creator's style sheets (for, e.g., ergonomic or 
-							user interface reasons). If it does, it SHOULD preserve as much as possible the cascade model of CSS.
-							Reading system developers are expected to also publicly document the user agent style sheets and how they
-							interact with EPUB creator's style settings.</p>
-					</li>
-					<li>
-						<p id="confreq-css-user-styles">
-							It MAY provide the user with an affordance that reverts the display to the author's stylesheet.</p>
+						<p id="confreq-css-rs-html-default">SHOULD support the [[html]] <a data-cite="html#rendering"
+								>suggested default rendering</a> in their user agent style sheet(s).</p>
 					</li>
 				</ul>
 
-				<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above, a reading
-					system's user agent style sheet SHOULD support the [[html]] <a data-cite="html#rendering">suggested
-						default rendering</a>.</p>
+				<div class="note">
+					<p>Reading system developers are expected to publicly document their user agent style sheet(s) and
+						how they interact with EPUB creator's style settings. </p>
+				</div>
 
-				<!-- <p>Reading system developers should implement CSS support at the level of major browsers.</p> -->
+				<section id="sec-css-overrides">
+					<h4>Author styling overrides</h4>
+
+					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
+						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD use
+						CSS-compatible methods (user agent style sheet, or [[html]] [^style^] attributes) that allow the
+						author's original design to be restored.</p>
+
+					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
+						any reading system-applied styling, thereby allowing users to view a publication as designed by
+						the author (e.g., so users can check the original design if a publication refers to location,
+						color, etc. that gets overriden by the reading system styling).</p>
+				</section>
 			</section>
 
 			<section id="sec-scripted-content">
@@ -2710,11 +2717,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
-					<li>06-August-2025: Updated the <a href="#sec-css">section on handling CSS</a>, in particular 
-						the relationships between the user agent's and the creators' style sheets. 
-						See discussion in <a href="https://github.com/w3c/epub-specs/issues/2762">issue 2762</a>
-						and <a href="https://github.com/w3c/epub-specs/pull/2771">pull request 2771</a>.
-					</li>
+					<li>06-August-2025: Updated the <a href="#sec-css">section on handling CSS</a>, in particular the
+						relationships between the user agent's and the creators' style sheets. See discussion in <a
+							href="https://github.com/w3c/epub-specs/issues/2762">issue 2762</a> and <a
+							href="https://github.com/w3c/epub-specs/pull/2771">pull request 2771</a>. </li>
 					<li>05-June-2025: Consolidated all deprecated features under the unsupported features section. See
 						the comments in <a href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035"
 							>pull request 2735</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1206,15 +1206,13 @@
 					</li>
 					<li>
 						<p id="confreq-css-overrides">MAY override parts of the creator's style sheets (for, e.g., ergonomic or 
-							user interface reasons). If it does, it SHOULD do so in a way that preserves the cascade model
-							of CSS: through a user agent style sheet, or [[html]] [^html-global/style^] attributes.
-							Reading system developers should also publicly document the user agent style sheets and how they
+							user interface reasons). If it does, it SHOULD preserve as much as possible the cascade model of CSS.
+							Reading system developers are expected to also publicly document the user agent style sheets and how they
 							interact with EPUB creator's style settings.</p>
 					</li>
 					<li>
-						<p id="confreq-css-user-styles">MAY override parts of the EPUB creator's style sheet as a result
-							of user interaction.  It MAY also provide additional user interaction to revert to the default
-							style sheets, with or without the effects of the user agent style sheets.</p>
+						<p id="confreq-css-user-styles">
+							It MAY provide the user with an affordance that reverts the display to the author's stylesheet.</p>
 					</li>
 				</ul>
 
@@ -2714,7 +2712,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<ul>
 					<li>06-August-2025: Updated the <a href="#sec-css">section on handling CSS</a>, in particular 
 						the relationships between the user agent's and the creators' style sheets. 
-						See discussion in <a href="https://github.com/w3c/epub-specs/issues/2762">issue 2762</a>.
+						See discussion in <a href="https://github.com/w3c/epub-specs/issues/2762">issue 2762</a>
+						and <a href="https://github.com/w3c/epub-specs/pull/2771">pull request 2771</a>.
 					</li>
 					<li>05-June-2025: Consolidated all deprecated features under the unsupported features section. See
 						the comments in <a href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035"

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1219,8 +1219,8 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's] styling (e.g., for ergonomic or user interface reasons), but only do so in a
-						way that allow the author's original design to be restored.</p>
+						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD only do so in
+						a way that allow the author's original design to be restored.</p>
 
 					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
 						any reading system-applied styling, thereby allowing users to view a publication as designed by

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1219,9 +1219,8 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD use
-						CSS-compatible methods (user agent style sheet, or [[html]] [^style^] attributes) that allow the
-						author's original design to be restored.</p>
+						publication's] styling (e.g., for ergonomic or user interface reasons), but only do so in a
+						way that allow the author's original design to be restored.</p>
 
 					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
 						any reading system-applied styling, thereby allowing users to view a publication as designed by


### PR DESCRIPTION
I have made the PR as discussed in https://github.com/w3c/epub-specs/issues/2762#issuecomment-3151116277 and onwards. 

See also my comments below on the discussion in #2762.

Fix #2762

***
See:

* For EPUB 3.4:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/css-sections-review-(issue-2762)/epub34/authoring/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/authoring/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/css-sections-review-(issue-2762)/epub34/authoring/index.html)
* For EPUB 3.4 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/css-sections-review-(issue-2762)/epub34/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/css-sections-review-(issue-2762)/epub34/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2771.html" title="Last updated on Sep 5, 2025, 1:56 PM UTC (d8c5510)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2771/da1c954...d8c5510.html" title="Last updated on Sep 5, 2025, 1:56 PM UTC (d8c5510)">Diff</a>