### PR TITLE
add a11y:contactEmail property

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1490,6 +1490,30 @@
 				</section>
 			</section>
 
+			<section id="sec-feedback">
+				<h3>Feedback</h3>
+				
+				<p>Although EPUB creators are expected to assess their publications prior to certifying them accessible,
+					due to the sheer volumes of content produced and the complexity of checking all the markup it is
+					sometimes the case that issues will slip through to the final product. Accessibility reporting can
+					also not be detailed enough for every user to be able to determine the suitability of the content
+					for their needs.</p>
+				
+				<p>To assist users in reporting any accessibility issues they encounter, or to discover more about the
+					accessibility of an EPUB publication, EPUB creators MAY include a contact email using the <a
+						href="#contactEmail"><code>a11y:contactEmail</code> property</a>.</p>
+				
+				<p>The email in this field is expected to direct user feedback and questions directly to the party or
+					individual reponsible for the accessibility of publications. It should not be a general purpose
+					feedback address.</p>
+				
+				<div class="example" title="Publisher contact for accessibility information">
+					<pre><code>&lt;meta property="a11y:contactEmail">
+   a11y-info@example.com
+&lt;/meta></code></pre>
+				</div>
+			</section>
+			
 			<section id="sec-a11y-resources" class="informative">
 				<h3>Additional resources</h3>
 
@@ -1738,150 +1762,199 @@
 						to declare the prefix in the <a href="https://www.w3.org/TR/epub/#dfn-package-document">package
 							document</a>.</p>
 				</section>
-				<section id="app-vocab-properties">
-					<h3>Certifier properties</h3>
+			</section>
+			
+			<section id="app-vocab-properties">
+				<h3>Certifier properties</h3>
 
-					<section id="certifiedBy">
-						<h4>certifiedBy</h4>
+				<section id="certifiedBy">
+					<h4>certifiedBy</h4>
 
-						<table class="tabledef">
-							<caption>Definition of the <code>certifiedBy</code> property</caption>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>certifiedBy</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>Identifies a party responsible for the testing and certification of the
-									accessibility of an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
-										publication</a>.</td>
-							</tr>
-							<tr>
-								<th>Allowed value(s):</th>
-								<td>
-									<code>xsd:string</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Cardinality:</th>
-								<td>One or more</td>
-							</tr>
-							<tr>
-								<th>Example:</th>
-								<td>
-									<pre>&lt;meta
-    property="a11y:certifiedBy">
-   Accessibility Testers Group
+					<table class="tabledef">
+						<caption>Definition of the <code>certifiedBy</code> property</caption>
+						<tr>
+							<th>Name:</th>
+							<td>
+								<code>certifiedBy</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Description:</th>
+							<td>Identifies a party responsible for the testing and certification of the
+								accessibility of an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
+									publication</a>.</td>
+						</tr>
+						<tr>
+							<th>Allowed value(s):</th>
+							<td>
+								<code>xsd:string</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Cardinality:</th>
+							<td>One or more</td>
+						</tr>
+						<tr>
+							<th>Example:</th>
+							<td>
+								<pre>&lt;meta
+property="a11y:certifiedBy">
+Accessibility Testers Group
 &lt;/meta></pre>
-								</td>
-							</tr>
-						</table>
-					</section>
+							</td>
+						</tr>
+					</table>
+				</section>
 
-					<section id="certifierCredential">
-						<h4>certifierCredential</h4>
+				<section id="certifierCredential">
+					<h4>certifierCredential</h4>
 
-						<table class="tabledef">
-							<caption>Definition of the <code>certifierCredential</code> property</caption>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>certifierCredential</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>Identifies a credential or badge that establishes the authority of the party
-									identified in the associated <a href="#certifiedBy"><code>certifiedBy</code>
-										property</a> to certify content accessible.</td>
-							</tr>
-							<tr>
-								<th>Allowed value(s):</th>
-								<td>
-									<code>xsd:string</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Cardinality:</th>
-								<td>Zero or more</td>
+					<table class="tabledef">
+						<caption>Definition of the <code>certifierCredential</code> property</caption>
+						<tr>
+							<th>Name:</th>
+							<td>
+								<code>certifierCredential</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Description:</th>
+							<td>Identifies a credential or badge that establishes the authority of the party
+								identified in the associated <a href="#certifiedBy"><code>certifiedBy</code>
+									property</a> to certify content accessible.</td>
+						</tr>
+						<tr>
+							<th>Allowed value(s):</th>
+							<td>
+								<code>xsd:string</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Cardinality:</th>
+							<td>Zero or more</td>
 
-							</tr>
-							<tr>
-								<th>Extends:</th>
-								<td>
-									<code>a11y:certifiedBy</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Example:</th>
-								<td>
-									<pre>&lt;meta
-    property="a11y:certifiedBy"
-    id="certifier">
-   Accessibility Testers Group
+						</tr>
+						<tr>
+							<th>Extends:</th>
+							<td>
+								<code>a11y:certifiedBy</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Example:</th>
+							<td>
+								<pre>&lt;meta
+property="a11y:certifiedBy"
+id="certifier">
+Accessibility Testers Group
 &lt;/meta>
 &lt;meta
-    property="a11y:certifierCredential"
-    refines="#certifier">
-   DAISY OK
+property="a11y:certifierCredential"
+refines="#certifier">
+DAISY OK
 &lt;/meta></pre>
-								</td>
-							</tr>
-						</table>
-					</section>
+							</td>
+						</tr>
+					</table>
+				</section>
 
-					<section id="certifierReport">
-						<h4>certifierReport</h4>
+				<section id="certifierReport">
+					<h4>certifierReport</h4>
 
-						<table class="tabledef">
-							<caption>Definition of the <code>certifierReport</code> property</caption>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>certifierReport</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>Provides a link to an accessibility report created by the party identified in the
-									associated <a href="#certifiedBy"><code>certifiedBy</code> property</a>.</td>
-							</tr>
-							<tr>
-								<th>Allowed value(s):</th>
-								<td>
-									<code>xsd:anyURI</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Cardinality:</th>
-								<td>Zero or more</td>
-							</tr>
-							<tr>
-								<th>Extends:</th>
-								<td>
-									<a href="#certifiedBy">
-										<code>certifiedBy</code>
-									</a>
-								</td>
-							</tr>
-							<tr>
-								<th>Example:</th>
-								<td>
-									<pre>&lt;meta
-    property="a11y:certifiedBy"
-    id="certifier">
-   Accessibility Testers Group
+					<table class="tabledef">
+						<caption>Definition of the <code>certifierReport</code> property</caption>
+						<tr>
+							<th>Name:</th>
+							<td>
+								<code>certifierReport</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Description:</th>
+							<td>Provides a link to an accessibility report created by the party identified in the
+								associated <a href="#certifiedBy"><code>certifiedBy</code> property</a>.</td>
+						</tr>
+						<tr>
+							<th>Allowed value(s):</th>
+							<td>
+								<code>xsd:anyURI</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Cardinality:</th>
+							<td>Zero or more</td>
+						</tr>
+						<tr>
+							<th>Extends:</th>
+							<td>
+								<a href="#certifiedBy">
+									<code>certifiedBy</code>
+								</a>
+							</td>
+						</tr>
+						<tr>
+							<th>Example:</th>
+							<td>
+								<pre>&lt;meta
+property="a11y:certifiedBy"
+id="certifier">
+Accessibility Testers Group
 &lt;/meta>
 &lt;link
-    rel="a11y:certifierReport"
-    refines="#certifier"
-    href="https://example.com/a11y-report/"/></pre>
-								</td>
-							</tr>
-						</table>
-					</section>
+rel="a11y:certifierReport"
+refines="#certifier"
+href="https://example.com/a11y-report/"/></pre>
+							</td>
+						</tr>
+					</table>
+				</section>
+			</section>
+					
+			<section id="app-vocab-general-properties">
+				<h3>General properties</h3>
+				
+				<section id="contactEmail">
+					<h4>contactEmail</h4>
+					
+					<table class="tabledef">
+						<caption>Definition of the <code>contactEmail</code> property</caption>
+						<tr>
+							<th>Name:</th>
+							<td>
+								<code>contactEmail</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Description:</th>
+							<td>Provides an email address for requesting more information about the accessibility of the
+								EPUB publication or to report issues with the work.</td>
+						</tr>
+						<tr>
+							<th>Allowed value(s):</th>
+							<td>
+								<code>MUST be a valid <a data-cite="rfc5322#section-3.4.1">email address</a>
+									[[rfc5322]].</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Cardinality:</th>
+							<td>Zero or one</td>
+						</tr>
+						<tr>
+							<th>Extends:</th>
+							<td>Only applies to the EPUB publication. MUST NOT be used when the <a
+									data-cite="epub-3#attrdef-refines"><code>refines</code> attribute</a> is
+								present.</td>
+						</tr>
+						<tr>
+							<th>Example:</th>
+							<td>
+								<pre>&lt;meta property="a11y:contactEmail">
+   accessibility@example.com
+&lt;/meta></pre>
+							</td>
+						</tr>
+					</table>
 				</section>
 			</section>
 		</section>
@@ -1901,6 +1974,9 @@
 				<summary>Substantive changes since <a href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility
 					1.1</a></summary>
 				<ul>
+					<li>04-Sept-2025: Added <code>a11y:contactEmail</code> to allow EPUB creators to include a contact
+						email for additional accessibility info and to express concerns. See <a
+							href="https://github.com/w3c/epub-specs/issues/2702">issue 2702</a>.</li>
 					<li>26-June-2025: Changed accessMode to a recommended property and accessModeSufficient to required
 						to better reflect their usefulness is determining if a book will be readable. See <a
 							href="https://github.com/w3c/epub-specs/issues/2679">issue 2679</a>.</li>


### PR DESCRIPTION
Adds the new property for contacting the publisher (or whoever) for more information.

I added a "feedback" subsection to explain the property in the body as this property doesn't fit under the certifier section. For the same reason, I added a "general properties" section to the vocabulary to list it there.

Fixes #2702 

***

See:

* For EPUB Accessibility 1.1.1:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2702a/epub34/a11y/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2702a/epub34/a11y/index.html)

