### PR TITLE
Adjusted text color for the 'support' class in dark mode

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -355,6 +355,11 @@ body.darkmode p.caution, body.darkmode div.caution {
     background-color: hsl(180, 40%, 20%);
 }
 
+body.darkmode p.support, body.darkmode div.support {
+    background-color: rgb(255, 255, 230);
+    color: rgb(30, 30, 30)
+}
+
 body.darkmode div.caution-title > span {
     color: rgb(255,140,0)
 }


### PR DESCRIPTION
The color was a light gray on yellowish background, which was unreadable. I set the text color to dark gray and left the background as is.

Best seen on its effect on RS:

See:

* For EPUB 3.4 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/support-class-in-dark-mode/epub34/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/support-class-in-dark-mode/epub34/rs/index.html)
