### PR TITLE
Editorial changes on the Annotation UCR

### DIFF
--- a/wg-notes/annotations-ucr/index.html
+++ b/wg-notes/annotations-ucr/index.html
@@ -52,7 +52,7 @@
             <section>
                 <h3>Annotating a textual section</h3>
                 <p>
-                    A user decides to annotate a textual section of an EPUB. She
+                    A user decides to annotate a textual section of an EPUB publication. She
                     selects the section, triggers the annotation affordance,
                     optionally enters a note, selects a highlight mode and
                     color. She then saves the annotation. The selected section
@@ -62,7 +62,7 @@
             <section>
                 <h3>Annotating an image</h3>
                 <p>
-                    A user annotates an image included in an EPUB. He selects
+                    A user annotates an image included in an EPUB publication. He selects
                     the image and triggers the annotation affordance. The
                     annotation feature is then identical to the one associated
                     with a textual selection.
@@ -95,7 +95,7 @@
             <section>
                 <h3>Bookmarking</h3>
                 <p>
-                    A user decides to bookmark a location in a reflowable EPUB. The
+                    A user decides to bookmark a location in a reflowable EPUB publication. The
                     cursor is located where the user clicks on the screen, or at a
                     default location (often the top-left corner of the screen, for
                     left-to-right content). The user triggers the bookmark
@@ -108,11 +108,11 @@
             <section>
                 <h3>Keeping track of the Last Reading Position</h3>
                 <p>
-                    A user stops reading and closes the EPUB. 
-                    He exports the EPUB with his annotations, bookmarks, 
+                    A user stops reading and closes the EPUB publication. 
+                    He exports the EPUB publication with his annotations, bookmarks, 
                     and last reading position. 
-                    He then imports the EPUB into another reading system that supports this specification. 
-                    The reading system opens the EPUB at the last reading position, 
+                    He then imports the EPUB publication into another reading system that supports this specification. 
+                    The reading system opens the EPUB publication at the last reading position, 
                     allowing him to continue reading from where he left off.
                 </p>
             </section>
@@ -122,15 +122,14 @@
             <section>
 				<h3>Creating and formatting textual notes</h3>
             	<p>
-	                A user adds an annotation to an EPUB after selecting an audio segment in an audio clip. 
-                    He adds a textual note with rich text formatting: 
-                    emphasize, italic, underline, subtitles.
+	                A user adds an annotation to an EPUB publication after selecting an audio segment in an audio clip. 
+                    He adds a textual note with rich text formatting, like emphasize, italic, underline, subtitles.
 	            </p>
             </section>
             <section>
 				<h3>Creating audio notes</h3>
             	<p>
-	                A user adds an annotation to an EPUB after selecting an image. 
+	                A user adds an annotation to an EPUB publication after selecting an image. 
                     She adds an audio note by recording her voice; the audio clip is attached 
                     to the annotation.
 	            </p>
@@ -138,7 +137,7 @@
             <section>
 				<h3>Creating image notes</h3>
             	<p>
-	                A user adds an annotation to an EPUB after highlighting some text. 
+	                A user adds an annotation to an EPUB publication after highlighting some text. 
                     She adds an image note by drawing a sketch on her screen with her digital pen and attaching it 
                     to the annotation.
 	            </p>
@@ -146,14 +145,14 @@
             <section>
 				<h3>Annotation color and highlight type</h3>
             	<p>
-	                A user adds an annotation to an EPUB after highlighting some text. 
-                    He selects a color for the highlight and a type (e.g. solid background,underline, strikethrough, outline).
+	                A user adds an annotation to an EPUB publication after highlighting some text. 
+                    He selects a color for the highlight and a type (e.g. solid background, underline, strikethrough, outline).
 	            </p>
             </section>
             <section>
-				<h3>Annotation keywords</h3>
+				<h3>Annotation keywords (tags)</h3>
             	<p>
-	                A user adds an annotation to an EPUB. 
+	                A user adds an annotation to an EPUB publication. 
                     He enters one or more keywords that will help categorizing the annotation.
 	            </p>
             </section>
@@ -180,7 +179,7 @@
             <section>
 				<h3>Exporting a book with annotations</h3>
             	<p>
-	                A user exports from a reading system an EPUB he has previously
+	                A user exports from a reading system an EPUB publication he has previously
 	                annotated. He decides to save his annotations and bookmarks in
 	                the EPUB package. If he imports the ebook into another reading
 	                system that supports this specification, annotations and
@@ -190,15 +189,15 @@
             <section>
 				<h3>Annotations used in the publishing workflow</h3>
             	<p>
-	                A copy-editor verifies an EPUB before publication. She opens the
-	                EPUB in a reading system that supports this specification,
+	                A copy-editor verifies an EPUB publication before publication. She opens the
+	                EPUB publication in a reading system that supports this specification,
 	                annotates text containing typos and images with missing
 	                descriptions. She exports his set of annotations on a destination
 	                folder with a specific file name, and provides the file to the
 	                EPUB creator. The EPUB creator associates the annotation set
 	                with the EPUB file in an editing tool that supports this
 	                specification, goes through the annotations, and corrects the
-	                EPUB.
+	                EPUB publication.
 	            </p>
             </section>
 			<section>
@@ -221,12 +220,13 @@
 				<section>
 					<h2>Generating citations</h2>
 					<p>
-							A student had temporary access to an EPUB via an academic subscription bundle.
-							He annotated the ebook while he had access to it and exported his set of annotations.
-							He no longer has access to the ebook.
-
-							These annotations are nevertheless useful to him, as they include ebook metadata (title, author, year of publication), and each annotation is associated with an indication of the progression in the publication (print pagination if present, % of progression in the publication, timestamp in the case of an audiobook), and contextual information like the chapter or section in which the annotation was created.
-							He can generate citations in a standardized format, like APA or MLA, to include in his report. He can then use these annotations in a word processor, or in a note-taking application, to prepare a report or an essay.
+                        A student had temporary access to an EPUB publication via an academic subscription bundle.
+                        He annotated the publication while he had access to it and exported his set of annotations.
+                        He no longer has access to the publication after the expiration of his subscription.
+                    </p>
+                    <p>
+                        These annotations are nevertheless useful to him, as they include the publication metadata (title, author, year of publication, etc.), and each annotation is associated with an indication of the progression in the publication (print pagination if present, % of progression in the publication, or the timestamp in the case of an audiobook), and contextual information like the chapter or section in which the annotation was created.
+                        He can therefore generate citations in a standardized format, like APA or MLA, to include in his report. He can also use these annotations in a word processor, or in a note-taking application, to prepare a report or an essay.
 					</p>
 				</section>
         <section>
@@ -234,7 +234,7 @@
 						<section>
 							<h3>Synchronizing annotation among devices</h3>
 							<p>
-									A user annotates an EPUB. She synchronizes her annotations and
+									A user annotates an EPUB publication. She synchronizes her annotations and
 									bookmarks with her other personal devices via a standardized
 									Cloud mechanism supported by each of these systems.
 							</p>
@@ -242,7 +242,7 @@
 						<section>
 							<h3>Sharing annotations among readers</h3>
 							<p>
-									Participants to a book club read the same EPUB ebook during a
+									Participants to a book club read the same EPUB publication ebook during a
 									period of time, in a reading system that supports this
 									specification. Each participant adds notes to the book, and
 									these annotations are shared via a standardized Cloud mechanism
@@ -253,19 +253,19 @@
 						</section>
 				</section>
         <section>
-            <h2>Surviving EPUB versioning</h2>
+            <h2>Surviving EPUB publication versioning</h2>
             <p>
-                A user has annotated a textual section of an EPUB and closed the
-                ebook. Today, he loads a new version of the EPUB in his reading
+                A user has annotated yesterday a textual section of an EPUB publication and closed the
+                ebook. Today, he loads a new version of the EPUB publication in his reading
                 system. The spine item in which the annotations were created has
                 been modified, and some words have been added to the leaf HTML
                 element in which an annotation was created, before the start of
-                the annotation and in the annotated text itself. Still, the user
+                the annotation and in the annotated text itself. Nevertheless, the user
                 gets the annotation at the proper location.
             </p>
             <p>
-                The same user loads a new edition of the EPUB in his reading
-                system. A new resource - a foreword - has been added to the
+                The same user loads a new edition of the EPUB publication in his reading
+                system. A new resource – a foreword – has been added to the
                 spine, and the page list has been modified. Still, the user gets
                 the annotation at the proper location.
             </p>
@@ -274,9 +274,9 @@
             <h2>List of requirements</h2>
             <p>
                 In this section, we will list all requirements the  
-                EPUB Annotations specification must respect to fulfil the use cases 
+                EPUB Annotations specification must respect to fulfill the use cases 
                 listed in the previous sections. 
-                Not all requirements will be kept during the implementation phase, and some 
+                Not all requirements will be adopted during the implementation phase, and some 
                 aspects may be postponed to future versions of the specification. 
             </p>
             <p>
@@ -311,7 +311,7 @@
                     <li>Support for textual notes with rich text formatting for (e.g., bold, italic, underline, subtitles).</li>
                     <li>Support for audio notes.</li>
                     <li>Support for image notes.</li>
-                    <li>Support for an annotation color.</li>
+                    <li>Support for an annotation background and foreground color.</li>
                     <li>Support for a highlight type (e.g. solid background, underline, strikethrough, outline)</li>
                     <li>Support for keyword tagging.</li>
                 </ul>
@@ -328,7 +328,7 @@
                 <h3>5. Export and Import</h3>
                 <ul>
                     <li>Embedding annotations within the EPUB package for distribution.</li>
-                    <li>Exporting annotations as standalone files, including metadata (book identity, author, timestamp).</li>
+                    <li>Exporting annotations as standalone files, including metadata (book identity, author, timestamp, etc.).</li>
                     <li>Importing external annotation files and linking them to an already imported EPUB, with support for author attribution.</li>
                 </ul>
             </section>


### PR DESCRIPTION
Apart from minor update proposals, I made a systematic 'EPUB" -> 'EPUB publication' change where appropriate, following the [terminology](https://www.w3.org/TR/epub-34/#dfn-epub-publication) in the authoring spec. (At the moment, it is not systematically used.)

See:

* For EPUB Annotations Use Cases and Requirements:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/ann-ucr-comments-september-iherman/wg-notes/annotations-ucr/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/wg-notes/annotations-ucr/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/ann-ucr-comments-september-iherman/wg-notes/annotations-ucr/index.html)

