### PR TITLE
Add Annotation usecase about sharing outside of a file or an app

### DIFF
--- a/wg-notes/annotations-ucr/index.html
+++ b/wg-notes/annotations-ucr/index.html
@@ -217,6 +217,20 @@
                     Their name or nickname is also attached to their annotations.
 	            </p>
             </section>
+			<section>
+				<h3>Annotations shared through social media</h3>
+            	<p>
+	                A user reads an ebook and prepares some annotations, which they feel are particularly insightful or useful. 
+                    They decide to share these annotations with their followers or a broader community on a social media platform. 
+                    They export their annotation file, which includes their name or nickname attached to each annotation.
+                    They then post a link to the annotation file on their social media page, perhaps with a short description or a teaser of the content. 
+                    They may offer the file for free or charge a small fee using an integrated payment system. 
+                    Another user, who is reading the same ebook, sees the post and decides to download the annotation file. 
+                    They import the annotations into their own reading system. 
+                    The annotations from the original user appear in the ebook, enriching their reading experience with new perspectives. 
+                    The other user can also add their own annotations and potentially share them in the same manner, creating a chain of shared knowledge.
+	            </p>
+            </section>
         </section>
 				<section>
 					<h2>Generating citations</h2>


### PR DESCRIPTION
Existing use cases occur in controlled environments, such as ePubs sold with annotations or annotations shared within the app. This adds a new use case: the annotation file is made available somewhere, and someone downloads it. This would also probably cover sending annotations through email.

[Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fwg-notes%2Fannotations-ucr%2F&doc2=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fepub-specs%2Fcbc791b6f83a5b3f9596eefe94313e4cc3c0bf4c%2Fwg-notes%2Fannotations-ucr%2Findex.html)