### PR TITLE
Add an RS affordance on resetting CSS to the author's settings (as much as possible)

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1219,15 +1219,15 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's] styling (e.g., for ergonomic or user interface reasons). Morevoer, they MAY allow
+						publication's] styling (e.g., for ergonomic or user interface reasons). Moreover, it MAY allow
 						users to set default themes and style preferences (e.g., for more accessible reading) that
 						further alter the original design of a publication.</p>
 
-					<!-- <p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
+					<p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
 						publication exactly as designed by an author, even if that is what the user wants. To assist
 						users in viewing an EPUB publication as closely as possible to the author intent, however,
-						reading systems MAY provide an affordance that reverts as much reading system-applied styling as
-						feasible.</p> -->
+						a reading system MAY provide an affordance that reverts as much reading system-applied styling as
+						feasible.</p>
 				</section>
 			</section>
 


### PR DESCRIPTION
After the [last WG discussion](https://w3c.github.io/pm-wg/minutes/2025-09-04.html#f0a7), and the merge of #2771 (which covered the non-controversial changes on the CSS related sections as discussed in #2762), this PR contains a more controversial text discussed originally: a _MAY_ statement for the RS-s, providing an affordance to re-set the author's CSS as close to his/her originals as possible. (Note that this _MAY_ statement is already covered in Apple Books and Thorium.)

Note that this PR does ***not*** cover another controversial matter that came up in #2762: providing author guidance on what properties to avoid due to the possible interference by the Reading System. If someone wants to discuss/propose such an authoring guidance, this should be done in a separate issue/PR (to keep discussions manageable).


See:

* For EPUB 3.4 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/RS-css-author-affordance/epub34/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/RS-css-author-affordance/epub34/rs/index.html)


