### PR TITLE
Update the reading system requirements for css in 2771

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1219,13 +1219,16 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD only do so in
-						a way that allow the author's original design to be restored.</p>
+						publication's] styling (e.g., for ergonomic or user interface reasons). Morevoer, they MAY allow
+						users to set default themes and style preferences (e.g., for more accessible reading) that
+						further alter the original design of a publication.</p>
 
-					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
-						any reading system-applied styling, thereby allowing users to view a publication as designed by
-						the author (e.g., so users can check the original design if a publication refers to location,
-						color, etc. that gets overriden by the reading system styling).</p>
+					<p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
+						publication exactly as designed by an author, even if that is what the user wants. To assist
+						users in viewing an EPUB publication as closely as possible to the author intent, however,
+						reading systems MAY provide an affordance that reverts as much reading system-applied styling as
+						feasible. For example, it could reset any user-applied styling and themes back to the reading
+						system defaults.</p>
 				</section>
 			</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1223,12 +1223,11 @@
 						users to set default themes and style preferences (e.g., for more accessible reading) that
 						further alter the original design of a publication.</p>
 
-					<p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
+					<!-- <p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
 						publication exactly as designed by an author, even if that is what the user wants. To assist
 						users in viewing an EPUB publication as closely as possible to the author intent, however,
 						reading systems MAY provide an affordance that reverts as much reading system-applied styling as
-						feasible. For example, it could reset any user-applied styling and themes back to the reading
-						system defaults.</p>
+						feasible.</p> -->
 				</section>
 			</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1038,14 +1038,14 @@
 						<p>Reading system support for the <a data-cite="rdfa-core#s_model">attribute processing
 								model</a> [[rdfa-core]] is OPTIONAL.</p>
 					</section>
-					
+
 					<section id="sec-xhtml-its">
 						<h5>Internationalization Tag Set (ITS)</h5>
-						
+
 						<p>Reading system support for <a data-cite="its20#conformance-product-html5-its">processing ITS
 								markup</a> [[its20]] is OPTIONAL.</p>
 					</section>
-					
+
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom attributes</h5>
 
@@ -1205,22 +1205,29 @@
 							[=EPUB content documents=].</p>
 					</li>
 					<li>
-						<p id="confreq-css-overrides">MAY override parts of the creator's style sheets (for, e.g., ergonomic or 
-							user interface reasons). If it does, it SHOULD preserve as much as possible the cascade model of CSS.
-							Reading system developers are expected to also publicly document the user agent style sheets and how they
-							interact with EPUB creator's style settings.</p>
-					</li>
-					<li>
-						<p id="confreq-css-user-styles">
-							It MAY provide the user with an affordance that reverts the display to the author's stylesheet.</p>
+						<p id="confreq-css-rs-html-default">SHOULD support the [[html]] <a data-cite="html#rendering"
+								>suggested default rendering</a> in their user agent style sheet(s).</p>
 					</li>
 				</ul>
 
-				<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above, a reading
-					system's user agent style sheet SHOULD support the [[html]] <a data-cite="html#rendering">suggested
-						default rendering</a>.</p>
+				<div class="note">
+					<p>Reading system developers are expected to publicly document their user agent style sheet(s) and
+						how they interact with EPUB creator's style settings. </p>
+				</div>
 
-				<!-- <p>Reading system developers should implement CSS support at the level of major browsers.</p> -->
+				<section id="sec-css-overrides">
+					<h4>Author styling overrides</h4>
+
+					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
+						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD use
+						CSS-compatible methods (user agent style sheet, or [[html]] [^style^] attributes) that allow the
+						author's original design to be restored.</p>
+
+					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
+						any reading system-applied styling, thereby allowing users to view a publication as designed by
+						the author (e.g., so users can check the original design if a publication refers to location,
+						color, etc. that gets overriden by the reading system styling).</p>
+				</section>
 			</section>
 
 			<section id="sec-scripted-content">
@@ -2710,11 +2717,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
-					<li>06-August-2025: Updated the <a href="#sec-css">section on handling CSS</a>, in particular 
-						the relationships between the user agent's and the creators' style sheets. 
-						See discussion in <a href="https://github.com/w3c/epub-specs/issues/2762">issue 2762</a>
-						and <a href="https://github.com/w3c/epub-specs/pull/2771">pull request 2771</a>.
-					</li>
+					<li>06-August-2025: Updated the <a href="#sec-css">section on handling CSS</a>, in particular the
+						relationships between the user agent's and the creators' style sheets. See discussion in <a
+							href="https://github.com/w3c/epub-specs/issues/2762">issue 2762</a> and <a
+							href="https://github.com/w3c/epub-specs/pull/2771">pull request 2771</a>. </li>
 					<li>05-June-2025: Consolidated all deprecated features under the unsupported features section. See
 						the comments in <a href="https://github.com/w3c/epub-specs/pull/2735#issuecomment-2944066035"
 							>pull request 2735</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1219,8 +1219,8 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's] styling (e.g., for ergonomic or user interface reasons), but only do so in a
-						way that allow the author's original design to be restored.</p>
+						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD only do so in
+						a way that allow the author's original design to be restored.</p>
 
 					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
 						any reading system-applied styling, thereby allowing users to view a publication as designed by

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1219,9 +1219,8 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's] styling (e.g., for ergonomic or user interface reasons), but SHOULD use
-						CSS-compatible methods (user agent style sheet, or [[html]] [^style^] attributes) that allow the
-						author's original design to be restored.</p>
+						publication's] styling (e.g., for ergonomic or user interface reasons), but only do so in a
+						way that allow the author's original design to be restored.</p>
 
 					<p id="confreq-css-user-styles">Reading systems MAY provide users with an affordance that removes
 						any reading system-applied styling, thereby allowing users to view a publication as designed by


### PR DESCRIPTION
This is an attempted update to the reading system requirements in #2771. I split off the two bullets that were dealing with overriding author styles and adding the affordance to view an altered version of the publication and created a new section for them.

Let me know if makes things better or worse...

* * *

[Preview](https://raw.githack.com/w3c/epub-specs/update/rs-req/epub34/rs/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/css-sections-review-(issue-2762)/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/update/rs-req/epub34/rs/index.html)
