### PR TITLE
Change accessibility version to 1.2

### DIFF
--- a/.github/workflows/epub-a11y-tech.yml
+++ b/.github/workflows/epub-a11y-tech.yml
@@ -21,7 +21,7 @@ jobs:
           SOURCE: epub34/a11y-tech/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y_TECH }}
-          W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-02-12-epub#resolution2
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-pm-wg/2023Oct/0028.html
           W3C_BUILD_OVERRIDE: |
              shortName: epub-a11y-tech-12
              specStatus: NOTE

--- a/.github/workflows/epub-a11y-tech.yml
+++ b/.github/workflows/epub-a11y-tech.yml
@@ -1,4 +1,4 @@
-# .github/workflows/epub-a11-tech-111.yml
+# .github/workflows/epub-a11-tech-12.yml
 name: CI (EPUB Accessibility Techniques)
 on:
   pull_request:
@@ -12,7 +12,7 @@ on:
       - "common/**"
 jobs:
   main:
-    name: Publish EPUB Accessibility Techniques 1.1.1 
+    name: Publish EPUB Accessibility Techniques 1.2 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,5 +23,5 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y_TECH }}
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-02-12-epub#resolution2
           W3C_BUILD_OVERRIDE: |
-             shortName: epub-a11y-tech-111
+             shortName: epub-a11y-tech-12
              specStatus: NOTE

--- a/.github/workflows/epub-a11y-tech.yml
+++ b/.github/workflows/epub-a11y-tech.yml
@@ -1,4 +1,4 @@
-# .github/workflows/epub-a11-tech-12.yml
+# .github/workflows/epub-a11y-tech-12.yml
 name: CI (EPUB Accessibility Techniques)
 on:
   pull_request:

--- a/.github/workflows/epub-a11y.yml
+++ b/.github/workflows/epub-a11y.yml
@@ -1,4 +1,4 @@
-# .github/workflows/epub-a11y-111.yml
+# .github/workflows/epub-a11y-12.yml
 name: CI (EPUB Accessibility)
 on:
   pull_request:
@@ -14,7 +14,7 @@ on:
       - "common/**"
 jobs:
   main:
-    name: Publish EPUB Accessibility 1.1.1
+    name: Publish EPUB Accessibility 1.2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,5 +25,5 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y }}
           W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
-             shortName: epub-a11y-111
+             shortName: epub-a11y-12
              specStatus: WD

--- a/.github/workflows/epub-a11y.yml
+++ b/.github/workflows/epub-a11y.yml
@@ -23,7 +23,7 @@ jobs:
           SOURCE: epub34/a11y/
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN_A11Y }}
-          W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-pm-wg/2023Oct/0028.html
           W3C_BUILD_OVERRIDE: |
              shortName: epub-a11y-12
              specStatus: WD

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB Accessibility Techniques 1.1.1</title>
+		<title>EPUB Accessibility Techniques 1.2</title>
 		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
@@ -13,7 +13,7 @@
 				group: "pm",
 				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
-				shortName: "epub-a11y-tech-111",
+				shortName: "epub-a11y-tech-12",
 				noRecTrack: true,
 				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-tech/",
                 // previousPublishDate: "2024-04-12",
@@ -123,29 +123,29 @@
 				<h3>Overview</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides informative guidance on how to understand and
-					apply the accessibility requirements defined in the EPUB Accessibility 1.1.1 specification
-					[[epub-a11y-111]] that are unique to <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
+					apply the accessibility requirements defined in the EPUB Accessibility 1.2 specification
+					[[epub-a11y-12]] that are unique to <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
 						publications</a>.</p>
 
 				<p>This document does not cover general web accessibility techniques already addressed in [[wcag2]] and
 					[[wai-aria]], for example, for which no substantive differences in application exist. Following
 					those techniques, as applicable, is also essential to meeting the accessibility requirements of the
-					EPUB Accessibility 1.1.1 specification.</p>
+					EPUB Accessibility 1.2 specification.</p>
 
 				<p>This document is not intended to be read in isolation, in other words, as it does not define
 					conformance requirements for making accessibility claims or cover every method for producing
-					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1.1
-					to make a claim of accessibility. Verifying only the techniques in this document does not mean an <a
+					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.2 to
+					make a claim of accessibility. Verifying only the techniques in this document does not mean an <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> can claim conformance to
-					EPUB Accessibility 1.1.1.</p>
+					EPUB Accessibility 1.2.</p>
 			</section>
 
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
 				<p>This document uses terminology defined in <a href="https://www.w3.org/TR/epub/#sec-terminology">EPUB
-						3.3</a> [[epub-3]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.1.1</a>
-					[[epub-a11y-111]]:</p>
+						3.3</a> [[epub-3]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.2</a>
+					[[epub-a11y-12]]:</p>
 
 				<div class="note">
 					<p>Only the first instance of a term in a section links to its definition.</p>
@@ -158,7 +158,7 @@
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
 					<a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> create <a
 					href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> that conform to the
-				requirements in [[epub-a11y-111]], but they are not all applicable in all situations and there may be
+				requirements in [[epub-a11y-12]], but they are not all applicable in all situations and there may be
 				other ways to meet the requirements of that specification. As a result, this document should not be read
 				as providing prescriptive requirements.</p>
 
@@ -898,7 +898,7 @@
 
 					<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> must now ensure that
 						their image-based content meets [[wcag2]] requirements for alternative text and extended
-						descriptions to conform with [[epub-a11y-111]].</p>
+						descriptions to conform with [[epub-a11y-12]].</p>
 
 					<section id="sec-desc-001-res">
 						<h5>Helpful resources</h5>
@@ -1063,7 +1063,7 @@
 
 				<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> therefore need to use their
 					best discretion when implementing this functionality to meet accessibility requirements. EPUB
-					publications that contain multiple renditions are conformant to the [[epub-a11y-111]] specification
+					publications that contain multiple renditions are conformant to the [[epub-a11y-12]] specification
 					if at least one rendition meets all the content requirements, but EPUB creators at a minimum need to
 					note that a reading system that supports multiple renditions is required in their <a
 						href="#accessibilitySummary">accessibility summary</a>. Any other methods the EPUB creator can

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB Accessibility 1.1.1</title>
+		<title>EPUB Accessibility 1.2</title>
 		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
@@ -15,7 +15,7 @@
 				group: "pm",
                 wgPublicList: "public-pm-wg",
 				specStatus: "ED",
-				shortName: "epub-a11y-111",
+				shortName: "epub-a11y-12",
 				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y/",
                 // implementationReportURI: "https://w3c.github.io/epub-specs/epub34/reports/",
                 // previousPublishDate: "2023-05-25",
@@ -199,8 +199,8 @@
 					WCAG [[wcag2]] separates its accessibility guidelines from the techniques to achieve them. This
 					approach allows the guidelines to remain stable even as the format evolves.</p>
 
-				<p>To facilitate this approach, the companion <a data-cite="epub-a11y-tech-111#">EPUB Accessibility
-						Techniques</a> [[epub-a11y-tech-111]] document outlines conformance techniques. These techniques
+				<p>To facilitate this approach, the companion <a data-cite="epub-a11y-tech-12#">EPUB Accessibility
+						Techniques</a> [[epub-a11y-tech-12]] document outlines conformance techniques. These techniques
 					explain how to meet the requirements of this specification for different versions of EPUB.</p>
 
 				<section id="sec-sc-i18n">
@@ -341,14 +341,6 @@
 					</li>
 				</ul>
 
-				<div class="issue" data-number="2679"
-					title="Switch requirements for accessMode and accessModeSufficient">
-					<p>The current draft makes accessModeSufficient a required property and accessMode a recommended
-						one, as accessModeSufficient is the more helpful in determining who can read the content. This
-						change will require the version number of the standard to change, otherwise existing content
-						could become invalid. If the version is not changed, this change will be undone.</p>
-				</div>
-
 				<p>EPUB publications SHOULD include the following [[schema-org]] accessibility metadata:</p>
 
 				<ul class="conformance-list">
@@ -388,8 +380,8 @@
 					<p>Refer to the <a href="https://w3c.github.io/epub-a11y-meta-guide/1.0/draft/#sec-discovery">EPUB
 							Accessibility Metadata Guidelines</a> for more information on these properties and how to
 						include them in different versions of EPUB. See also <a
-							data-cite="epub-a11y-tech-111#dist-a11y-metadata">Include accessibility metadata in
-							distribution records</a> [[epub-a11y-tech-111]] for more information on including
+							data-cite="epub-a11y-tech-12#dist-a11y-metadata">Include accessibility metadata in
+							distribution records</a> [[epub-a11y-tech-12]] for more information on including
 						accessibility metadata in other formats.</p>
 				</div>
 			</section>
@@ -457,7 +449,7 @@
 					publications. (Each requirement explains its relationship to WCAG in its respective section.)</p>
 
 				<p>The same is true of the techniques in the EPUB Accessibility Techniques document
-					[[epub-a11y-tech-111]]. It provides coverage of techniques that are unique to EPUB publications, or
+					[[epub-a11y-tech-12]]. It provides coverage of techniques that are unique to EPUB publications, or
 					that need clarification in the context of an EPUB publication. It does not mean that the rest of the
 					WCAG techniques are not applicable.</p>
 
@@ -571,7 +563,7 @@
 							understandable, and robust against the full EPUB publication, not only against each EPUB
 							content document within it.</p>
 
-						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-111]] provide more information about
+						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-12]] provide more information about
 							applying these guidelines to EPUB publications.</p>
 					</section>
 
@@ -647,9 +639,9 @@
 							meet the Multiple Ways success criterion.</p>
 
 						<div class="note">
-							<p>Refer to <a href="https://www.w3.org/TR/epub-a11y-tech-111/#sec-epub-page-navigation"
-									>Page navigation</a> [[epub-a11y-tech-111]] for more information on the inclusion of
-								page navigation in EPUB publications.</p>
+							<p>Refer to <a href="https://www.w3.org/TR/epub-a11y-tech-12/#sec-epub-page-navigation">Page
+									navigation</a> [[epub-a11y-tech-12]] for more information on the inclusion of page
+								navigation in EPUB publications.</p>
 						</div>
 					</section>
 
@@ -718,8 +710,8 @@
 											href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a>
 										metadata.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#pageSource">Identifying the
-												pagination source</a> [[epub-a11y-tech-111]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-12#pageSource">Identifying the
+												pagination source</a> [[epub-a11y-tech-12]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -762,8 +754,8 @@
 									<p>EPUB creators should include links for all pages in the source whether they are
 										reproduced or not, but this is not a requirement.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#pageList">Provide a page list</a>
-											[[epub-a11y-tech-111]] for more information on meeting this objective.</p>
+										<p>Refer to <a data-cite="epub-a11y-tech-12#pageList">Provide a page list</a>
+											[[epub-a11y-tech-12]] for more information on meeting this objective.</p>
 									</div>
 								</dd>
 							</dl>
@@ -809,9 +801,9 @@
 										of the content (e.g., EPUB 3 media overlays [[?epub-3]]), EPUB creators MUST
 										identify the page numbers in the markup that controls the playback.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#pageBreakMarkers">Provide page
-												break markers</a> [[epub-a11y-tech-111]] for more information on meeting
-											this objective.</p>
+										<p>Refer to <a data-cite="epub-a11y-tech-12#pageBreakMarkers">Provide page break
+												markers</a> [[epub-a11y-tech-12]] for more information on meeting this
+											objective.</p>
 									</div>
 								</dd>
 							</dl>
@@ -901,8 +893,8 @@
 										provide synchronized audio playback for all visible textual content as well as
 										all textual alternatives for visual media.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-coverage">Ensuring complete
-												text coverage</a> [[epub-a11y-tech-111]] for more information on meeting
+										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-coverage">Ensuring complete
+												text coverage</a> [[epub-a11y-tech-12]] for more information on meeting
 											this objective.</p>
 									</div>
 								</dd>
@@ -961,8 +953,8 @@
 									<p>If EPUB creators use a different ordering, that ordering MUST still result in a
 										logical playback of the content.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-reading-order">Specifying the
-												reading order</a> [[epub-a11y-tech-111]] for more information on meeting
+										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-reading-order">Specifying the
+												reading order</a> [[epub-a11y-tech-12]] for more information on meeting
 											this objective.</p>
 									</div>
 								</dd>
@@ -1002,8 +994,8 @@
 								<dd>
 									<p>EPUB creators SHOULD identify all skippable structures.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-skippability">Identifying
-												skippable structures</a> [[epub-a11y-tech-111]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-skippability">Identifying
+												skippable structures</a> [[epub-a11y-tech-12]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -1043,8 +1035,8 @@
 								<dd>
 									<p>EPUB creators SHOULD identify all escapable structures.</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-escapability">Identifying
-												escapable structures</a> [[epub-a11y-tech-111]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-escapability">Identifying
+												escapable structures</a> [[epub-a11y-tech-12]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -1083,8 +1075,8 @@
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
 											document</a> [[epub-3]].</p>
 									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-111#sync-nav">Synchronizing the
-												navigation document</a> [[epub-a11y-tech-111]] for more information on
+										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-nav">Synchronizing the
+												navigation document</a> [[epub-a11y-tech-12]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -1160,7 +1152,10 @@
 						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
 							<p>Specifies the version number of the EPUB Accessibility specification the publication
-								conforms to. The value MUST be <code>1.1</code> or higher.</p>
+								conforms to. The value MUST NOT be lower <code>1.1</code> as the 1.0 version of this
+								specification used a different conformance identification scheme.</p>
+							<p>The value MUST be <code>1.2</code> to indicate conformance to this version of the
+								specification.</p>
 						</dd>
 						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
 						<dd>
@@ -1176,7 +1171,7 @@
 
 					<aside class="example" title="A basic conformance statement">
 						<p>In this example, the <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a>
-							is stating that their publication conforms to the EPUB Accessibility 1.1 specification at
+							is stating that their publication conforms to the EPUB Accessibility 1.2 specification at
 							WCAG 2.2 Level AA.</p>
 
 						<pre>&lt;package …>
@@ -1185,7 +1180,7 @@
       &lt;meta 
           property="dcterms:conformsTo"
           id="conf">
-         EPUB Accessibility 1.1 - WCAG 2.2 Level AA
+         EPUB Accessibility 1.2 - WCAG 2.2 Level AA
       &lt;/meta>
       …
    &lt;/metadata>
@@ -1205,6 +1200,15 @@
 						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level A</li>
 						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</li>
 						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AAA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AAA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AAA</li>
 					</ul>
 
 					<div class="note">
@@ -1275,7 +1279,7 @@
   &lt;meta
       property="dcterms:conformsTo"
       id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
+     EPUB Accessibility 1.2 - WCAG 2.2 Level AA
   &lt;/meta>
   &lt;meta
       property="a11y:certifiedBy"
@@ -1299,13 +1303,6 @@
 						<p>It is REQUIRED that the date string conform to [[iso8601-1]], particularly the subset
 							expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
 							machine readable.</p>
-
-						<div class="issue" data-number="2725" title="Evaluation date format">
-							<p>The change to require the form of the evaluation date depends on the standard version
-								number changing, and as a consequence there being new conformance identifiers.
-								Otherwise, this change could invalidate existing content. The requirement could be
-								lowered to a recommendation in a future update if a version change is opposed.</p>
-						</div>
 
 						<aside class="example" title="Expressing the evaluation date">
 							<pre>&lt;metadata …>
@@ -1352,7 +1349,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
+     EPUB Accessibility 1.2 - WCAG 2.2 Level AA
    &lt;/meta>
    
    &lt;meta
@@ -1386,7 +1383,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
+     EPUB Accessibility 1.2 - WCAG 2.2 Level AA
    &lt;/meta>
 
    &lt;meta
@@ -1410,7 +1407,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-     EPUB Accessibility 1.1 - WCAG 2.2 Level AA
+     EPUB Accessibility 1.2 - WCAG 2.2 Level AA
    &lt;/meta>
    
    &lt;meta
@@ -1501,28 +1498,28 @@
 
 			<section id="sec-feedback">
 				<h3>Feedback</h3>
-				
+
 				<p>Although EPUB creators are expected to assess their publications prior to certifying them accessible,
 					due to the sheer volumes of content produced and the complexity of checking all the markup it is
 					sometimes the case that issues will slip through to the final product. Accessibility reporting can
 					also not be detailed enough for every user to be able to determine the suitability of the content
 					for their needs.</p>
-				
+
 				<p>To assist users in reporting any accessibility issues they encounter, or to discover more about the
 					accessibility of an EPUB publication, EPUB creators MAY include a contact email using the <a
 						href="#contactEmail"><code>a11y:contactEmail</code> property</a>.</p>
-				
+
 				<p>The email in this field is expected to direct user feedback and questions directly to the party or
 					individual reponsible for the accessibility of publications. It should not be a general purpose
 					feedback address.</p>
-				
+
 				<div class="example" title="Publisher contact for accessibility information">
 					<pre><code>&lt;meta property="a11y:contactEmail">
    a11y-info@example.com
 &lt;/meta></code></pre>
 				</div>
 			</section>
-			
+
 			<section id="sec-a11y-resources" class="informative">
 				<h3>Additional resources</h3>
 
@@ -1530,9 +1527,9 @@
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>:</p>
 
 				<dl>
-					<dt><a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility Techniques 1.1.1</a></dt>
+					<dt><a href="https://www.w3.org/TR/epub-a11y-12/">EPUB Accessibility Techniques 1.2</a></dt>
 					<dd>
-						<p>The EPUB Accessibility techniques [[epub-a11y-tech-111]] provide specific guidance on how to
+						<p>The EPUB Accessibility techniques [[epub-a11y-tech-12]] provide specific guidance on how to
 							apply WCAG techniques to EPUB publications as well a guidance on how to meet the
 							EPUB-specific objectives of this document.</p>
 					</dd>
@@ -1772,7 +1769,7 @@
 							document</a>.</p>
 				</section>
 			</section>
-			
+
 			<section id="app-vocab-properties">
 				<h3>Certifier properties</h3>
 
@@ -1789,9 +1786,8 @@
 						</tr>
 						<tr>
 							<th>Description:</th>
-							<td>Identifies a party responsible for the testing and certification of the
-								accessibility of an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
-									publication</a>.</td>
+							<td>Identifies a party responsible for the testing and certification of the accessibility of
+								an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a>.</td>
 						</tr>
 						<tr>
 							<th>Allowed value(s):</th>
@@ -1828,9 +1824,9 @@ Accessibility Testers Group
 						</tr>
 						<tr>
 							<th>Description:</th>
-							<td>Identifies a credential or badge that establishes the authority of the party
-								identified in the associated <a href="#certifiedBy"><code>certifiedBy</code>
-									property</a> to certify content accessible.</td>
+							<td>Identifies a credential or badge that establishes the authority of the party identified
+								in the associated <a href="#certifiedBy"><code>certifiedBy</code> property</a> to
+								certify content accessible.</td>
 						</tr>
 						<tr>
 							<th>Allowed value(s):</th>
@@ -1918,13 +1914,13 @@ href="https://example.com/a11y-report/"/></pre>
 					</table>
 				</section>
 			</section>
-					
+
 			<section id="app-vocab-general-properties">
 				<h3>General properties</h3>
-				
+
 				<section id="contactEmail">
 					<h4>contactEmail</h4>
-					
+
 					<table class="tabledef">
 						<caption>Definition of the <code>contactEmail</code> property</caption>
 						<tr>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1152,8 +1152,8 @@
 						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
 							<p>Specifies the version number of the EPUB Accessibility specification the publication
-								conforms to. The value MUST NOT be lower <code>1.1</code> as the 1.0 version of this
-								specification used a different conformance identification scheme.</p>
+								conforms to. The value MUST NOT be lower than <code>1.1</code> as the 1.0 version of
+								this specification used a different conformance identification scheme.</p>
 							<p>The value MUST be <code>1.2</code> to indicate conformance to this version of the
 								specification.</p>
 						</dd>


### PR DESCRIPTION
As noted in a specification, a couple of changes we made early on in the revision necessitate a version number change to not make existing content invalid. Since there hasn't been any negative feedback received since, this pull request makes the changes to the documents so we can republish them under their new numbers. Specifically, it:

- updates the version numbers to 1.2;
- updates all references to 1.1.1 to 1.2;
- removes the open issues markers that noted a version change was required;
- adds the new 1.2 conformance strings;
- explains the the reason the value must not be lower than 1.1 is because 1.0 had a different conformance scheme and adds a second paragraph that conformance to this version requires the number 1.2 (I almost modified the numbering here before spotting it would be a mistake, so I think this makes things a little clearer)

I think that's all that needs changing in the documents, but we'll probably have to get some people involved on the back end to keep the old and new documents in sync as we change numbers.

I've shut off the actions to publish the accessibility spec and techniques, but we'll need a final group approval of this change before merging. I can create the static versions for you @iherman when that's done.

(After the manual FPWDs are created and published, we'll also need to go back and change any other documents that refer to 1.1.1 - for sure the authoring and overview docs.)

Closes #2679
Closes #2725 
