### PR TITLE
Remove xmlns and xml:lang from root html elements

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.1.1</title>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1.1</title>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="color-scheme" content="light dark" />

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>

--- a/epub34/overview/index.html
+++ b/epub34/overview/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Overview</title>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Reading Systems 3.4</title>

--- a/wg-notes/a11y-exemption/index.html
+++ b/wg-notes/a11y-exemption/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="color-scheme" content="light dark" />

--- a/wg-notes/annotations-ucr/index.html
+++ b/wg-notes/annotations-ucr/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="color-scheme" content="light dark" />

--- a/wg-notes/epub-a11y-eaa-mapping/index.html
+++ b/wg-notes/epub-a11y-eaa-mapping/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="color-scheme" content="light dark" />

--- a/wg-notes/epub-aria-authoring/index.html
+++ b/wg-notes/epub-aria-authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Type to ARIA Role Authoring Guide 1.1</title>

--- a/wg-notes/fxl-a11y-tech/index.html
+++ b/wg-notes/fxl-a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility - Fixed Layout Techniques</title>
@@ -75,8 +75,8 @@
 			pre {
 				white-space: break-spaces !important;
 			}
-            table {
-                border-collapse: collapse;
+			table {
+				border-collapse: collapse;
             }
             th, td {
                 border: 1px solid black;

--- a/wg-notes/fxl-a11y-tech/index.html
+++ b/wg-notes/fxl-a11y-tech/index.html
@@ -75,8 +75,8 @@
 			pre {
 				white-space: break-spaces !important;
 			}
-			table {
-				border-collapse: collapse;
+            table {
+                border-collapse: collapse;
             }
             th, td {
                 border: 1px solid black;

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-        <meta name="color-scheme" content="light dark" />
+		<meta name="color-scheme" content="light dark" />
 		<title>EPUB Accessibility - Fixed Layout Challenges and Best Practices</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="color-scheme" content="light dark" />
+        <meta name="color-scheme" content="light dark" />
 		<title>EPUB Accessibility - Fixed Layout Challenges and Best Practices</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>

--- a/wg-notes/multi-rend/index.html
+++ b/wg-notes/multi-rend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Multiple-Rendition Publications 1.1</title>

--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Structural Semantics Vocabulary 1.1</title>

--- a/wg-notes/tts/index.html
+++ b/wg-notes/tts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Text-to-Speech Enhancements 1.0</title>


### PR DESCRIPTION
As the title says. We don't need to pretend these are xhtml documents when they're just html using some xhtml conventions.

I'm tempted to globally replace "/>" with ">", but it's not strictly necessary. Self-closing tags are valid html.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2784.html" title="Last updated on Aug 28, 2025, 12:44 PM UTC (4c83ae8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2784/bce520b...4c83ae8.html" title="Last updated on Aug 28, 2025, 12:44 PM UTC (4c83ae8)">Diff</a>