### PR TITLE
Updates to FXL A11y 

### DIFF
--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -958,7 +958,7 @@ This publication has not been accessibility tested, or had remediation work done
 
                 <p>In cases where the EPUB creator has included fallbacks for potentially unsupported content (e.g. MathML, audio, video), the reading system should support fallbacks. EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section.</p>
 
-                <aside class="issue" title="Open issues regarding fallbacks">
+                <aside class="issue" title="Open issues regarding fallbacks" data-number="2773">
                     <p>The Publishing Maintenance WG repository currently has an open issue regarding fallback support and their use in fixed layout content. This is part of a broader issue with fallbacks that will require discussion with the group. Anyone interested in this topic is asked to contribute to the discussion.</p>
 
                     <ul>

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -185,6 +185,8 @@
             <p>EPUB 3.3 [[epub-33]] supports multiple methods for content development, particularly for fixed layout content. The two primary methods are to use XHTML and SVG for building EPUB content documents. A third method used in many EPUB fixed layout books is to reference image files in the spine of the EPUB file. We will discuss the accessibility considerations for all three methods in this document.</p>
 
             <p>In addition to the core technologies mentioned in the EPUB 3.3 recommendation, EPUB accessibility may also require the use of the Accessible Rich Internet Applications [[wai-aria-1.2]] and Digital Publishing WAI-ARIA [[dpub-aria-1.1]] recommendations.</p>
+
+            <p>EPUB content creators should be aware that regardless of the format of the EPUB, reflowable or fixed layout, content may be rendered in alternative ways. We have provided information for reading systems on <a href="#rs-a11y-alt-rendering">alternative rendering methods</a>, but creators should consider alternative rendering methods in the development of the content as well. EPUB content can be rendered visually, audibly, or even in tactile formats. When developing fixed layout content, keep in mind that the reader may not experience the content visually. This document aims to provide guidance for content creators that will enable them to create content that can be consumed in non-visual ways.</p>
         </section>
 
         <section id="reading-order">
@@ -674,6 +676,19 @@
             </pre>
         </aside>
 
+        <section id="using-fallbacks">
+            <h3>Using manifest fallbacks in fixed layout EPUBs<h3>
+
+            <p>If using fallbacks, EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section. It is important to note that manifest fallbacks are most commonly used to support content that may not be supported by the reading system, such as MathML, audio, or video. Fallback support in reading systems is mixed, so fallbacks should not be relied on for providing accessible alternatives to fixed layout content or images.</p>
+
+            <aside class="issue" title="Open issues regarding fallbacks" data-number="2773">
+                    <p>The Publishing Maintenance WG repository currently has an open issue regarding fallback support and their use in fixed layout content. This is part of a broader issue with fallbacks that will require discussion with the group. Anyone interested in this topic is asked to contribute to the discussion.</p>
+
+                    <ul>
+                        <li><a href="https://github.com/w3c/epub-specs/issues/2773">Fallback definition and authoring guidance is missing</a></li>
+                    </ul>
+            </aside>
+        </section>
 
         <section id="a11y-metadata">
             <h3>Examples of accessibility metadata</h3>
@@ -957,14 +972,6 @@ This publication has not been accessibility tested, or had remediation work done
                 <h4>Support fallbacks</h4>
 
                 <p>In cases where the EPUB creator has included fallbacks for potentially unsupported content (e.g. MathML, audio, video), the reading system should support fallbacks. EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section.</p>
-
-                <aside class="issue" title="Open issues regarding fallbacks" data-number="2773">
-                    <p>The Publishing Maintenance WG repository currently has an open issue regarding fallback support and their use in fixed layout content. This is part of a broader issue with fallbacks that will require discussion with the group. Anyone interested in this topic is asked to contribute to the discussion.</p>
-
-                    <ul>
-                        <li><a href="https://github.com/w3c/epub-specs/issues/2773">Fallback definition and authoring guidance is missing</a></li>
-                    </ul>
-                </aside>
             </section>
         </section>
 

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -673,22 +673,22 @@
 &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
             </pre>
         </aside>
-    </section>
 
-    <section id="a11y-metadata">
-        <h2>Examples of accessibility metadata</h2>
 
-        <p>Books with accessible elements require metadata to indicate how they are accessible, and if they present any hazards to the reader. A full description of accessibility metadata in EPUB can be found in <a href="https://www.w3.org/TR/epub-a11y-11/#sec-discovery">section 2</a> of EPUB Accessibility 1.1 [[epub-a11y-11]] and the <a href="https://www.w3.org/community/reports/a11y-discov-vocab/CG-FINAL-vocabulary-20230718/">Schema.org Accessibility Properties for Discoverability Vocabulary</a>.</p>
+        <section id="a11y-metadata">
+            <h3>Examples of accessibility metadata</h3>
 
-        <p>The <a href="https://kb.daisy.org/publishing/docs/metadata/schema.org/index.html">DAISY Knowledge Base</a> also provides excellent guidance on the usage and definitions of Schema.org metadata in an EPUB file. In this section, we have provided some examples of what this metadata might look like depending on different fixed layout use cases.</p>
+            <p>Books with accessible elements require metadata to indicate how they are accessible, and if they present any hazards to the reader. A full description of accessibility metadata in EPUB can be found in <a href="https://www.w3.org/TR/epub-a11y-11/#sec-discovery">section 2</a> of EPUB Accessibility 1.1 [[epub-a11y-11]] and the <a href="https://www.w3.org/community/reports/a11y-discov-vocab/CG-FINAL-vocabulary-20230718/">Schema.org Accessibility Properties for Discoverability Vocabulary</a>.</p>
 
-        <section id="a11y-metadata-childrens-book">
-            <h3>Accessibility metadata for a children's picture book</h3>
+            <p>The <a href="https://kb.daisy.org/publishing/docs/metadata/schema.org/index.html">DAISY Knowledge Base</a> also provides excellent guidance on the usage and definitions of Schema.org metadata in an EPUB file. In this section, we have provided some examples of what this metadata might look like depending on different fixed layout use cases.</p>
 
-            <p>A common use for fixed layout is children's picture books, which feature expressive illustrations and small amounts of text. In this example, this is a book where the EPUB creator has done everything needed for accessibility.</p>
+            <section id="a11y-metadata-childrens-book">
+                <h4>Accessibility metadata for a children's picture book</h4>
 
-            <aside class="example" title="Accessibility metadata for a children's book">
-                <pre>
+                <p>A common use for fixed layout is children's picture books, which feature expressive illustrations and small amounts of text. In this example, this is a book where the EPUB creator has done everything needed for accessibility.</p>
+
+                <aside class="example" title="Accessibility metadata for a children's book">
+                    <pre>
 &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
 &lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
@@ -701,17 +701,17 @@
 &lt;meta property="schema:accessibilitySummary"&gt;
 This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
 &lt;/meta&gt;
-                </pre>
-            </aside>
-        </section>
+                    </pre>
+                </aside>
+            </section>
 
-        <section id="a11y-metadata-cookbook">
-            <h3>Accessibility metadata for a cookbook</h3>
+            <section id="a11y-metadata-cookbook">
+                <h4>Accessibility metadata for a cookbook</h4>
 
-            <p>Cookbooks are commonly formatted using fixed layout, due to their highly visual layout. In this example, the publisher has created a cookbook that meets accessibility requirements, including providing a detailed table of contents and index.</p>
+                <p>Cookbooks are commonly formatted using fixed layout, due to their highly visual layout. In this example, the publisher has created a cookbook that meets accessibility requirements, including providing a detailed table of contents and index.</p>
 
-            <aside class="example" title="Accessibility metadata for a cookbook">
-                <pre>
+                <aside class="example" title="Accessibility metadata for a cookbook">
+                    <pre>
 &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
 &lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
@@ -726,17 +726,17 @@ This publication conforms to all the success criteria of WCAG 2.1 AA with the ex
 &lt;meta property="schema:accessibilitySummary"&gt;
 This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
 &lt;/meta&gt;
-                </pre>
-            </aside>
-        </section>
+                    </pre>
+                </aside>
+            </section>
 
-        <section id="a11y-metadata-mo-hazard">
-            <h3>Accessibility metadata for a children's book with media overlays</h3>
+            <section id="a11y-metadata-mo-hazard">
+                <h4>Accessibility metadata for a children's book with media overlays</h4>
 
-            <p>This example is for a children's book that uses media overlays. The audio for the book contains a potential sound hazard, so it is declared in <code>accessibilityHazard</code> and further detail is provided in the <code>accessibilitySummary</code>.</p>
+                <p>This example is for a children's book that uses media overlays. The audio for the book contains a potential sound hazard, so it is declared in <code>accessibilityHazard</code> and further detail is provided in the <code>accessibilitySummary</code>.</p>
 
-            <aside class="example" title="Accessibility metadata for a children's book with media overlays">
-                <pre>
+                <aside class="example" title="Accessibility metadata for a children's book with media overlays">
+                    <pre>
 &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
 &lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
@@ -751,17 +751,17 @@ This publication conforms to all the success criteria of WCAG 2.1 AA with the ex
 &lt;meta property="schema:accessibilitySummary"&gt;
 This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains synchronized audio along with the text. Readers should be advised that the audio for this book includes a loud bang on page 7. There are no other audio hazards in the book. 
 &lt;/meta&gt;
-                </pre>
-            </aside>
-        </section>
+                    </pre>
+                </aside>
+            </section>
 
-        <section id="a11y-metadata-textbook">
-            <h3>Accessibility metadata for a textbook with video</h3>
+            <section id="a11y-metadata-textbook">
+                <h4>Accessibility metadata for a textbook with video</h4>
 
-            <p>This example features a textbook that includes video content. The video content does not include audio descriptions, but as described in <code>accessibilitySummary</code>, the EPUB creator fully describes the video content in surrounding text. There are potential hazards due to the type of video content.</p>
+                <p>This example features a textbook that includes video content. The video content does not include audio descriptions, but as described in <code>accessibilitySummary</code>, the EPUB creator fully describes the video content in surrounding text. There are potential hazards due to the type of video content.</p>
 
-            <aside class="example" title="Accessibility metadata for a textbook with video">
-                <pre>
+                <aside class="example" title="Accessibility metadata for a textbook with video">
+                    <pre>
 &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
 &lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
@@ -779,36 +779,39 @@ This publication conforms to all the success criteria of WCAG 2.1 AA with the ex
 &lt;meta property="schema:accessibilitySummary"&gt;
 This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains video content that illustrates what is described in the text. The video content does not have audio descriptions as they are fully described in the surrounding text for each video. The video content may pose a flashing or motion simulation hazard for some readers, to reduce the risk of a hazard, all videos have been set to only play when triggered by the reader.
 &lt;/meta&gt;
-                </pre>
-            </aside>
-        </section>
+                    </pre>
+                </aside>
+            </section>
 
-        <section id="a11y-metadata-unremediated">
-            <h3>Accessibility metadata for a book that has not been remediated yet</h3>
+            <section id="a11y-metadata-unremediated">
+                <h4>Accessibility metadata for a book that has not been remediated yet</h4>
 
-            <p>As EPUB creators work on remediating their catalogues, some books may not be fully accessible or tested against WCAG requirements. It is helpful for readers to know the status of a book, even if it is not yet accessible, so they can make informed decisions when buying or borrowing.</p>
+                <p>As EPUB creators work on remediating their catalogues, some books may not be fully accessible or tested against WCAG requirements. It is helpful for readers to know the status of a book, even if it is not yet accessible, so they can make informed decisions when buying or borrowing.</p>
 
-            <pre class="example" title="Accessibility metadata for a book that is not remediated">
+                <aside class="example" title="Accessibility metadata for a book that is not remediated">
+                    <pre>
 &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessModeSufficient"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessibilityFeature"&gt;unknown&lt;/meta&gt;
 &lt;meta property="schema:accessibilitySummary"&gt;
 This publication has not been accessibility tested, or had remediation work done. If there are any questions about this book's content, or an urgent need for an accessible edition of this book, please contact us at [help]@[publisher].com.
-            </pre>
-        </section>
+                    </pre>
+                </aside>
+            </section>
 
-        <section id="a11y-metadata-manga">
-            <h3>Accessibility metadata for a manga EPUB</h3>
+            <section id="a11y-metadata-manga">
+                <h4>Accessibility metadata for a manga EPUB</h4>
 
-            <p>Manga is commonly distributed in fixed layout EPUB format, either with images as spine items or embedded in individual XHTML files for each page. Most manga features images where the text is part of the image and not provided separately.</p>
+                <p>Manga is commonly distributed in fixed layout EPUB format, either with images as spine items or embedded in individual XHTML files for each page. Most manga features images where the text is part of the image and not provided separately.</p>
 
-            <aside class="example" title="Accessibility metadata for a manga EPUB">
-                <pre>
+                <aside class="example" title="Accessibility metadata for a manga EPUB">
+                    <pre>
 &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessModeSufficient"&gt;visual&lt;/meta&gt;
 &lt;meta property="schema:accessibilityFeature"&gt;none&lt;/meta&gt;
-                </pre>
-            </aside>
+                    </pre>
+                </aside>
+            </section>
         </section>
     </section>
 

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -957,6 +957,14 @@ This publication has not been accessibility tested, or had remediation work done
                 <h4>Support fallbacks</h4>
 
                 <p>In cases where the EPUB creator has included fallbacks for potentially unsupported content (e.g. MathML, audio, video), the reading system should support fallbacks. EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section.</p>
+
+                <aside class="issue" title="Open issues regarding fallbacks">
+                    <p>The Publishing Maintenance WG repository currently has an open issue regarding fallback support and their use in fixed layout content. This is part of a broader issue with fallbacks that will require discussion with the group. Anyone interested in this topic is asked to contribute to the discussion.</p>
+
+                    <ul>
+                        <li><a href="https://github.com/w3c/epub-specs/issues/2773">Fallback definition and authoring guidance is missing</a></li>
+                    </ul>
+                </aside>
             </section>
         </section>
 

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -677,7 +677,7 @@
         </aside>
 
         <section id="using-fallbacks">
-            <h3>Using manifest fallbacks in fixed layout EPUBs<h3>
+            <h3>Using manifest fallbacks in fixed layout EPUBs</h3>
 
             <p>If using fallbacks, EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section. It is important to note that manifest fallbacks are most commonly used to support content that may not be supported by the reading system, such as MathML, audio, or video. Fallback support in reading systems is mixed, so fallbacks should not be relied on for providing accessible alternatives to fixed layout content or images.</p>
 

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -975,6 +975,8 @@ This publication has not been accessibility tested, or had remediation work done
 
             <p>If the fixed layout publication does not conform to the recommendations made in this document, or WCAG [[wcag2]], providing alternate renderings of the content may result in an unusable or poor reading experience. Content that is not formatted in conformance with WCAG may result in output that has an incorrect reading order, broken sentences, or choppy pronounciation. The user should be informed if the content does not have accessibility metadata that would provide clarity on whether alternate renderings are supported, such as <code>dcterms:conformsTo</code> with a value for WCAG, or metadata values that conform to properties like <a href="https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/#supports-nonvisual-reading">Supports nonvisual reading</a> from the <a href="https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/">User Experience Guide for Displaying Accessibility Metadata</a>.</p>
 
+            <p>Fixed layout publications that do conform to the recommendations in this document and WCAG 2 will likely be compatible with any alternate rendering features that may be built into reading systems.</p>
+
             <p class="ednote">The <a href="https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/">User Experience Guide for Displaying Accessibility Metadata</a> is currently a draft document and is subject to change.</p>
 
             <p>There are ongoing discussions about transforming visual publications into reflowable textual content for complete AA compliance. While these are not in production yet, by creating our fixed layout with logical reading order, full image descriptions, and good semantics and structure where possible we are preparing our files in the best way for these future developments.</p>
@@ -996,6 +998,8 @@ This publication has not been accessibility tested, or had remediation work done
                 <p>How a reading system implements TTS will depend on multiple factors, including platform, underlying operating system, or technical feasibility. There are a variety of TTS APIs and speech engines available. An example is the <a href="https://wicg.github.io/speech-api/">Web Speech API</a> from W3C Web Platform Incubator Community Group. Reading system developers can test their support of TTS with Epubtest.org's <a href="https://epubtest.org/test-books/read-aloud">Fundamental Accessibility Tests Read Aloud</a>.</p>
 
                 <p>The <a href="https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te">Accessible Name and Description Computation</a> draft specification is another useful reference in implementing a text to speech experience.</p>
+
+                <p>EPUB publications that follow best practices for accessibility and fixed layout content will be compatible with most TTS implementations.</p>
             </section>
 
         </section>


### PR DESCRIPTION
Two editorial updates:
1. Merge sections 3 and 4 to create one section on metadata instead of 2. 
2. Added an issue about fallbacks.

One addition to the document is adding text about accessible FXL documents being potentially compatible with reading systems that offer alternate rendering methods or TTS. 

---

See:

* For EPUB Fixed Layout Accessibility:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fxl-a11y-updates/wg-notes/fxl-a11y/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/wg-notes/fxl-a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fxl-a11y-updates/wg-notes/fxl-a11y/index.html)
