### PR TITLE
Used subsections for annotations; used he/she for persons

### DIFF
--- a/wg-notes/annotations-ucr/index.html
+++ b/wg-notes/annotations-ucr/index.html
@@ -1,132 +1,198 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="color-scheme" content="light dark" />
+        <title>EPUB Annotations Use Cases and Requirement</title>
+        <script
+            src="https://www.w3.org/Tools/respec/respec-w3c"
+            class="remove"
+        ></script>
+        <script src="../../common/js/css-inline.js" class="remove"></script>
+        <script class="remove">
+            var respecConfig = {
+                group: "pm",
+                wgPublicList: "public-pm-wg",
+                specStatus: "ED",
+                shortName: "epub-ann-ucr",
+                noRecTrack: true,
+                edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/annotations-ucr/",
+                copyrightStart: "2025",
+                editors: [
+                    {
+                        name: "Laurent Le Meur",
+                        company: "EDRLab",
+                        companyURL: "https://www.edrlab.org",
+                        w3cid: 91888,
+                    },
+                ],
+                includePermalinks: true,
+                permalinkEdge: true,
+                permalinkHide: false,
+                github: {
+                    repoURL: "https://github.com/w3c/epub-specs",
+                    branch: "main",
+                },
+                preProcess: [inlineCustomCSS],
+                xref: {
+                    profile: "web-platform",
+                    specs: ["epub-34"],
+                },
+            };
+        </script>
+    </head>
 
-	<head>
-		<meta charset="utf-8" />
-		<meta name="color-scheme" content="light dark" />
-		<title>EPUB Annotations Use Cases and Requirement</title>
-		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../../common/js/css-inline.js" class="remove"></script>
-		<script class="remove">
-			var respecConfig = {
-				group: "pm",
-				wgPublicList: "public-pm-wg",
-				specStatus: "ED",
-				shortName: "epub-ann-ucr",
-				noRecTrack: true,
-				edDraftURI: "https://w3c.github.io/epub-specs/wg-notes/annotations-ucr/",
-				copyrightStart: "2025",
-				editors: [
-					{
-						name: "Laurent Le Meur",
-						company: "EDRLab",
-						companyURL: "https://www.edrlab.org",
-						"w3cid": 91888
-					}
-				],
-				includePermalinks: true,
-				permalinkEdge: true,
-				permalinkHide: false,
-				github: {
-					repoURL: "https://github.com/w3c/epub-specs",
-					branch: "main"
-				},
-				preProcess: [inlineCustomCSS],
-				xref: {
-					profile: "web-platform",
-					specs: ["epub-34"]
-				},
-
-			};
-		</script>
-	</head>
-
-	<body>
-		<section id="abstract">
-			<p>Lorem ipsum…</p>
+    <body>
+        <section id="abstract">
+            <p>Lorem ipsum…</p>
+        </section>
+        <section id="sotd"></section>
+        <section>
+            <h2>Annotating</h2>
+            <section>
+                <h3>Annotating a textual section</h3>
+                <p>
+                    A user decides to annotate a textual section of an EPUB. She
+                    selects the section, triggers the annotation affordance,
+                    optionally enters a note, selects a highlight mode and
+                    color. She then saves the annotation. The selected section
+                    appears on the page with the chosen highlight.
+                </p>
+            </section>
+            <section>
+                <h3>Annotating an image</h3>
+                <p>
+                    A user decides to annotate an image of an EPUB. He selects
+                    the image and triggers the annotation affordance. The
+                    annotation feature is then identical to the one associated
+                    with a textual selection.
+                </p>
+            </section>
+            <section>
+                <h3>Annotation parts of an image</h3>
+                <p>
+                    A user consults an EPUB publication that includes detailed
+                    diagrams (e.g., in SVG) and images (e.g., in JPG or PNG)
+                    visualizing a research data set. She analyses the data by
+                    annotating <em>parts</em> of the diagrams and/or images by
+                    selecting rectangular areas of the data visualization and
+                    shares these annotations with her colleagues.
+                </p>
+            </section>
+        </section>
+        <section>
+            <h2>Formatting annotations</h2>
+            <p>
+                A user adds an annotation to an EPUB. He adds some formatting to
+                the text of the annotation: emphasize, italic, underline,
+                subtitles.
+            </p>
+        </section>
+        <section>
+            <h2>Bookmarking</h2>
+            <p>
+                A user decides to bookmark a location in a reflowable EPUB. The
+                cursor is located where the user clicks on the screen, or at a
+                default location (often the top-left corner of the screen, for
+                left-to-right content). The user triggers the bookmark
+                affordance, optionally selects a highlight mode & color, and
+                saves the bookmark. A bookmark icon appears on the page, near
+                the line where the cursor was positioned when the bookmark was
+                created.
+            </p>
+        </section>
+        <section>
+            <h2>Exporting &amp; importing annotations and bookmarks</h2>
+            <section>
+				<h3>Publishing a book with annotations</h3>
+            	<p>
+	                A famous author annotates a book she has just written, and deals
+	                with his publisher a specific edition of the EPUB version of the
+	                book which includes these annotations. Readers buy this highly
+	                marketed edition, open it with a reading system that supports
+	                this specification, and benefit from the author's notes.
+	            </p>
+            </section>
+            <section>
+				<h3>Exporting a book with annotations</h3>
+            	<p>
+	                A user exports from a reading system an EPUB he has previously
+	                annotated. He decides to save his annotations and bookmarks in
+	                the EPUB package. If he imports the ebook into another reading
+	                system that supports this specification, annotations and
+	                bookmarks automatically appear.
+	            </p>
+            </section>
+            <section>
+				<h3>Annotations used in the publishing workflow</h3>
+            	<p>
+	                A copy-editor verifies an EPUB before publication. She opens the
+	                EPUB in a reading system that supports this specification,
+	                annotates text containing typos and images with missing
+	                descriptions. She exports his set of annotations on a destination
+	                folder with a specific file name, and provides the file to the
+	                EPUB creator. The EPUB creator associates the annotation set
+	                with the EPUB file in an editing tool that supports this
+	                specification, goes through the annotations, and corrects the
+	                EPUB.
+	            </p>
+            </section>
+            <section>
+				<h3>Annotation used in the classroom</h3>
+            	<p>
+	                A teacher reads an ebook and prepares some annotations. He adds
+	                a keyword to each annotation so that students can group them
+	                easily; examples of keywords include “clarification”,
+	                “question”, and “interpretation” (1). He exports an annotation
+	                file and shares this file with his students. His name (or
+	                nickname) is attached to each annotation. The students import
+	                the ebook, and then the detached annotation file into their
+	                reading application. The annotations made by the teacher appear
+	                in the ebook. Students can add their annotations to the ebook
+	                and send them back to the teacher.
+	            </p>
+            </section>
+        </section>
+        <section>
+            <h2>Synchronizing annotations and bookmarks</h2>
+				<section>
+					<h3>Synchronizing annotation among devices</h3>
+					<p>
+						A user annotates an EPUB. She synchronizes her annotations and
+						bookmarks with her other personal devices via a standardized
+						Cloud mechanism supported by each of these systems.
+					</p>
+				</section>
+				<section>
+					<h3>Sharing annotations among readers</h3>
+					<p>
+		                Participants to a book club read the same EPUB ebook during a
+		                period of time, in a reading system that supports this
+		                specification. Each participant adds notes to the book, and
+		                these annotations are shared via a standardized Cloud mechanism
+		                supported by their reading system. The name of each participant
+		                appears, so that each participant can see who made which
+		                annotation.
+		            </p>
+				</section>
 		</section>
-		<section id="sotd"></section>
-		<section>
-
-			<h2>Annotating</h2>
-			<p>
-				A user decides to annotate a textual section of an EPUB. 
-				He selects the section, triggers the annotation affordance, optionally enters a note, selects a highlight mode and color. 
-				He then saves the annotation. 
-				The selected section appears on the page with the chosen highlight.
-			</p>
-			<p>
-				A user decides to annotate an image of an EPUB. 
-				He selects the image and triggers the annotation affordance. 
-				The annotation feature is then identical to the one associated with a textual selection.
-			</p>
-			<p>
-				A user consults an EPUB publication that includes detailed diagrams (e.g., in SVG) and images (e.g., in JPG or PNG) visualizing 
-				a research data set. 
-				She analyses the data by annotating <em>portions</em> of the diagrams and/or images by selecting rectangular areas of 
-				the data visualization and shares these annotations with her colleagues.
-			</p>
-		</section>
-		<section>
-			<h2>Formatting annotations</h2>
-			<p>
-				A user adds an annotation to an EPUB. He adds some formatting to the text of the annotation: emphasize, italic, underline, subtitles.
-			</p>
-		</section>
-		<section>
-			<h2>Bookmarking</h2>
-			<p>
-				A user decides to bookmark a location in a reflowable EPUB. The cursor is located where the user clicks on the screen, or at a default location (often the top-left corner of the screen, for left-to-right content). 
-				The user triggers the bookmark affordance, optionally selects a highlight mode & color, and saves the bookmark. 
-				A bookmark icon appears on the page, near the line where the cursor was positioned when the bookmark was created.
-			</p>
-		</section>
-		<section>
-			<h2>Exporting &amp; importing annotations and bookmarks</h2>
-			<p>
-				A famous author annotates a book he has just written, and deals with his publisher a specific edition of the EPUB version of the book which includes these annotations. 
-				Readers buy this highly marketed edition, open it with a reading system that supports this specification, and benefit from the author's notes.
-			</p>
-			<p>
-				A user exports from a reading system an EPUB he has previously annotated. 
-				He decides to save his annotations and bookmarks in the EPUB package. 
-				If he imports the ebook into another reading system that supports this specification, annotations and bookmarks automatically appear.
-			</p>
-			<p>
-				A copy-editor verifies an EPUB before publication. He opens the EPUB in a reading system that supports this specification, annotates text containing typos and images with missing descriptions. He exports his set of annotations on a destination folder with a specific file name, and provides the file to the EPUB creator. 
-				The EPUB creator associates the annotation set with the EPUB file in an editing tool that supports this specification, goes through the annotations, and corrects the EPUB.
-			</p>
-			<p>
-				A teacher reads an ebook and prepares some annotations. 
-				He adds a keyword to each annotation so that students can group them easily; examples of keywords include “clarification”, “question”, and “interpretation” (1). 
-				He exports an annotation file and shares this file with his students. 
-				His name (or nickname) is attached to each annotation. 
-				The students import the ebook, and then the detached annotation file into their reading application. 
-				The annotations made by the teacher appear in the ebook. 
-				Students can add their annotations to the ebook and send them back to the teacher. 
-			</p>
-		</section>
-		<section>
-			<h2>Synchronising annotations and bookmarks</h2>
-			<p>				
-				A user annotates an EPUB. He synchronises his annotations and bookmarks with his other personal devices via a standardized Cloud mechanism supported by each of these systems.
-			</p>
-			<p>
-				Participants to a book club read the same EPUB ebook during a period of time, in a reading system that supports this specification. Each participant adds notes to the book, and these annotations are shared via a standardized Cloud mechanism supported by their reading system. The name of each participant appears, so that each participant can see who made which annotation.
-			</p>
-		</section>
-		<section>
-			<h2>Surviving versioning</h2>
-			<p>
-				A user has annotated a textual section of an EPUB and closed the ebook. 
-				Today, he loads a new version of the EPUB in his reading system. The spine item in which the annotations were created has been modified, and some words have been added to the leaf HTML element in which an annotation was created, before the start of the annotation and in the annotated text itself. 
-				Still, the user gets the annotation at the proper location.
-			</p>
-			<p>
-				The same user loads a new edition of the EPUB in his reading system. A new resource - a foreword - has been added to the spine, and the page list has been modified. 
-				Still, the user gets the annotation at the proper location.
-			</p>
-		</section>
-	</body>
-
+        <section>
+            <h2>Surviving versioning</h2>
+            <p>
+                A user has annotated a textual section of an EPUB and closed the
+                ebook. Today, he loads a new version of the EPUB in his reading
+                system. The spine item in which the annotations were created has
+                been modified, and some words have been added to the leaf HTML
+                element in which an annotation was created, before the start of
+                the annotation and in the annotated text itself. Still, the user
+                gets the annotation at the proper location.
+            </p>
+            <p>
+                The same user loads a new edition of the EPUB in his reading
+                system. A new resource - a foreword - has been added to the
+                spine, and the page list has been modified. Still, the user gets
+                the annotation at the proper location.
+            </p>
+        </section>
+    </body>
 </html>


### PR DESCRIPTION
Picking up at https://github.com/w3c/epub-specs/pull/2767#issuecomment-3148302585 : put the different use cases in their own subsections, when applicable. Also, used the she/her for, roughly, half of the use cases.