### PR TITLE
Change css intro note into a separate section

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6201,7 +6201,7 @@ No Entry</pre>
 							section, EPUB defers to the W3C to define CSS and expects reading systems to support it at
 							level of major browsers.</p>
 
-						<p>Although [=Reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
+						<p>Although [=reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
 								defined in the CSS snapshot</a>, the reality is that most reading systems currently do
 							not support all desired features of CSS, and often will modify, and allow users to change,
 							the default presentation defined by the [=EPUB creator=]. As a result, EPUB creators will

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6198,15 +6198,16 @@ No Entry</pre>
 							provided prefixed versions of numerous other properties. Although the CSS Working Group no
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
-							section, EPUB defers to the W3C to define CSS and expects reading systems to support it at
-							level of major browsers.</p>
+							section, EPUB defers to the W3C to define CSS and expects [=reading systems=] to support it
+							at level of major browsers.</p>
 
-						<p>Although [=reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
-								defined in the CSS snapshot</a>, the reality is that most reading systems currently do
-							not support all desired features of CSS, and often will modify, and allow users to change,
-							the default presentation defined by the [=EPUB creator=]. As a result, EPUB creators will
-							need to adapt their styling to these realities. For more information, refer to <a
-								href="#sec-css-rs"></a>.</p>
+						<p>Although reading systems are expected to support <a
+								data-cite="epub-rs-34#confreq-css-rs-support">CSS as defined in the CSS snapshot</a>
+							[[epub-rs-34]], the reality is that most reading systems currently do not support all
+							desired features of CSS, and often will modify, and allow users to change, the default
+							presentation defined by the [=EPUB creator=]. As a result, EPUB creators will need to adapt
+							their styling to these realities. For more information, refer to <a href="#sec-css-rs"
+							></a>.</p>
 					</section>
 
 					<section id="sec-css-req" data-epubcheck="true"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6199,7 +6199,7 @@ No Entry</pre>
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
 							section, EPUB defers to the W3C to define CSS and expects [=reading systems=] to support it
-							at level of major browsers.</p>
+							at the level of major browsers.</p>
 
 						<p>Although reading systems are expected to support <a
 								data-cite="epub-rs-34#confreq-css-rs-support">CSS as defined in the CSS snapshot</a>
@@ -6284,7 +6284,7 @@ No Entry</pre>
 						</ul>
 
 						<p>Reading systems will typically set some aspects of an [=EPUB publication | EPUB
-							publication's=] style (e.g., setting borders appropriate to the application), potentially
+							publication's=] style (e.g., setting margins appropriate to the application), potentially
 							overriding the [=EPUB creator | EPUB creator's=] instructions. To mitigate conflicts, and
 							any potential rendering problems, EPUB creators are advised to consult reading systems' user
 							agent style sheets, when made publicly available, and adapt their styling choices for

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6198,7 +6198,15 @@ No Entry</pre>
 							provided prefixed versions of numerous other properties. Although the CSS Working Group no
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
-							section, EPUB defers to the W3C to define CSS.</p>
+							section, EPUB defers to the W3C to define CSS and expects reading systems to support it at
+							level of major browsers.</p>
+
+						<p>Although [=Reading systems=] are expected to support <a href="confreq-css-rs-support">CSS as
+								defined in the CSS snapshot</a>, the reality is that most reading systems currently do
+							not support all desired features of CSS, and often will modify, and allow users to change,
+							the default presentation defined by the [=EPUB creator=]. As a result, EPUB creators will
+							need to adapt their styling to these realities. For more information, refer to <a
+								href="#sec-css-rs"></a>.</p>
 					</section>
 
 					<section id="sec-css-req" data-epubcheck="true"
@@ -6257,10 +6265,10 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-css-rs" class="informative">
-						<h4>Reading system considerations</h4>
+						<h4>Reading system support considerations</h4>
 
-						<p>[=Reading systems=] do not support all desired features of CSS. The following are known to be
-							particularly problematic:</p>
+						<p>Support for the following CSS features are known to be particularly problematic in [=EPUB
+							reading systems=]:</p>
 
 						<ul>
 							<li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6199,40 +6199,6 @@ No Entry</pre>
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
 							section, EPUB defers to the W3C to define CSS.</p>
-
-						<div class="note">
-							<p>Keep in mind that some [=reading systems=] will not support all desired features of CSS.
-								The following are known to be particularly problematic:</p>
-
-							<ul>
-								<li>
-									<p>Reading system-induced pagination can interact poorly with style sheets as
-										reading systems sometimes paginate using columns. This may result in incorrect
-										values for viewport sizes. Fixed and absolute positioning are particularly
-										problematic.</p>
-								</li>
-								<li>
-									<p>Some types of screens will render animations and transitions poorly (e.g., those
-										with high latency).</p>
-								</li>
-								<li>
-									<p>
-										Creators should be aware that a reading systems usually override some aspects of 
-										the creator's style settings; creators may want to consult the reading systems' 
-										user agent style sheets, if publicly available. Furthermore, reading systems may
-										also modify some rendering aspects as a result of user interaction (e.g., choice 
-										of fonts, text justification, or foreground and background colors).
-									</p>
-								</li>
-								<li>
-									<p>
-										Creators should avoid using [[html]] [^html-global/style^] attributes in content documents. 
-										Styling should always be done via CSS files, otherwise a reading system will 
-										not be able to easily override them when interacting with the user.
-									</p>
-								</li>
-							</ul>
-						</div>
 					</section>
 
 					<section id="sec-css-req" data-epubcheck="true"
@@ -6288,6 +6254,40 @@ No Entry</pre>
 								</li>
 							</ul>
 						</div>
+					</section>
+
+					<section id="sec-css-rs" class="informative">
+						<h4>Reading system considerations</h4>
+
+						<p>[=Reading systems=] do not support all desired features of CSS. The following are known to be
+							particularly problematic:</p>
+
+						<ul>
+							<li>
+								<p>Reading system-induced pagination can interact poorly with style sheets as reading
+									systems sometimes paginate using columns. This may result in incorrect values for
+									viewport sizes. Fixed and absolute positioning are particularly problematic.</p>
+							</li>
+							<li>
+								<p>Some types of screens will render animations and transitions poorly (e.g., those with
+									high latency).</p>
+							</li>
+						</ul>
+
+						<p>Reading systems will typically set some aspects of an [=EPUB publication | EPUB
+							publication's=] style (e.g., setting borders appropriate to the application), potentially
+							overriding the [=EPUB creator | EPUB creator's=] instructions. To mitigate conflicts, and
+							any potential rendering problems, EPUB creators are advised to consult reading systems' user
+							agent style sheets, when made publicly available, and adapt their styling choices for
+							optimal display.</p>
+
+						<p>Furthermore, reading systems that allow users to change the appearance (e.g., choice of
+							fonts, text justification, or foreground and background colors) will also modify some CSS
+							rendering directions in an EPUB publication. Due to CSS precedence rules, it is advisable to
+							limit the use of [[html]] [^html-global/style^] attributes in EPUB content documents so that
+							the user experience is not negatively impacted (i.e., the users' style choices not being
+							universally applied). Although some reading systems will override inline styles, such
+							behavior is not guaranteed.</p>
 					</section>
 
 					<section id="sec-css-prefixed">


### PR DESCRIPTION
This is a start on how I'd suggest reworking the note under discussion in pr #2771 into a separate informative section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2778.html" title="Last updated on Aug 15, 2025, 7:01 PM UTC (8c85c6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2778/86d6b16...8c85c6a.html" title="Last updated on Aug 15, 2025, 7:01 PM UTC (8c85c6a)">Diff</a>