### PR TITLE
Add note about use of URLs in evaluator credential

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -256,8 +256,9 @@
 				<p>It also defines the following term:</p>
 
 				<dl>
-					<dt><dfn id="dfn-assistive-technology" data-lt="assistive technologies">assistive
-						technology</dfn></dt>
+					<dt>
+						<dfn id="dfn-assistive-technology" data-lt="assistive technologies">assistive technology</dfn>
+					</dt>
 					<dd>
 						<p>This specification uses the <a data-cite="wcag2#dfn-assistive-technologies">definition of
 								assistive technology</a> from [[wcag2]].</p>
@@ -1154,20 +1155,28 @@
 							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
 						><var>WCAG-LVL</var></a></p>
 
-					<p><i>where:</i></p>
+					<p>
+						<i>where:</i>
+					</p>
 
 					<dl class="varlist">
-						<dt id="acc-ver"><var>A11Y-VER</var></dt>
+						<dt id="acc-ver">
+							<var>A11Y-VER</var>
+						</dt>
 						<dd>
 							<p>Specifies the version number of the EPUB Accessibility specification the publication
 								conforms to. The value MUST be <code>1.1</code> or higher.</p>
 						</dd>
-						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
+						<dt id="wcag-ver">
+							<var>WCAG-VER</var>
+						</dt>
 						<dd>
 							<p>Specifies the version number of WCAG the publication conforms to. The value MUST be
 									<code>2.0</code> or higher.</p>
 						</dd>
-						<dt id="wcag-lvl"><var>WCAG-LVL</var></dt>
+						<dt id="wcag-lvl">
+							<var>WCAG-LVL</var>
+						</dt>
 						<dd>
 							<p>Specifies the WCAG conformance level the publication conforms to (e.g., <code>A</code> or
 									<code>AA</code>).</p>
@@ -1336,12 +1345,12 @@
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<div class="note">
-							<p>Although it is possible to use a URL as the value of the credential property instead of a
-								human-readable string, this could lead to awkward display of the metadata in some
-								reading systems, vendor bookstores, and library catalogues. To improve the display
-								(e.g., to match the URL and display an icon in its place), the provider of the
-								credential is responsible for ensuring these systems are aware of their URL badge and
-								how to process it.</p>
+							<p>Although it is possible to use a URL as the value of the
+									<code>a11y:certifierCredential</code> property instead of a human-readable string,
+								this could lead to awkward display of the metadata in some reading systems, vendor
+								bookstores, and library catalogues. To improve the display (e.g., to match the URL and
+								display an icon in its place), the provider of the credential is responsible for
+								ensuring these systems are aware of their URL badge and how to process it.</p>
 						</div>
 
 						<aside class="example" title="Expressing a basic credential">
@@ -1506,53 +1515,67 @@
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>:</p>
 
 				<dl>
-					<dt><a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility Techniques 1.1.1</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility Techniques 1.1.1</a>
+					</dt>
 					<dd>
 						<p>The EPUB Accessibility techniques [[epub-a11y-tech-111]] provide specific guidance on how to
 							apply WCAG techniques to EPUB publications as well a guidance on how to meet the
 							EPUB-specific objectives of this document.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 Understanding Docs</a></dt>
+					<dt>
+						<a href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 Understanding Docs</a>
+					</dt>
 					<dd>
 						<p>The WCAG Understanding Docs provide detailed explanations of the purpose and goals of the
 							WCAG success criteria.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG (Quick Reference)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG (Quick Reference)</a>
+					</dt>
 					<dd>
 						<p>The WCAG quick reference guide provides links to techniques showing ways to meet each WCAG
 							success critierion.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a>
+					</dt>
 					<dd>
 						<p>The ARIA standard [[wai-aria]] defines roles, states, and properties for making dynamic
 							content that does not use native HTML elements and attributes accessible. It also provides a
 							set of landmarks for navigating web pages.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
+					</dt>
 					<dd>
 						<p>ARIA in HTML [[html-aria]] specifies how the roles, states, and properties defined ARIA and
 							DPUB-ARIA can be used in HTML documents.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices Guide (APG)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices Guide (APG)</a>
+					</dt>
 					<dd>
 						<p>The ARIA Authoring Practices guide provides examples of how to use ARIA roles, states, and
 							properties to make dynamic content more accessible.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module
-						(DPUB-ARIA)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a>
+					</dt>
 					<dd>
 						<p>The [[dpub-aria]] specification is an extension of [[wai-aria]] that provides additional
 							roles specific to identifying common publishing structures.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/epub-aria-authoring/">EPUB Type to ARIA Role Authoring
-						Guide</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/epub-aria-authoring/">EPUB Type to ARIA Role Authoring Guide</a>
+					</dt>
 					<dd>
 						<p>The EPUB Type to ARIA Role authoring guide provides mappings from the semantics used in the
 								<code>epub:type</code> attribute to ARIA and DPUB-ARIA role equivalents.</p>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -256,9 +256,8 @@
 				<p>It also defines the following term:</p>
 
 				<dl>
-					<dt>
-						<dfn id="dfn-assistive-technology" data-lt="assistive technologies">assistive technology</dfn>
-					</dt>
+					<dt><dfn id="dfn-assistive-technology" data-lt="assistive technologies">assistive
+						technology</dfn></dt>
 					<dd>
 						<p>This specification uses the <a data-cite="wcag2#dfn-assistive-technologies">definition of
 								assistive technology</a> from [[wcag2]].</p>
@@ -1155,28 +1154,20 @@
 							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
 						><var>WCAG-LVL</var></a></p>
 
-					<p>
-						<i>where:</i>
-					</p>
+					<p><i>where:</i></p>
 
 					<dl class="varlist">
-						<dt id="acc-ver">
-							<var>A11Y-VER</var>
-						</dt>
+						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
 							<p>Specifies the version number of the EPUB Accessibility specification the publication
 								conforms to. The value MUST be <code>1.1</code> or higher.</p>
 						</dd>
-						<dt id="wcag-ver">
-							<var>WCAG-VER</var>
-						</dt>
+						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
 						<dd>
 							<p>Specifies the version number of WCAG the publication conforms to. The value MUST be
 									<code>2.0</code> or higher.</p>
 						</dd>
-						<dt id="wcag-lvl">
-							<var>WCAG-LVL</var>
-						</dt>
+						<dt id="wcag-lvl"><var>WCAG-LVL</var></dt>
 						<dd>
 							<p>Specifies the WCAG conformance level the publication conforms to (e.g., <code>A</code> or
 									<code>AA</code>).</p>
@@ -1515,67 +1506,53 @@
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>:</p>
 
 				<dl>
-					<dt>
-						<a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility Techniques 1.1.1</a>
-					</dt>
+					<dt><a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility Techniques 1.1.1</a></dt>
 					<dd>
 						<p>The EPUB Accessibility techniques [[epub-a11y-tech-111]] provide specific guidance on how to
 							apply WCAG techniques to EPUB publications as well a guidance on how to meet the
 							EPUB-specific objectives of this document.</p>
 					</dd>
 
-					<dt>
-						<a href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 Understanding Docs</a>
-					</dt>
+					<dt><a href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 Understanding Docs</a></dt>
 					<dd>
 						<p>The WCAG Understanding Docs provide detailed explanations of the purpose and goals of the
 							WCAG success criteria.</p>
 					</dd>
 
-					<dt>
-						<a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG (Quick Reference)</a>
-					</dt>
+					<dt><a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG (Quick Reference)</a></dt>
 					<dd>
 						<p>The WCAG quick reference guide provides links to techniques showing ways to meet each WCAG
 							success critierion.</p>
 					</dd>
 
-					<dt>
-						<a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a>
-					</dt>
+					<dt><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a></dt>
 					<dd>
 						<p>The ARIA standard [[wai-aria]] defines roles, states, and properties for making dynamic
 							content that does not use native HTML elements and attributes accessible. It also provides a
 							set of landmarks for navigating web pages.</p>
 					</dd>
 
-					<dt>
-						<a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
-					</dt>
+					<dt><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a></dt>
 					<dd>
 						<p>ARIA in HTML [[html-aria]] specifies how the roles, states, and properties defined ARIA and
 							DPUB-ARIA can be used in HTML documents.</p>
 					</dd>
 
-					<dt>
-						<a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices Guide (APG)</a>
-					</dt>
+					<dt><a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices Guide (APG)</a></dt>
 					<dd>
 						<p>The ARIA Authoring Practices guide provides examples of how to use ARIA roles, states, and
 							properties to make dynamic content more accessible.</p>
 					</dd>
 
-					<dt>
-						<a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a>
-					</dt>
+					<dt><a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module
+						(DPUB-ARIA)</a></dt>
 					<dd>
 						<p>The [[dpub-aria]] specification is an extension of [[wai-aria]] that provides additional
 							roles specific to identifying common publishing structures.</p>
 					</dd>
 
-					<dt>
-						<a href="https://www.w3.org/TR/epub-aria-authoring/">EPUB Type to ARIA Role Authoring Guide</a>
-					</dt>
+					<dt><a href="https://www.w3.org/TR/epub-aria-authoring/">EPUB Type to ARIA Role Authoring
+						Guide</a></dt>
 					<dd>
 						<p>The EPUB Type to ARIA Role authoring guide provides mappings from the semantics used in the
 								<code>epub:type</code> attribute to ARIA and DPUB-ARIA role equivalents.</p>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1.1</title>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1.1</title>
@@ -1335,6 +1335,15 @@
 							<a href="https://www.w3.org/TR/epub/#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
+						<div class="note">
+							<p>Although it is possible to use a URL as the value of the credential property instead of a
+								human-readable string, this could lead to awkward display of the metadata in some
+								reading systems, vendor bookstores, and library catalogues. To improve the display
+								(e.g., to match the URL and display an icon in its place), the provider of the
+								credential is responsible for ensuring these systems are aware of their URL badge and
+								how to process it.</p>
+						</div>
+
 						<aside class="example" title="Expressing a basic credential">
 							<p>In this example, the <code>refines</code> attribute associates the credential with the
 								certifier.</p>
@@ -1901,6 +1910,9 @@
 				<summary>Substantive changes since <a href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility
 					1.1</a></summary>
 				<ul>
+					<li>05-Sept-2025: Added a note to the evaluator credential field that while URLs are valid values
+						they will typically require additional processing for display. See <a
+							href="https://github.com/w3c/epub-specs/issues/2112">issue 2112</a>.</li>
 					<li>26-June-2025: Changed accessMode to a recommended property and accessModeSufficient to required
 						to better reflect their usefulness is determining if a book will be readable. See <a
 							href="https://github.com/w3c/epub-specs/issues/2679">issue 2679</a>.</li>


### PR DESCRIPTION
As discussed on the TF call yesterday, this pull request adds a note to the accessibility specification explaining that URLs are valid in the certifierCredential field but they may cause display issues, and will be up to the issuer of the credential to address how to replace the URL with an icon (or whatever). We can't ban URLs as they have been in use by Benetech for years now.

Fixes #2112 
Fixes #2760 

***

[Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2112/epub34/a11y/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2112/epub34/a11y/index.html)

