### PR TITLE
Remove "epub creator" from the accessibility documents

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>
@@ -129,8 +129,9 @@
 
 				<p>This document is not intended to be read in isolation, in other words, as it does not define
 					conformance requirements for making accessibility claims or cover every method for producing
-					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.2 to
-					make a claim of accessibility; verifying only the techniques in this document is not sufficient.</p>
+					accessible content. An EPUB publication has to meet all the requirements of EPUB Accessibility 1.2
+					to make a claim of accessibility; verifying only the techniques in this document is not
+					sufficient.</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -149,9 +150,9 @@
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
 				create <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> that conform to the requirements
-				in [[epub-a11y-12]], but they are not all applicable in all situations and there may be other ways to
-				meet the requirements of that specification. As a result, this document should not be read as providing
-				prescriptive requirements.</p>
+				in [[epub-a11y-12]], but they are not all applicable in all situations and there can be other ways to
+				meet the requirements of that specification. As a result, this document is not intended to be read as
+				providing prescriptive requirements.</p>
 
 			<p>These techniques also do not address issues in digital publishing for which no universally accessible
 				solutions exist. The W3C's Digital Publishing Interest Group has published a note that outlines many of
@@ -230,8 +231,8 @@
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>
 
-					<p>Anyone unfamiliar with [[wcag2]] may find the number of techniques daunting, as they are intended
-						to provide broad coverage of possible solutions.</p>
+					<p>Anyone unfamiliar with [[wcag2]] might find the number of techniques daunting, as they are
+						intended to provide broad coverage of possible solutions.</p>
 
 					<p>Assistance applying these techniques to EPUB content documents is available from the following
 						sources:</p>
@@ -264,7 +265,7 @@
 
 					<p>As EPUB allows two <a data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> to
 						be rendered together in a <a data-cite="epub/#spread">synthetic spread</a> [[epub]], the order
-						of content within a single document cannot always be evaluated in isolation. Content may span
+						of content within a single document cannot always be evaluated in isolation. Content might span
 						visually from one document to the next. For example, a sidebar might span the bottom of two
 						pages.</p>
 
@@ -327,8 +328,8 @@
 						<h5>Note about the table of contents</h5>
 
 						<p>A common question about the EPUB table of contents is what completeness it needs to have with
-							respect to the headings of the publication. Although the obvious answer seems like it should
-							be a simple aggregation of all headings for all sections, practically there are several
+							respect to the headings of the publication. Although the obvious answer is to create a
+							simple aggregation of all the headings for all the sections, practically there are several
 							usability challenges to this approach.</p>
 
 						<p>Factors such as device screen sizes can make the table of contents for publications with a
@@ -369,12 +370,12 @@
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
 						understand the structure and ordering of an <a data-cite="epub/#dfn-epub-publication">EPUB
-							publication</a>. Consequently, users may have difficulty locating where they are in a
+							publication</a>. Consequently, users might have difficulty locating where they are in a
 						publication, where they want to go, and also how to return to previous locations when the order
 						of entries in the table of contents does not match the linear reading order.</p>
 
 					<p>To ensure that the table of contents matches the linear order of the content, the order of its
-						entries should reflect both:</p>
+						entries needs to reflect both:</p>
 
 					<ul>
 						<li>the order of <a data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> in
@@ -382,15 +383,15 @@
 						<li>the order of each referenced section within its respective EPUB content document.</li>
 					</ul>
 
-					<p>Only if there is a logical case for an alternative arrangement of entries should the ordering
-						differ. Such scenarios typically only occur when the content does not have to be read linearly
-						or when additional information is included at the end of a table of contents. For example, the
-						table of contents for a magazine might be ordered to list all the major articles first, followed
-						by features, etc.</p>
+					<p>Only if there is a logical case for an alternative arrangement of entries is it advised that the
+						ordering differ. Such scenarios typically only occur when the content does not have to be read
+						linearly or when additional information is included at the end of a table of contents. For
+						example, the table of contents for a magazine might be ordered to list all the major articles
+						first, followed by features, etc.</p>
 
 					<p>When the ordering of the table of contents does not match the content, the <a
 							href="https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/#accessibilitySummary"
-							>accessibility summary</a> should explain why.</p>
+							>accessibility summary</a> needs to explain why.</p>
 
 					<p>Avoid linking directly to supplementary content from of the table of contents. Instead, define
 						navigation lists to group together related links, such as a table of figures or a table of
@@ -423,11 +424,12 @@
 						This success criterion does not apply to typical EPUB publications, however, as EPUB content
 						documents do not repeat content in the same way that web sites do.</p>
 
-					<p>Each new content document may begin with similar content, such as learning objectives or key
+					<p>Each new content document might begin with similar content, such as learning objectives or key
 						terms, but this content is part of the body of the publication and not identical to what came
-						before. Consequently, it is not required to add a link to skip it. (Secondary content should be
-						identified in accordance with <a href="https://www.w3.org/TR/WCAG/#info-and-relationships"
-							>success criterion 1.3.1</a>, however.)</p>
+						before. Consequently, it is not required to add a link to skip it. (Secondary content still
+						needs to be identified in accordance with <a
+							href="https://www.w3.org/TR/WCAG/#info-and-relationships">success criterion 1.3.1</a>,
+						however.)</p>
 
 					<div class="note">
 						<p>If an EPUB publication were to reproduce a set of web pages with their full site trappings,
@@ -452,7 +454,7 @@
 								document</a> to identify key structures.</p>
 					</div>
 
-					<p>Although the <code>role</code> attribute may seem similar in nature to the <a
+					<p>Although the <code>role</code> attribute might seem similar in nature to the <a
 							data-cite="epub/#sec-epub-type-attribute"><code>type</code> attribute</a> [[epub]], their
 						target uses in EPUB content documents do not overlap.</p>
 
@@ -539,7 +541,7 @@
 &lt;/html></pre>
 
 					<div class="note">
-						<p>When more than one instance of a role is included in a document, each must be uniquely
+						<p>When more than one instance of a role is included in a document, each has to be uniquely
 							identified. The <code>aria-labelledby</code> attribute provides the name of each landmark in
 							the preceding example. The attribute is not required if only one instance is present, so it
 							is omitted from the following examples.</p>
@@ -609,9 +611,9 @@
 						navigation in its own way.</p>
 
 					<p>The EPUB specification does not require that EPUB publications include a specific set of
-						landmarks, but it is recommended that they include a link to the start of the body matter as
-						well as to any major reference sections (e.g., table of contents, endnotes, bibliography,
-						glossary, index).</p>
+						landmarks; it only recommends to include a link to the start of the body matter as well as to
+						any major reference sections (e.g., table of contents, endnotes, bibliography, glossary,
+						index).</p>
 
 					<aside class="example" title="Landmarks expressed in the EPUB 3 navigation document">
 						<pre>&lt;nav epub:type="landmarks">
@@ -783,12 +785,12 @@
 						needs to have a numbered heading element that reflects its actual position in the
 						publication.</p>
 
-					<p>EPUB publications should also be chunked so that the first heading in a document always has the
-						highest number. For example, if a document starts with an <code>h3</code> heading, there should
-						not be an <code>h2</code> heading later in the document (e.g., do not include the start of a new
-						section with the trailing subsections of the previous). It is acceptable for there to be
-						subsequent headings at the same level as the first (e.g., multiple subsections in one document
-						could all have <code>h3</code> headings).</p>
+					<p>It is advised to chunk EPUB publications so that the first heading in a document always has the
+						highest number. For example, if a document starts with an <code>h3</code> heading,
+							an <code>h1</code> or <code>h2</code> heading does not appear later in the document (e.g.,
+						do not include the start of a new section with the trailing subsections of the previous). It is
+						acceptable for there to be subsequent headings at the same level as the first (e.g., multiple
+						subsections in one document could all have <code>h3</code> headings).</p>
 
 					<aside class="example" title="Heading order across documents">
 						<p>In this example, there are two consecutive EPUB content documents in a textbook. The first
@@ -844,8 +846,8 @@
 					<h4>Heading topic or purpose</h4>
 
 					<p><a data-cite="wcag2#non-text-content">Success Criterion 2.4.6</a> [[wcag2]] currently states that
-						all headings must describe their topic or purpose. The implication of this wording is that all
-						chapters in a novel, for example, have a topic or purpose and that the topic or purpose is
+						all headings have to describe their topic or purpose. The implication of this wording is that
+						all chapters in a novel, for example, have a topic or purpose and that the topic or purpose is
 						always clearly reflected by the title of the chapter. Not only is this not always the case, but
 						this success criterion also complicates the use of chapter numbers as headings since these do
 						not establish a topic.</p>
@@ -857,8 +859,7 @@
 						wording &#8212; namely, that the requirement for headings is only that they establish a unique
 						context for the content.</p>
 
-					<p>By this interpretation, the headings in publications should always pass provided they are
-						unique.</p>
+					<p>By this interpretation, the headings in publications always pass provided they are unique.</p>
 
 					<p>It is expected that the wording of the success criterion will be updated to better reflect the
 						uniqueness requirement, likely in the future WCAG 3 due the complexities of changing the wording
@@ -876,7 +877,7 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p>Image-based content in <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> must now
+					<p>Image-based content in <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> now has to
 						meet [[wcag2]] requirements for alternative text and extended descriptions to conform with
 						[[epub-a11y-12]].</p>
 
@@ -942,7 +943,7 @@
 						proper language for users.</p>
 
 					<p class="note">The languages specified in the package document have no effect on individual EPUB
-						content documents (i.e., the language of each document must be specified using the language
+						content documents (i.e., the language of each document has to be specified using the language
 						expression mechanisms it provides).</p>
 				</section>
 
@@ -968,9 +969,9 @@
 
 					<p>Although it is not strictly required to set this information to meet <a
 							data-cite="wcag2#language-of-page">Success Criterion 3.1.1</a> [[wcag2]], as it is
-						non-normative, it should be considered a best practice to always set this field with the proper
-						language information. (Note that EPUB3 requires the language always be specified, so omitting
-						will fail validation requirements.)</p>
+						non-normative, it is best practice to always set this field with the proper language
+						information. (Note that EPUB3 requires the language always be specified, so omitting will fail
+						validation requirements.)</p>
 
 					<p>Although <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not use this
 						language information to render the text content of the EPUB publication, they do use it to
@@ -979,7 +980,7 @@
 
 					<p class="note">The languages specified in the package document have no effect on individual <a
 							data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> (i.e., the language
-						of each document must be specified using the language expression mechanisms it provides).</p>
+						of each document has to be specified using the language expression mechanisms it provides).</p>
 				</section>
 			</section>
 
@@ -1036,8 +1037,8 @@
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB publication might not be readable by them.</p>
 
-				<p>Using multiple renditions to meet accessibility requirements should only be done when there is no
-					other alternative. EPUB publications that contain multiple renditions are conformant to the
+				<p>Using multiple renditions to meet accessibility requirements is only advised when there is no other
+					alternative. EPUB publications that contain multiple renditions are conformant to the
 					[[epub-a11y-12]] specification if at least one rendition meets all the content requirements, but
 					such publications, at a minimum, need to note that a reading system that supports multiple
 					renditions is required in their <a
@@ -1068,9 +1069,9 @@
 					<p>For accessibility purposes, it is most important to specify the <code>role</code> attribute value
 						as this is what <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>
 						will process. The <code>epub:type</code> attribute is not recognized by these devices, but it
-						may be used by <a data-cite="epub/#dfn-epub-reading-system">epub reading systems</a> to enhance
-						the user experience. For compatibility with both types of devices, it is recommended to apply
-						both attributes, although only the <code>role</code> attribute is strictly required for
+						could be used by <a data-cite="epub/#dfn-epub-reading-system">epub reading systems</a> to
+						enhance the user experience. For compatibility with both types of devices, it is advised to
+						apply both attributes, although only the <code>role</code> attribute is strictly required for
 						accessibility conformance.</p>
 
 					<aside class="example" title="Expressing a page break">
@@ -1085,10 +1086,10 @@
 					<p>A <code>title</code> or <code>aria-label</code> attribute is required on the element, as it
 						provides the value that is announced to the user.</p>
 
-					<p>The page number may be inserted as text content within the element, but assistive technologies
-						may not provide a way to disable announcing of the numbers. As a result, users may hear the
-						numbers announced wherever they occur, which could cause confusion (e.g., the number may seem to
-						be part of the sentence it occurs within).</p>
+					<p>The page number can be inserted as text content within the element, but assistive technologies
+						might not provide a way to disable announcing of the numbers. As a result, users might hear the
+						numbers announced wherever they occur, which could cause confusion (e.g., the number might seem
+						to be part of the sentence it occurs within).</p>
 
 					<aside class="example" title="Text page break">
 						<pre>&lt;p>With a philosophical flourish Cato throws himself 
@@ -1139,11 +1140,10 @@
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
-					<p>To mitigate this potential annoyance to readers, page announcements in <a
-							data-cite="epub/#dfn-media-overlay-document">media overlay documents</a> should be
-						identified when they are included. Identification allows a <a
-							data-cite="epub/#dfn-epub-reading-system">reading system</a> to provide a playback
-						experience where the numbers are automatically skipped.</p>
+					<p>To mitigate this potential annoyance to readers, it is advised to identify page announcements in
+							<a data-cite="epub/#dfn-media-overlay-document">media overlay documents</a> when they are
+						included. Identification allows a <a data-cite="epub/#dfn-epub-reading-system">reading
+							system</a> to provide a playback experience where the numbers are automatically skipped.</p>
 
 					<p>To identify page numbers in media overlay documents, attach an <code>epub:type</code> attribute
 						with the value "<a data-cite="epub-ssv-11/#pagebreak"><code>pagebreak</code></a>" [[epub-ssv]]
@@ -1312,8 +1312,8 @@
 					</aside>
 
 					<div class="note">
-						<p>The <a data-cite="epub/#sec-source-of"><code>source-of</code> property</a> was previously
-							recommended in these techniques to identify the <a
+						<p>These techniques previously advised using the <a data-cite="epub/#sec-source-of"
+									><code>source-of</code> property</a> to identify the <a
 								data-cite="epub/#sec-opf-dcmes-optional-def"><code>dc:source</code> element</a>
 							containing the source of the pagination [[epub]]. This method came with a number of
 							limitations, however. It was not future proof, for example, as it relied on the EPUB 3 <a
@@ -1322,11 +1322,10 @@
 							element.</p>
 
 						<p>The <a data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a>
-							[[epub]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly
-							recommended that anyone using the <code>source-of</code> property switch to using the
+							[[epub]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly advised
+							that anyone using the <code>source-of</code> property switch to using the
 								<code>pageBreakSource</code> property. Although the <code>source-of</code> method will
-							remain valid for backwards compatibility purposes, it is no longer recommended for new
-							publications.</p>
+							remain valid for backwards compatibility purposes, its use is no longer advised.</p>
 					</div>
 
 					<p>If an ISBN is not available, include as much information as possible about the source publication
@@ -1390,33 +1389,33 @@
 						embedded audio and video in the document).</p>
 
 					<div class="note">
-						<p>Media overlays should not synchronize to hidden text content. Synchronizing audio with
-							invisible text will be confusing for sighted readers following the playback.</p>
+						<p>Do not synchronize media overlays to hidden text content. Synchronizing audio with invisible
+							text will be confusing for sighted readers following the playback.</p>
 
 						<p>Text content in a collapsed element, like the <a data-lt="details"><code>details</code>
 								element</a> [[html]], is not considered hidden content.</p>
 					</div>
 
-					<p>In addition to synchronizing the visible text, synchronized text-audio playback must also address
-						text alternatives for image-based content. Images may have alternative text and descriptions
-						that are not visible to all users. As synchronization is also meant to aid users who cannot see
-						the images, including these text alternatives and descriptions in the playback is essential to
-						providing the user all the information in the EPUB publication.</p>
+					<p>In addition to synchronizing the visible text, synchronized text-audio playback also has to
+						address text alternatives for image-based content. Images can have alternative text and
+						descriptions that are not visible to all users. As synchronization is also meant to aid users
+						who cannot see the images, including these text alternatives and descriptions in the playback is
+						essential to providing the user all the information in the EPUB publication.</p>
 
-					<p>Text alternatives and descriptions in HTML may be represented in the <a
+					<p>Text alternatives and descriptions in HTML can be represented in the <a
 							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[html]] and linked by ARIA
 						attributes (e.g., <a data-cite="wai-aria#aria-describedby"><code>aria-describedby</code></a> and
 							<a data-cite="wai-aria#aria-details"><code>aria-details</code></a> [[wai-aria]]).
 						Descriptions for image elements in SVG are typically represented in a <a
 							href="https://www.w3.org/TR/SVG/struct.html#DescElement"><code>desc</code> element</a> but
-						ARIA attributes may also be used.</p>
+						ARIA attributes can also be used.</p>
 				</section>
 
 				<section id="sync-reading-order">
 					<span id="sync-002"></span>
 					<h4>Specifying the reading order</h4>
 
-					<p>The default reading order should typically represent the order in which <a
+					<p>The default reading order typically represents the order in which <a
 							data-cite="epub/#dfn-epub-reading-system">reading systems</a> render content to users during
 						synchronized text-audio playback. For <a data-cite="epub/#dfn-epub-publication">EPUB
 							publications</a>, this is a combination of the sequence of <a
@@ -1431,14 +1430,14 @@
 						order.</p>
 
 					<p>Use caution when making alterations, however, as other accessibility issues can arise when the
-						logical order does not match the default order. For example, the content may not be accessible
+						logical order does not match the default order. For example, the content might not be accessible
 						to users of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> when
 						the order in the markup does not match how the assistive technology reads the content. In these
 						cases, using playback to create a logical order can make the EPUB publication fail WCAG
 						conformance requirements.</p>
 
-					<p>One case where the logical may diverge from the reading order and remain accessible is in tables,
-						as assistive technologies typically allow users to choose whether to read by row or by
+					<p>One case where the logical order can diverge from the reading order and remain accessible is in
+						tables, as assistive technologies typically allow users to choose whether to read by row or by
 						column.</p>
 				</section>
 
@@ -1448,8 +1447,8 @@
 
 					<p>Some content elements are not critical to read when following the primary narrative of a work,
 						and that would interrupt a user's concentration if they had to stop and listen to. Footnotes and
-						endnotes are examples of such content, as users may only want to come back and read this content
-						after finishing the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>. The
+						endnotes are examples of such content, as users might only want to come back and read this
+						content after finishing the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>. The
 						announcement of page break numbers can be similarly annoying to readers.</p>
 
 					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] does not
@@ -1460,7 +1459,7 @@
 							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements [[epub]]. These semantics
 						are what allow reading systems to provide users the option to skip their playback sequences.</p>
 
-					<p>The recommended structures to identify for skippability are:</p>
+					<p>It is strongly advised to identify the following structures for skippability:</p>
 
 					<ul>
 						<li>Endnotes &#8212; use the <a data-cite="epub-ssv-11#endnotes"><code>endnotes</code></a> and
@@ -1548,10 +1547,10 @@
 					<h4>Identifying escapable structures</h4>
 
 					<p>Some content elements are containers for expressing complex information. A table, for example,
-						has data arranged in rows and cells. Lists similarly may contain many items. While users may be
-						interested in some of the information in these structures, they also often want to escape from
-						them to keep reading, not have to listen to the entire content before being able to move on.
-						These are called escapable elements, because the user needs to be able to escape from them
+						has data arranged in rows and cells. Lists similarly can contain many items. While users might
+						be interested in some of the information in these structures, they also often want to escape
+						from them to keep reading, not have to listen to the entire content before being able to move
+						on. These are called escapable elements, because the user needs to be able to escape from them
 						whenever they choose to simplify the reading experience.</p>
 
 					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] only
@@ -1562,7 +1561,7 @@
 						are what allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to provide users
 						the option to escape their playback sequences.</p>
 
-					<p>The recommended structures to identify for escapability are:</p>
+					<p>It is strongly advised to identify the following structures for escapability:</p>
 
 					<ul>
 						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code> semantic</a>
@@ -1579,7 +1578,7 @@
 						requirement.</p>
 
 					<div class="note">
-						<p>Identifying nested escapable structures is not recommended at this time. Refer to <a
+						<p>Identifying nested escapable structures is not advised at this time. Refer to <a
 								data-cite="epub/#sec-escapability">Escapability</a> [[epub]] for more information.</p>
 					</div>
 
@@ -1687,7 +1686,7 @@
 					generate text-to-speech playback, or for a refreshable braille display to have access to the
 					underlying text, as well as cause other accessibility issues.</p>
 
-				<p>The application of digital rights management therefore must not impair or impede the functionality of
+				<p>Therefore, the application of digital rights management cannot impair or impede the functionality of
 					assistive technologies on EPUB publications users have the right to access.</p>
 			</section>
 

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -352,7 +352,7 @@
 							everyone — there are legitimate usability reasons why they are not provided now.</p>
 
 						<p>When opting not to provide links to all the headings, it is best to optimize the links that
-							are provide to improve the overall reading experience. Some considerations on how to achieve
+							are provided to improve the overall reading experience. Some considerations on how to achieve
 							this include:</p>
 
 						<ul>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -401,7 +401,7 @@
 					<p>When the ordering of the table of contents does not match the content, the <a
 							href="#accessibilitySummary">accessibility summary</a> should explain why.</p>
 
-					<p>It is also recommended to avoid including links to supplementary content at the end of the table
+					<p>Avoid including links to supplementary content at the end of the table
 						of contents. Links to figure, tables, illustrations and similar content is better included as a
 						separate navigation elements (either in the <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-navigation-document">EPUB navigation document</a>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>
@@ -135,9 +135,7 @@
 				<p>This document is not intended to be read in isolation, in other words, as it does not define
 					conformance requirements for making accessibility claims or cover every method for producing
 					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.2 to
-					make a claim of accessibility. Verifying only the techniques in this document does not mean an <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> can claim conformance to
-					EPUB Accessibility 1.2.</p>
+					make a claim of accessibility; verifying only the techniques in this document is not sufficient.</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -156,9 +154,8 @@
 			<h2>About the techniques</h2>
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
-					<a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> create <a
-					href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> that conform to the
-				requirements in [[epub-a11y-12]], but they are not all applicable in all situations and there may be
+				create <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> that conform to
+				the requirements in [[epub-a11y-12]], but they are not all applicable in all situations and there may be
 				other ways to meet the requirements of that specification. As a result, this document should not be read
 				as providing prescriptive requirements.</p>
 
@@ -167,10 +164,10 @@
 				these issues [[dpub-accessibility]]. As solutions become available, they will be incorporated into the
 				appropriate document, whether this one or one it refers to.</p>
 
-			<p>If EPUB creators encounter issues that are not covered in these or related techniques, they are
-				encouraged to report the issue to the appropriate community for guidance on how to meet accessibility
-				standards. The <a href="https://www.w3.org/WAI/IG/">W3C Web Accessibility Interest Group</a> has a
-				public mailing list where issues meeting [[wcag2]] and [[wai-aria]] requirements can be raised. The <a
+			<p>When encountering issues that are not covered in these or related techniques, please report an issue to
+				the appropriate community for guidance on how to meet accessibility standards. The <a
+					href="https://www.w3.org/WAI/IG/">W3C Web Accessibility Interest Group</a> has a public mailing list
+				where issues meeting [[wcag2]] and [[wai-aria]] requirements can be raised. The <a
 					href="https://github.com/w3c/publ-a11y/issues">W3C Publishing Community Group issue tracker</a> can
 				be used to ask for support implementing EPUB-specific requirements and the <a
 					href="https://github.com/w3c/epub-specs/issues">EPUB 3 Working Group's issue tracker</a> to report
@@ -239,8 +236,8 @@
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>
 
-					<p>EPUB creators not familiar with [[wcag2]] may find the number of techniques daunting, as they are
-						intended to provide broad coverage of possible solutions.</p>
+					<p>Anyone unfamiliar with [[wcag2]] may find the number of techniques daunting, as they are intended
+						to provide broad coverage of possible solutions.</p>
 
 					<p>Assistance applying these techniques to EPUB content documents is available from the following
 						sources:</p>
@@ -293,11 +290,10 @@
 					<p><a data-cite="wcag2#multiple-ways">Success Criterion 2.4.5</a> [[wcag2]] requires there be more
 						than one way to locate a web page within a set of web pages. By default, <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> meet this WCAG
-						requirement so long as <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a>
-						follow the EPUB requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all
-							EPUB content documents in the spine</a> and <a
-							href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure access to all non-linear
-							documents</a> [[epub-3]].</p>
+						requirement so long as <a href="https://www.w3.org/TR/epub/#sec-spine-elem">all EPUB content
+							documents are included in the spine</a> and <a
+							href="https://www.w3.org/TR/epub/#sec-itemref-elem">access to all non-linear documents is
+							provided</a> [[epub-3]].</p>
 
 					<p>The reason an EPUB publication passes by meeting these requirements has to do with differences in
 						how a user interacts with the set of documents in an EPUB publication. In particular, although
@@ -314,12 +310,11 @@
 						how the publication is chunked.</p>
 
 					<p>Following these two requirements therefore satisfies the need for multiple ways to access the
-						content. Reading systems also typically provide search capabilities, something the EPUB creator
-						cannot provide, so users also have a third option available in most cases.</p>
+						content. Reading systems also typically provide search capabilities so users also have a third
+						option available in most cases.</p>
 
-					<p>Although EPUB creators only need to follow EPUB requirements to meet this criterion, they are
-						still encouraged to provide additional methods to improve access beyond the minimum. Some
-						suggestions include:</p>
+					<p>Although following EPUB's basic requirements will meet this criterion, providing additional
+						methods to improve access beyond the minimum is encouraged. Some suggestions include:</p>
 
 					<ul>
 						<li>
@@ -345,9 +340,8 @@
 							usability challenges to this approach.</p>
 
 						<p>Factors such as device screen sizes can make the table of contents for publications with a
-							deep hierarchy of headings unreadable, so <a
-								href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> will trim headings
-							below a certain depth to improve the readability. Further, <a
+							deep hierarchy of headings unreadable, so headings below a certain depth get trimmed to
+							improve the readability. Further, <a
 								href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a> do not
 							always provide structured access to the headings in the table of contents, or provide
 							shortcuts to navigate the links. The result is that users have to listen to each link one at
@@ -357,9 +351,9 @@
 							accessibility support for EPUB evolves — making complete tables of contents usable by
 							everyone — there are legitimate usability reasons why they are not provided now.</p>
 
-						<p>When EPUB creators choose not to provide links to all the headings, however, they should
-							optimize the linking they do provide for the best overall reading experience. Some
-							considerations on how to achieve this include:</p>
+						<p>When opting not to provide links to all the headings, it is best to optimize the links that
+							are provide to improve the overall reading experience. Some considerations on how to achieve
+							this include:</p>
 
 						<ul>
 							<li>
@@ -388,9 +382,8 @@
 						also how to return to previous locations when the order of entries in the table of contents does
 						not match the linear reading order.</p>
 
-					<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> should therefore ensure
-						that the entries in the table of contents always match the linear order of the content.
-						Specifically, the order of entries should reflect both:</p>
+					<p>It is therefore recommended to ensure that the entries in the table of contents always match the
+						linear order of the content. Specifically, the order of entries should reflect both:</p>
 
 					<ul>
 						<li>the order of <a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content
@@ -405,15 +398,16 @@
 						table of contents for a magazine might be ordered to list all the major articles first, followed
 						by features, etc.</p>
 
-					<p>When the ordering of the table of contents does not match the content, EPUB creators should
-						include an explanation why in the <a href="#accessibilitySummary">accessibility summary</a>.</p>
+					<p>When the ordering of the table of contents does not match the content, the <a
+							href="#accessibilitySummary">accessibility summary</a> should explain why.</p>
 
-					<p>EPUB creators should avoid including links to supplementary content at the end of the table of
-						contents. Links to figure, tables, illustrations and similar content is better included as a
+					<p>It is also recommended to avoid including links to supplementary content at the end of the table
+						of contents. Links to figure, tables, illustrations and similar content is better included as a
 						separate navigation elements (either in the <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-navigation-document">EPUB navigation document</a>
-						or in the spine). EPUB creators can include links to these additional navigation lists in the
-						table of contents.</p>
+						or in the spine). The table of content can then provide links to these navigation elements to
+						ensure that users can access them (not all reading systems support the rendering of additional
+						navigation elements).</p>
 				</section>
 
 				<section id="access-bypass-blocks">
@@ -477,16 +471,15 @@
 						footnotes or special presentations of the content).</p>
 
 					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
-						Due to the lack of restrictions on where <a href="https://www.w3.org/TR/epub/#dfn-epub-creator"
-							>EPUB creators</a> can use the <code>type</code> attribute, pairing the attributes may cause
-						accessibility issues (e.g., putting roles on the [[html]] <a data-lt="body"><code>body</code>
-							element</a>).</p>
+						Due to the lack of restrictions on where the <code>type</code> attribute can be used, pairing
+						the attributes may cause accessibility issues (e.g., if it leads to putting roles on the
+						[[html]] <a data-lt="body"><code>body</code> element</a>).</p>
 
 					<p>In particular, the use of the <code>type</code> attribute is not a means of satisfying
 						requirements for ARIA roles in WCAG.</p>
 
-					<p>For EPUB creators looking to move from the <code>type</code> attribute to using ARIA roles, the
-							<a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
+					<p>For anyone looking to move from the <code>type</code> attribute to using ARIA roles, the <a
+							href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
 							Authoring Guide</a> guide details notable authoring differences between the two attributes.
 						It also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
 						equivalent ARIA roles in [[dpub-aria-1.1]] and [[wai-aria]].</p>
@@ -505,11 +498,10 @@
 						is rare, at least for books, for an EPUB publication to contain only one EPUB content document
 						with all the content in it.</p>
 
-					<p>When content is chunked in this way, it often requires the <a
-							href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> to make decisions about
-						how best to restructure the information. A part, for example, will typically not include all the
-						chapters that belong to it. The EPUB creator will instead separate the part heading from each
-						chapter, putting each into a separate document.</p>
+					<p>When content is chunked in this way, it often requires tough decisions about how best to
+						restructure the information. A part, for example, will typically not include all the chapters
+						that belong to it. Instead, the part heading might be separated from each chapter, leaving each
+						chapter in a separate document.</p>
 
 					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
 						functionality of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive
@@ -518,13 +510,12 @@
 						cannot provide a list of landmarks for the whole publication, as it cannot see outside the
 						current document.</p>
 
-					<p>To counteract this destructuring effect, EPUB creators sometimes think to re-add or re-identify
+					<p>To counteract this destructuring effect, a common bad practice is to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
 						(e.g., adding an extra [[html]] <a data-lt="section"><code>section</code> element</a> around a
 						chapter to indicate it belongs to a part). All this practice does, however, is add repetition
 						that is not only disruptive when reading but can make the structure of the publication harder to
-						follow. EPUB creators are therefore advised not to attempt to rebuild structures in these
-						ways.</p>
+						follow. It is therefore advised not to attempt to rebuild structures in these ways.</p>
 
 					<p>For example, consider a book that has five parts and each part contains five chapters.
 						Structurally, each chapter belongs to its part (i.e., is grouped with it), as in the following
@@ -599,25 +590,21 @@
 					<p>[[wai-aria]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
 							href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[epub-3]]: both are
 						designed to provide users with quick access to the major structures of a document, such as
-						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by <a
-							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> from the <a
-							href="#roles-epub-type">roles</a> that have been applied to the markup, so <a
-							href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> only need to follow
-						the requirement to include roles for the landmarks to be made available to users.</p>
+						chapters, glossaries and indexes.</p>
 
-					<p>Although automatic generation of ARIA landmarks simplifies authoring, it also means that ARIA
-						landmarks are limited to how the EPUB publication has been chunked up into <a
-							href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content documents</a>. An
-						assistive technology can only present the landmarks available in the currently-loaded document;
-						it cannot provide a complete picture of all the landmarks in a multi-document publication (see
-						the <a href="#role-repetition">previous section</a> for more discussion about content
-						chunking).</p>
+					<p>ARIA landmarks are compiled automatically by <a data-cite="epub-a11y-11#dfn-assistive-technology"
+							>assistive technologies</a> from the <a href="#roles-epub-type">roles</a> that have been
+						applied to in an <a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content
+							document</a>, but this also means that ARIA landmarks are limited to how the EPUB
+						publication has been chunked up. An assistive technology can only present the landmarks found in
+						the currently-loaded document; it cannot provide a complete picture of all the landmarks in a
+						multi-document publication (see the <a href="#role-repetition">previous section</a> for more
+						discussion about content chunking).</p>
 
-					<p>EPUB landmarks, on the other hand, are compiled by the EPUB creator prior to distribution, and
-						are not directly linked to the use of the <a
-							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
-						><code>type</code> attribute</a> [[epub-3]] in the content. They are designed to simplify
-						linking to major sections of the publication in a machine-readable way, as <a
+					<p>EPUB landmarks, on the other hand, are compiled prior to distribution, and are not directly
+						linked to the use of the <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
+								><code>type</code> attribute</a> [[epub-3]] in the content. They are designed to
+						simplify linking to major sections of the publication in a machine-readable way, as <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a> do not scan
 						the entire publication for landmarks, either. EPUB landmarks are typically not as numerous as
 						ARIA landmarks, as reading systems only expose so many of these navigation aids.</p>
@@ -626,9 +613,10 @@
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
 						navigation in its own way.</p>
 
-					<p>The EPUB specification does not require that EPUB creators include a specific set of landmarks,
-						but it is recommended to include a link to the start of the body matter as well as to any major
-						reference sections (e.g., table of contents, endnotes, bibliography, glossary, index).</p>
+					<p>The EPUB specification does not require that EPUB publications include a specific set of
+						landmarks, but it is recommended that they include a link to the start of the body matter as
+						well as to any major reference sections (e.g., table of contents, endnotes, bibliography,
+						glossary, index).</p>
 
 					<aside class="example" title="Landmarks expressed in the EPUB 3 navigation document">
 						<pre>&lt;nav epub:type="landmarks">
@@ -795,20 +783,19 @@
 							data-lt="h2"><code>h2</code></a> heading).</p>
 
 					<p>Technique <a href="https://www.w3.org/WAI/WCAG22/Techniques/general/G141">G141: Organizing a page
-							using headings</a> instructs <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB
-							creators</a> on correctly using numbered headings within a document, but with EPUB
-						publications the numbered headings also need to remain consistent across documents. Practically,
-						this means that each EPUB content document does not have to begin with an
-						<code>h1</code> heading unless the first heading is a top-level heading — the first heading
+							using headings</a> provides guidance on correctly using numbered headings within a document,
+						but with EPUB publications the numbered headings also need to remain consistent across
+						documents. Practically, this means that each EPUB content document does not have to begin with
+						an <code>h1</code> heading unless the first heading is a top-level heading — the first heading
 						needs to have a numbered heading element that reflects its actual position in the
 						publication.</p>
 
-					<p>EPUB creators also need to chunk their content so that the first heading in a document always has
-						the highest number. For example, if a document starts with an <code>h3</code> heading, there
-						should not be an <code>h2</code> heading later in the document (e.g., do not include the start
-						of a new section with the trailing subsections of the previous). It is acceptable for there to
-						be subsequent headings at the same level as the first (e.g., multiple subsections in one
-						document could all have <code>h3</code> headings).</p>
+					<p>EPUB publications should also be chunked so that the first heading in a document always has the
+						highest number. For example, if a document starts with an <code>h3</code> heading, there should
+						not be an <code>h2</code> heading later in the document (e.g., do not include the start of a new
+						section with the trailing subsections of the previous). It is acceptable for there to be
+						subsequent headings at the same level as the first (e.g., multiple subsections in one document
+						could all have <code>h3</code> headings).</p>
 
 					<aside class="example" title="Heading order across documents">
 						<p>In this example, there are two consecutive EPUB content documents in a textbook. The first
@@ -896,8 +883,8 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> must now ensure that
-						their image-based content meets [[wcag2]] requirements for alternative text and extended
+					<p>Image-based content in <a href="https://www.w3.org/TR/epub/#dfn-epub-publications">EPUB
+							publications</a> must now meet [[wcag2]] requirements for alternative text and extended
 						descriptions to conform with [[epub-a11y-12]].</p>
 
 					<section id="sec-desc-001-res">
@@ -972,11 +959,11 @@
 					<h4>Language of the EPUB publication</h4>
 
 					<p>In addition to being able to express the language of text content, the <a
-							href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a> also allows <a
-							href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> to identify the
-						languages of the <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a>
-						in <a href="https://www.w3.org/TR/epub/#sec-opf-dclanguage"><code>dc:language</code>
-							elements</a> [[epub-3]].</p>
+							href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a> also allows the
+						identification of the languages of the <a
+							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a> in <a
+							href="https://www.w3.org/TR/epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a>
+						[[epub-3]].</p>
 
 					<aside class="example" title="Setting the language of an EPUB publication to Italian">
 						<pre><code>&lt;package …>
@@ -1032,7 +1019,7 @@
 					<p>The use of Unicode characters for all text content avoids this problem, allowing content to
 						successfully meet the minimum requirement for Level A.</p>
 
-					<p>For compliance with <a data-cite="wcag2#cc1_AA">Level AA</a>, EPUB creators are directed to <a
+					<p>For compliance with <a data-cite="wcag2#cc1_AA">Level AA</a>, please also refer to <a
 							data-cite="wcag2#images-of-text">Success Criterion 1.4.5</a> which further restricts the use
 						of images of text to only a set of essential cases.</p>
 				</section>
@@ -1061,14 +1048,13 @@
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB publication might not be readable by them.</p>
 
-				<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> therefore need to use their
-					best discretion when implementing this functionality to meet accessibility requirements. EPUB
-					publications that contain multiple renditions are conformant to the [[epub-a11y-12]] specification
-					if at least one rendition meets all the content requirements, but EPUB creators at a minimum need to
-					note that a reading system that supports multiple renditions is required in their <a
-						href="#accessibilitySummary">accessibility summary</a>. Any other methods the EPUB creator can
-					use to make this dependence known is advisable (e.g., in the <a href="#dist-a11y-metadata"
-						>distribution metadata</a>).</p>
+				<p>Using multiple renditions to meet accessibility requirements should only be done when there is no
+					other alternative. EPUB publications that contain multiple renditions are conformant to the
+					[[epub-a11y-12]] specification if at least one rendition meets all the content requirements, but
+					such publications, at a minimum, need to note that a reading system that supports multiple
+					renditions is required in their <a href="#accessibilitySummary">accessibility summary</a>. The use
+					of methods outside the EPUB publication that can make this dependence known are also advisable
+					(e.g., in the <a href="#dist-a11y-metadata">distribution metadata</a>).</p>
 
 				<p>This section will be updated with techniques for using multiple renditions when there is enough
 					support in reading systems to broadly recommend their use.</p>
@@ -1098,8 +1084,7 @@
 						strictly required for accessibility conformance.</p>
 
 					<aside class="example" title="Expressing a page break">
-						<p>In this example, the EPUB creator identifies an HTML <code>span</code> element as a page
-							break.</p>
+						<p>In this example, the an HTML <code>span</code> element is identified as a page break.</p>
 						<pre>&lt;span
     id="page001"
     epub:type="pagebreak"
@@ -1128,8 +1113,8 @@
 						list</a> is the only way a user can jump to the locations.</p>
 
 					<aside class="example" title="Adding a hyperlink destination in EPUB 2">
-						<p>In this example, the EPUB creator adds an XHTML 1.1 <code>span</code> element to use as a
-							hyperlink destination.</p>
+						<p>In this example, an XHTML 1.1 <code>span</code> element is used as a hyperlink
+							destination.</p>
 						<pre>&lt;html …>
    …
    &lt;body>
@@ -1163,10 +1148,9 @@
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
-					<p>To mitigate this potential annoyance to readers, <a
-							href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> need to identify page
-						announcements in <a href="https://www.w3.org/TR/epub/#dfn-media-overlay-document">media overlay
-							documents</a> when they are included. Identification allows a <a
+					<p>To mitigate this potential annoyance to readers, identify page announcements in <a
+							href="https://www.w3.org/TR/epub/#dfn-media-overlay-document">media overlay documents</a>
+						when they are included. Identification allows a <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading system</a> to provide a
 						playback experience where the numbers are automatically skipped.</p>
 
@@ -1350,9 +1334,9 @@
 
 						<p>The <a data-cite="epub-3#sec-pageBreakSource"><code>pageBreakSource</code> property</a>
 							[[epub-3]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly
-							recommended that EPUB creators who were using the <code>source-of</code> property switch to
-							using the <code>pageBreakSource</code> property. Although the <code>source-of</code> method
-							will remain valid for backwards compatibility purposes, it is no longer recommended for new
+							recommended that anyone using the <code>source-of</code> property switch to using the
+								<code>pageBreakSource</code> property. Although the <code>source-of</code> method will
+							remain valid for backwards compatibility purposes, it is no longer recommended for new
 							publications.</p>
 					</div>
 
@@ -1418,10 +1402,8 @@
 						document).</p>
 
 					<div class="note">
-						<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> should not
-							synchronize hidden text content in an alternative presentation like media overlays.
-							Synchronizing audio with invisible text will be confusing for sighted readers following the
-							playback.</p>
+						<p>Media overlays should not synchronize to hidden text content. Synchronizing audio with
+							invisible text will be confusing for sighted readers following the playback.</p>
 
 						<p>Text content in a collapsed element, like the <a data-lt="details"><code>details</code>
 								element</a> [[html]], is not considered hidden content.</p>
@@ -1455,18 +1437,18 @@
 						document.</p>
 
 					<p>If there are cases where the logical reading order (how a reader would naturally read the
-						content) diverges from the default reading order, EPUB creators can order the playback sequence
-						of <a href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
+						content) diverges from the default reading order, order the playback sequence of <a
+							href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
 							href="https://www.w3.org/TR/epub/#sec-smil-par-elem"><code>par</code></a> elements in a <a
 							href="https://www.w3.org/TR/epub/#sec-overlay-docs">media overlays document</a> [[epub-3]]
 						to match the logical order.</p>
 
-					<p>EPUB creators need to use caution when making alterations, however, as other accessibility issues
-						can arise when the logical order does not match the default order. For example, the content may
-						not be accessible to users of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive
-							technologies</a> when the order in the markup does not match how the assistive technology
-						reads the content. In these cases, using playback to create a logical order can make the EPUB
-						publication fail WCAG conformance requirements.</p>
+					<p>Use caution when making alterations, however, as other accessibility issues can arise when the
+						logical order does not match the default order. For example, the content may not be accessible
+						to users of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> when
+						the order in the markup does not match how the assistive technology reads the content. In these
+						cases, using playback to create a logical order can make the EPUB publication fail WCAG
+						conformance requirements.</p>
 
 					<p>One case where the logical may diverge from the reading order and remain accessible is in tables,
 						as assistive technologies typically allow users to choose whether to read by row or by
@@ -1486,14 +1468,13 @@
 
 					<p>EPUB 3's <a href="https://www.w3.org/TR/epub/#sec-media-overlays">media overlays feature</a>
 						[[epub-3]] does not allow <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
-							systems</a> to determine if playback sequences are skippable unless <a
-							href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> add additional
-						semantics to the markup, however. EPUB creators must use the <a
-							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code></a>
-						attribute [[epub-3]] to add semantics to <a href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"
-								><code>seq</code></a> and <a href="https://www.w3.org/TR/epub/#sec-smil-par-elem"
-								><code>par</code></a> elements [[epub-3]], thereby allowing reading systems to provide
-						users the option to skip their playback sequences.</p>
+							systems</a> to determine if playback sequences are skippable unless additional semantics are
+						added to the markup using the <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
+								><code>epub:type</code></a> attribute [[epub-3]] on <a
+							href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
+							href="https://www.w3.org/TR/epub/#sec-smil-par-elem"><code>par</code></a> elements
+						[[epub-3]]. These semantics are what allow reading systems to provide users the option to skip
+						their playback sequences.</p>
 
 					<p>The recommended structures to identify for skippability are:</p>
 
@@ -1508,7 +1489,8 @@
 								semantic</a> [[epub-ssv-11]] to identify each.</li>
 					</ul>
 
-					<p>EPUB creators may identify other structures but it is not necessary to meet this requirement.</p>
+					<p>The identification of other structures is encouraged but is not necessary to meet this
+						requirement.</p>
 
 					<aside class="example" title="Identifying a skippable footnote">
 						<p>In this example, the <code>footnote</code> semantic identifies a skippable footnote in the
@@ -1589,14 +1571,13 @@
 						whenever they choose to simplify the reading experience.</p>
 
 					<p>EPUB 3's <a href="https://www.w3.org/TR/epub/#sec-media-overlays">media overlays feature</a>
-						[[epub-3]] only supports escapability if <a href="https://www.w3.org/TR/epub/#dfn-epub-creator"
-							>EPUB creators</a> add structural semantics to the markup. EPUB creators must use the <a
-							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
-							attribute</a> [[epub-3]] to add semantics to <a
-							href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
-							href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"><code>par</code></a> elements
-						[[epub-3]] to allow <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
-							systems</a> to provide users the option to escape their playback sequences.</p>
+						[[epub-3]] only supports escapability if structural semantics are added to the markup using the
+							<a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
+							attribute</a> [[epub-3]] on <a href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"
+								><code>seq</code></a> and <a href="https://www.w3.org/TR/epub/#sec-smil-seq-elem"
+								><code>par</code></a> elements [[epub-3]]. These semantics are what allow <a
+							href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a> to provide
+						users the option to escape their playback sequences.</p>
 
 					<p>The recommended structures to identify for escapability are:</p>
 
@@ -1611,7 +1592,8 @@
 							[[epub-ssv-11]] to identify each.</li>
 					</ul>
 
-					<p>EPUB creators may identify other structures but it is not necessary to meet this requirement.</p>
+					<p>The identification of other structures is encouraged but is not necessary to meet this
+						requirement.</p>
 
 					<div class="note">
 						<p>Identifying nested escapable structures is not recommended at this time. Refer to <a
@@ -1688,10 +1670,9 @@
 					<span id="sync-005"></span>
 					<h4>Synchronizing the navigation document</h4>
 
-					<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> can add a <a
-							href="https://www.w3.org/TR/epub/#dfn-media-overlay-document">media overlay document</a> for
-						the <a href="https://www.w3.org/TR/epub/#dfn-epub-navigation-document">EPUB navigation
-							document</a> even when it is not included in the <a
+					<p>A <a href="https://www.w3.org/TR/epub/#dfn-media-overlay-document">media overlay document</a> can
+						be provided for the <a href="https://www.w3.org/TR/epub/#dfn-epub-navigation-document">EPUB
+							navigation document</a> even when the navigation document is not included in the <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-spine">spine</a>. Doing so allow <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a> to announce
 						the link labels regardless of how they present the navigation elements to users (e.g., many

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>
@@ -352,8 +352,8 @@
 							everyone — there are legitimate usability reasons why they are not provided now.</p>
 
 						<p>When opting not to provide links to all the headings, it is best to optimize the links that
-							are provided to improve the overall reading experience. Some considerations on how to achieve
-							this include:</p>
+							are provided to improve the overall reading experience. Some considerations on how to
+							achieve this include:</p>
 
 						<ul>
 							<li>
@@ -382,8 +382,8 @@
 						also how to return to previous locations when the order of entries in the table of contents does
 						not match the linear reading order.</p>
 
-					<p>It is therefore recommended to ensure that the entries in the table of contents always match the
-						linear order of the content. Specifically, the order of entries should reflect both:</p>
+					<p>To ensure that the table of contents matches the linear order of the content, the order of its
+						entries should reflect both:</p>
 
 					<ul>
 						<li>the order of <a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content
@@ -401,13 +401,21 @@
 					<p>When the ordering of the table of contents does not match the content, the <a
 							href="#accessibilitySummary">accessibility summary</a> should explain why.</p>
 
-					<p>Avoid including links to supplementary content at the end of the table
-						of contents. Links to figure, tables, illustrations and similar content is better included as a
-						separate navigation elements (either in the <a
+					<p>Avoid linking directly to supplementary content from of the table of contents. Instead, define
+						navigation lists to group together related links, such as a table of figures or a table of
+						illustrations. These types of lists can be created using <a
+							href="https://www.w3.org/TR/epub/#sec-nav-def-types-other">custom <code>nav</code>
+							elements</a> [[epub-3]] in the <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-navigation-document">EPUB navigation document</a>
-						or in the spine). The table of content can then provide links to these navigation elements to
-						ensure that users can access them (not all reading systems support the rendering of additional
-						navigation elements).</p>
+						or using navigation lists in XHTML content documents. When these navigation lists are included
+						in the <code>spine</code>, the table of contents can link users to them.</p>
+
+					<div class="note">
+						<p>Reading systems do not always provide users an interface to access to custom <code>nav</code>
+							elements in the EPUB navigation document. Consequently, when using the navigation document
+							to add supplementary content lists, it is best to ensure the document is also included in
+							the spine.</p>
+					</div>
 				</section>
 
 				<section id="access-bypass-blocks">
@@ -470,19 +478,21 @@
 							href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a> (e.g., pop-up
 						footnotes or special presentations of the content).</p>
 
-					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
-						Due to the lack of restrictions on where the <code>type</code> attribute can be used, pairing
-						the attributes may cause accessibility issues (e.g., if it leads to putting roles on the
-						[[html]] <a data-lt="body"><code>body</code> element</a>).</p>
-
-					<p>In particular, the use of the <code>type</code> attribute is not a means of satisfying
-						requirements for ARIA roles in WCAG.</p>
+					<p>Since each attribute offers different advantages, it is only necessary to pair them together when
+						both attributes provide benefits. For example, it is common to pair footnote roles and types to
+						ensure reading systems can provide pop-up functionality and assistive technologies can announce
+						the type of link the user has encountered.</p>
 
 					<p>For anyone looking to move from the <code>type</code> attribute to using ARIA roles, the <a
 							href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
-							Authoring Guide</a> guide details notable authoring differences between the two attributes.
-						It also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
-						equivalent ARIA roles in [[dpub-aria-1.1]] and [[wai-aria]].</p>
+							Authoring Guide</a> details notable authoring differences between the two attributes. It
+						also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
+						equivalent ARIA roles in [[dpub-aria-1.1]] and [[wai-aria]]. [[html-aria]] is another useful
+						reference that provides the full list of restrictions on where ARIA roles can be used in
+						HTML.</p>
+
+					<p>Finally, be aware that the use of the <code>type</code> attribute is not a means of satisfying
+						requirements for ARIA roles in WCAG.</p>
 				</section>
 
 				<section id="role-repetition">

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1094,7 +1094,7 @@
 						strictly required for accessibility conformance.</p>
 
 					<aside class="example" title="Expressing a page break">
-						<p>In this example, the an HTML <code>span</code> element is identified as a page break.</p>
+						<p>In this example, the HTML <code>span</code> element is identified as a page break.</p>
 						<pre>&lt;span
     id="page001"
     epub:type="pagebreak"

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -136,9 +136,8 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses terminology defined in <a data-cite="epub/#sec-terminology">EPUB 3.3</a>
-					[[epub]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.2</a>
-					[[epub-a11y-12]]:</p>
+				<p>This document uses terminology defined in <a data-cite="epub/#sec-terminology">EPUB 3.3</a> [[epub]]
+					and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.2</a> [[epub-a11y-12]]:</p>
 
 				<div class="note">
 					<p>Only the first instance of a term in a section links to its definition.</p>
@@ -149,10 +148,10 @@
 			<h2>About the techniques</h2>
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
-				create <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> that conform to
-				the requirements in [[epub-a11y-12]], but they are not all applicable in all situations and there may be
-				other ways to meet the requirements of that specification. As a result, this document should not be read
-				as providing prescriptive requirements.</p>
+				create <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> that conform to the requirements
+				in [[epub-a11y-12]], but they are not all applicable in all situations and there may be other ways to
+				meet the requirements of that specification. As a result, this document should not be read as providing
+				prescriptive requirements.</p>
 
 			<p>These techniques also do not address issues in digital publishing for which no universally accessible
 				solutions exist. The W3C's Digital Publishing Interest Group has published a note that outlines many of
@@ -284,10 +283,9 @@
 
 					<p><a data-cite="wcag2#multiple-ways">Success Criterion 2.4.5</a> [[wcag2]] requires there be more
 						than one way to locate a web page within a set of web pages. By default, <a
-							data-cite="epub/#dfn-epub-publication">EPUB publications</a> meet this WCAG
-						requirement so long as <a data-cite="epub/#sec-spine-elem">all EPUB content
-							documents are included in the spine</a> and <a
-							data-cite="epub/#sec-itemref-elem">access to all non-linear documents is
+							data-cite="epub/#dfn-epub-publication">EPUB publications</a> meet this WCAG requirement so
+						long as <a data-cite="epub/#sec-spine-elem">all EPUB content documents are included in the
+							spine</a> and <a data-cite="epub/#sec-itemref-elem">access to all non-linear documents is
 							provided</a> [[epub-3]].</p>
 
 					<p>The reason an EPUB publication passes by meeting these requirements has to do with differences in
@@ -335,11 +333,11 @@
 
 						<p>Factors such as device screen sizes can make the table of contents for publications with a
 							deep hierarchy of headings unreadable, so headings below a certain depth get trimmed to
-							improve the readability. Further, <a
-								data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not
-							always provide structured access to the headings in the table of contents, or provide
-							shortcuts to navigate the links. The result is that users have to listen to each link one at
-							a time to find where they want to go, a tedious and time-consuming process.</p>
+							improve the readability. Further, <a data-cite="epub/#dfn-epub-reading-system">reading
+								systems</a> do not always provide structured access to the headings in the table of
+							contents, or provide shortcuts to navigate the links. The result is that users have to
+							listen to each link one at a time to find where they want to go, a tedious and
+							time-consuming process.</p>
 
 						<p>Although it is expected that reading systems will improve access to the table of contents as
 							accessibility support for EPUB evolves — making complete tables of contents usable by
@@ -391,16 +389,16 @@
 						by features, etc.</p>
 
 					<p>When the ordering of the table of contents does not match the content, the <a
-							href="#accessibilitySummary">accessibility summary</a> should explain why.</p>
+							href="https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/#accessibilitySummary"
+							>accessibility summary</a> should explain why.</p>
 
 					<p>Avoid linking directly to supplementary content from of the table of contents. Instead, define
 						navigation lists to group together related links, such as a table of figures or a table of
 						illustrations. These types of lists can be created using <a
-							data-cite="epub/#sec-nav-def-types-other">custom <code>nav</code>
-							elements</a> [[epub-3]] in the <a
-							data-cite="epub/#dfn-epub-navigation-document">EPUB navigation document</a>
-						or using navigation lists in XHTML content documents. When these navigation lists are included
-						in the <code>spine</code>, the table of contents can link users to them.</p>
+							data-cite="epub/#sec-nav-def-types-other">custom <code>nav</code> elements</a> [[epub-3]] in
+						the <a data-cite="epub/#dfn-epub-navigation-document">EPUB navigation document</a> or using
+						navigation lists in XHTML content documents. When these navigation lists are included in the
+							<code>spine</code>, the table of contents can link users to them.</p>
 
 					<div class="note">
 						<p>Reading systems do not always provide users an interface to access to custom <code>nav</code>
@@ -487,14 +485,13 @@
 					<span id="sem-002"></span>
 					<h4>Do not repeat roles across chunked content</h4>
 
-					<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> appear
-						as single contiguous documents to users when read, they are typically composed of many
-						individual <a data-cite="epub/#dfn-epub-content-document">EPUB content
-							documents</a>. This practice keeps the amount of markup that has to be rendered small to
-						reduce the load time in <a data-cite="epub/#dfn-epub-reading-system">reading
-							systems</a> (i.e., to minimize the time the user has to wait for a document to appear). It
-						is rare, at least for books, for an EPUB publication to contain only one EPUB content document
-						with all the content in it.</p>
+					<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> appear as single
+						contiguous documents to users when read, they are typically composed of many individual <a
+							data-cite="epub/#dfn-epub-content-document">EPUB content documents</a>. This practice keeps
+						the amount of markup that has to be rendered small to reduce the load time in <a
+							data-cite="epub/#dfn-epub-reading-system">reading systems</a> (i.e., to minimize the time
+						the user has to wait for a document to appear). It is rare, at least for books, for an EPUB
+						publication to contain only one EPUB content document with all the content in it.</p>
 
 					<p>When content is chunked in this way, it often requires restructuring the information to fit
 						within the new file structure. A part, for example, will typically not include all the chapters
@@ -586,9 +583,9 @@
 					<h4>Include EPUB landmarks</h4>
 
 					<p>[[wai-aria]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
-							data-cite="epub/#sec-nav-landmarks">EPUB landmarks</a> [[epub-3]]: both are
-						designed to provide users with quick access to the major structures of a document, such as
-						chapters, glossaries and indexes.</p>
+							data-cite="epub/#sec-nav-landmarks">EPUB landmarks</a> [[epub-3]]: both are designed to
+						provide users with quick access to the major structures of a document, such as chapters,
+						glossaries and indexes.</p>
 
 					<p>ARIA landmarks are compiled automatically by <a data-cite="epub-a11y-11#dfn-assistive-technology"
 							>assistive technologies</a> from the <a href="#roles-epub-type">roles</a> that have been
@@ -601,11 +598,11 @@
 
 					<p>EPUB landmarks, on the other hand, are compiled prior to distribution, and are not directly
 						linked to the use of the <a data-cite="epub/#sec-epub-type-attribute"
-								><code>type</code> attribute</a> [[epub-3]] in the content. They are designed to
-						simplify linking to major sections of the publication in a machine-readable way, as <a
-							data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not scan
-						the entire publication for landmarks, either. EPUB landmarks are typically not as numerous as
-						ARIA landmarks, as reading systems only expose so many of these navigation aids.</p>
+							><code>type</code> attribute</a> [[epub-3]] in the content. They are designed to simplify
+						linking to major sections of the publication in a machine-readable way, as <a
+							data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not scan the entire
+						publication for landmarks, either. EPUB landmarks are typically not as numerous as ARIA
+						landmarks, as reading systems only expose so many of these navigation aids.</p>
 
 					<p>Given these differences in application, however, it is important to include EPUB landmarks and
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
@@ -879,9 +876,9 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p>Image-based content in <a data-cite="epub/#dfn-epub-publication">EPUB
-							publications</a> must now meet [[wcag2]] requirements for alternative text and extended
-						descriptions to conform with [[epub-a11y-12]].</p>
+					<p>Image-based content in <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> must now
+						meet [[wcag2]] requirements for alternative text and extended descriptions to conform with
+						[[epub-a11y-12]].</p>
 
 					<section id="sec-desc-001-res">
 						<h5>Helpful resources</h5>
@@ -954,11 +951,9 @@
 					<h4>Language of the EPUB publication</h4>
 
 					<p>In addition to being able to express the language of text content, the <a
-							data-cite="epub/#dfn-package-document">package document</a> also allows the
-						identification of the languages of the <a
-							data-cite="epub/#dfn-epub-publication">EPUB publication</a> in <a
-							data-cite="epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a>
-						[[epub]].</p>
+							data-cite="epub/#dfn-package-document">package document</a> also allows the identification
+						of the languages of the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> in <a
+							data-cite="epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a> [[epub]].</p>
 
 					<aside class="example" title="Setting the language of an EPUB publication to Italian">
 						<pre><code>&lt;package …>
@@ -1045,9 +1040,11 @@
 					other alternative. EPUB publications that contain multiple renditions are conformant to the
 					[[epub-a11y-12]] specification if at least one rendition meets all the content requirements, but
 					such publications, at a minimum, need to note that a reading system that supports multiple
-					renditions is required in their <a href="https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/#accessibilitySummary">accessibility summary</a>. The use
-					of methods outside the EPUB publication that can make this dependence known are also advisable
-					(e.g., in the <a href="#dist-a11y-metadata">distribution metadata</a>).</p>
+					renditions is required in their <a
+						href="https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/#accessibilitySummary"
+						>accessibility summary</a>. The use of methods outside the EPUB publication that can make this
+					dependence known are also advisable (e.g., in the <a href="#dist-a11y-metadata">distribution
+						metadata</a>).</p>
 
 				<p>This section will be updated with techniques for using multiple renditions when there is enough
 					support in reading systems to broadly recommend their use.</p>
@@ -1143,10 +1140,10 @@
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
 					<p>To mitigate this potential annoyance to readers, page announcements in <a
-							data-cite="epub/#dfn-media-overlay-document">media overlay documents</a>
-						should be identified when they are included. Identification allows a <a
-							data-cite="epub/#dfn-epub-reading-system">reading system</a> to provide a
-						playback experience where the numbers are automatically skipped.</p>
+							data-cite="epub/#dfn-media-overlay-document">media overlay documents</a> should be
+						identified when they are included. Identification allows a <a
+							data-cite="epub/#dfn-epub-reading-system">reading system</a> to provide a playback
+						experience where the numbers are automatically skipped.</p>
 
 					<p>To identify page numbers in media overlay documents, attach an <code>epub:type</code> attribute
 						with the value "<a data-cite="epub-ssv-11/#pagebreak"><code>pagebreak</code></a>" [[epub-ssv]]
@@ -1299,8 +1296,7 @@
 
 					<p>To allow users to determine the suitability of the pagination, identify the ISBN of the source
 						work in the <a data-cite="epub/#dfn-package-document">package document</a> metadata using the <a
-							data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a>
-						[[epub]].</p>
+							data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a> [[epub]].</p>
 
 					<aside class="example" title="Expressing the source of pagination">
 						<p>In this example, the <code>pageBreakSource</code> property contains the ISBN of the print
@@ -1316,14 +1312,14 @@
 					</aside>
 
 					<div class="note">
-						<p>The <a data-cite="epub/#sec-source-of"><code>source-of</code> property</a>
-							was previously recommended in these techniques to identify the <a
-								data-cite="epub/#sec-opf-dcmes-optional-def"><code>dc:source</code>
-								element</a> containing the source of the pagination [[epub]]. This method came with a
-							number of limitations, however. It was not future proof, for example, as it relied on the
-							EPUB 3 <a data-cite="epub/#attrdef-refines"><code>refines</code>
-								attribute</a> [[epub]] and it could not handle pagination without a source due to the
-							reliance on a <code>dc:source</code> element.</p>
+						<p>The <a data-cite="epub/#sec-source-of"><code>source-of</code> property</a> was previously
+							recommended in these techniques to identify the <a
+								data-cite="epub/#sec-opf-dcmes-optional-def"><code>dc:source</code> element</a>
+							containing the source of the pagination [[epub]]. This method came with a number of
+							limitations, however. It was not future proof, for example, as it relied on the EPUB 3 <a
+								data-cite="epub/#attrdef-refines"><code>refines</code> attribute</a> [[epub]] and it
+							could not handle pagination without a source due to the reliance on a <code>dc:source</code>
+							element.</p>
 
 						<p>The <a data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a>
 							[[epub]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly
@@ -1373,9 +1369,9 @@
 						even audio-only playback, have access to the same information as users who do not require
 						synchronized playback.</p>
 
-					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] allows
-						audio to be synchronized with any element in an <a data-cite="epub/#dfn-epub-content-document"
-							>EPUB content document</a>, so there is no technical barrier to providing synchronized
+					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] allows audio
+						to be synchronized with any element in an <a data-cite="epub/#dfn-epub-content-document">EPUB
+							content document</a>, so there is no technical barrier to providing synchronized
 						playback.</p>
 
 					<p>The primary consideration for this objective is what constitutes the text content of an EPUB
@@ -1389,9 +1385,9 @@
 
 					<p>The media overlays <a data-cite="epub/#sec-smil-text-elem"><code>text</code> element</a> is used
 						to reference these elements, either to play back the pre-recorded audio in a sibling <a
-							data-cite="epub/#sec-smil-audio-elem"><code>audio</code> element</a> [[epub]] or to
-						initiate playback of an audio or video element if the <code>audio</code> element is missing
-						(e.g., for embedded audio and video in the document).</p>
+							data-cite="epub/#sec-smil-audio-elem"><code>audio</code> element</a> [[epub]] or to initiate
+						playback of an audio or video element if the <code>audio</code> element is missing (e.g., for
+						embedded audio and video in the document).</p>
 
 					<div class="note">
 						<p>Media overlays should not synchronize to hidden text content. Synchronizing audio with
@@ -1431,8 +1427,8 @@
 						content) diverges from the default reading order, order the playback sequence of <a
 							data-cite="epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
 							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements in a <a
-							data-cite="epub/#sec-overlay-docs">media overlays document</a> [[epub]]
-						to match the logical order.</p>
+							data-cite="epub/#sec-overlay-docs">media overlays document</a> [[epub]] to match the logical
+						order.</p>
 
 					<p>Use caution when making alterations, however, as other accessibility issues can arise when the
 						logical order does not match the default order. For example, the content may not be accessible
@@ -1453,19 +1449,16 @@
 					<p>Some content elements are not critical to read when following the primary narrative of a work,
 						and that would interrupt a user's concentration if they had to stop and listen to. Footnotes and
 						endnotes are examples of such content, as users may only want to come back and read this content
-						after finishing the <a data-cite="epub/#dfn-epub-publication">EPUB
-							publication</a>. The announcement of page break numbers can be similarly annoying to
-						readers.</p>
+						after finishing the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>. The
+						announcement of page break numbers can be similarly annoying to readers.</p>
 
-					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a>
-						[[epub]] does not allow <a data-cite="epub/#dfn-epub-reading-system">reading
-							systems</a> to determine if playback sequences are skippable unless additional semantics are
-						added to the markup using the <a data-cite="epub/#sec-epub-type-attribute"
-								><code>epub:type</code></a> attribute [[epub]] on <a
-							data-cite="epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
-							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements
-						[[epub]]. These semantics are what allow reading systems to provide users the option to skip
-						their playback sequences.</p>
+					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] does not
+						allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to determine if playback
+						sequences are skippable unless additional semantics are added to the markup using the <a
+							data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code></a> attribute [[epub]] on
+							<a data-cite="epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
+							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements [[epub]]. These semantics
+						are what allow reading systems to provide users the option to skip their playback sequences.</p>
 
 					<p>The recommended structures to identify for skippability are:</p>
 
@@ -1561,14 +1554,13 @@
 						These are called escapable elements, because the user needs to be able to escape from them
 						whenever they choose to simplify the reading experience.</p>
 
-					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a>
-						[[epub]] only supports escapability if structural semantics are added to the markup using the
-							<a data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code>
-							attribute</a> [[epub]] on <a data-cite="epub/#sec-smil-seq-elem"
-								><code>seq</code></a> and <a data-cite="epub/#sec-smil-seq-elem"
-								><code>par</code></a> elements [[epub]]. These semantics are what allow <a
-							data-cite="epub/#dfn-epub-reading-system">reading systems</a> to provide
-						users the option to escape their playback sequences.</p>
+					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] only
+						supports escapability if structural semantics are added to the markup using the <a
+							data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[epub]] on
+							<a data-cite="epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
+							data-cite="epub/#sec-smil-seq-elem"><code>par</code></a> elements [[epub]]. These semantics
+						are what allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to provide users
+						the option to escape their playback sequences.</p>
 
 					<p>The recommended structures to identify for escapability are:</p>
 
@@ -1659,14 +1651,13 @@
 					<span id="sync-005"></span>
 					<h4>Synchronizing the navigation document</h4>
 
-					<p>A <a data-cite="epub/#dfn-media-overlay-document">media overlay document</a> can
-						be provided for the <a data-cite="epub/#dfn-epub-navigation-document">EPUB
-							navigation document</a> even when the navigation document is not included in the <a
-							data-cite="epub/#dfn-epub-spine">spine</a>. Doing so allow <a
-							data-cite="epub/#dfn-epub-reading-system">reading systems</a> to announce
-						the link labels regardless of how they present the navigation elements to users (e.g., many
-						reading systems applications create custom table of contents panels by extracting the data from
-						the EPUB navigation document).</p>
+					<p>A <a data-cite="epub/#dfn-media-overlay-document">media overlay document</a> can be provided for
+						the <a data-cite="epub/#dfn-epub-navigation-document">EPUB navigation document</a> even when the
+						navigation document is not included in the <a data-cite="epub/#dfn-epub-spine">spine</a>. Doing
+						so allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to announce the link
+						labels regardless of how they present the navigation elements to users (e.g., many reading
+						systems applications create custom table of contents panels by extracting the data from the EPUB
+						navigation document).</p>
 
 					<p>The process for adding a media overlay document is no different than one for any other
 						document.</p>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -498,8 +498,8 @@
 						is rare, at least for books, for an EPUB publication to contain only one EPUB content document
 						with all the content in it.</p>
 
-					<p>When content is chunked in this way, it often requires tough decisions about how best to
-						restructure the information. A part, for example, will typically not include all the chapters
+					<p>When content is chunked in this way, it often requires restructuring the information to fit
+						within the new file structure. A part, for example, will typically not include all the chapters
 						that belong to it. Instead, the part heading might be separated from each chapter, leaving each
 						chapter in a separate document.</p>
 

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1148,9 +1148,9 @@
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
-					<p>To mitigate this potential annoyance to readers, identify page announcements in <a
+					<p>To mitigate this potential annoyance to readers, page announcements in <a
 							href="https://www.w3.org/TR/epub/#dfn-media-overlay-document">media overlay documents</a>
-						when they are included. Identification allows a <a
+						should be identified when they are included. Identification allows a <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading system</a> to provide a
 						playback experience where the numbers are automatically skipped.</p>
 

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>
@@ -211,9 +211,9 @@
 						[[epub]], for example, which ensures the correct character data can be used (i.e., avoiding the
 						need to use images of text). Although this is an important feature, it is often not enough on
 						its own to ensure that the text is fully accessible in any given language (e.g., additional
-						information about directionality, emphasis, pronunciation, etc. may also be needed).</p>
+						information about directionality, emphasis, pronunciation, etc. might also be needed).</p>
 
-					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
+					<p>Consequently, there can also be language- or culture-specific practices for meeting accessibility
 						requirements. Whether these practices are defined within this specification and its techniques
 						or elsewhere (e.g., in WCAG techniques or language-specific best practice recommendations) will
 						depend on whether the issues are specific to EPUB or broadly affect all web content.</p>
@@ -231,11 +231,11 @@
 					discoverability requirements. Ideally, though, EPUB 2 publications will be upgraded to the latest
 					version of EPUB 3 to get access to the most advanced accessibility features and techniques.</p>
 
-				<p>Note that not all metadata expressions defined in this specification are supported in EPUB 2 as it
-					does not have an equivalent to the <a data-cite="epub/#attrdef-refines"><code>refines</code>
+				<p>Note that EPUB 2 does not support all metadata expressions defined in this specification as it does
+					not have an equivalent to the <a data-cite="epub/#attrdef-refines"><code>refines</code>
 						attribute</a> [[epub]]. If metadata expressions that require a <code>refines</code> attribute
 					cannot be avoided, there will be a certain amount of ambiguity in the statements (i.e.,
-					relationships between expression may only be apparent by their placement in the package document
+					relationships between expression might only be apparent by their placement in the package document
 					metadata).</p>
 			</section>
 
@@ -277,7 +277,7 @@
 				<p>Unlike web pages, <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> are distributed
 					through many channels for personal consumption — a model that has made EPUB a successful format for
 					ebooks and other types of digital publications. A consequence of this model, however, is that
-					specific details about the accessibility of a publication must travel with it.</p>
+					specific details about the accessibility of a publication have to travel with it.</p>
 
 				<p>An online bookstore aggregating content from publishers and authors, for example, does not know the
 					production quality that went into each submission unless the publisher informs them through
@@ -464,7 +464,7 @@
 						<li>
 							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[wcag20]],
 								but it is strongly RECOMMENDED that it meet the requirements of the <a
-									data-cite="wcag2#">latest recommended version of WCAG 2</a>.</p>
+									data-cite="wcag2#">latest W3C Recommendation of WCAG 2</a>.</p>
 						</li>
 
 						<li>
@@ -490,7 +490,7 @@
 
 					<p>Ideally, EPUB publications will conform to the latest version of WCAG 2 at Level AA, but local
 						and national laws, or procurer or distributor requirements, will define the formal thresholds
-						they must meet.</p>
+						they have to meet.</p>
 
 					<div class="note">
 						<p>Examples of legislative requirements for accessibility include the <a
@@ -574,7 +574,8 @@
 							<li>The "<a data-cite="wcag2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
 								page cannot be excluded when making a conformance claim -- applies to every <a
 									data-cite="epub/#dfn-epub-content-document">EPUB content document</a> in the EPUB
-								publication (i.e., they must all conform in full to the conformance level claimed).</li>
+								publication (i.e., they all have to conform in full to the conformance level
+								claimed).</li>
 						</ul>
 					</section>
 				</section>
@@ -727,8 +728,9 @@
 										reproduced in the digital edition).</p>
 									<p>The page list MUST include links to all the <a href="#sec-page-breaks-obj">page
 											break markers</a> in the content.</p>
-									<p>The page list should include links to all pages in the source, whether they are
-										reproduced or not, but this is not a conformance requirement.</p>
+									<p>It is encouraged to include links to all pages in the source in the page list,
+										whether they are reproduced or not, but this is not a conformance
+										requirement.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageList">Provide a page list</a>
 											[[epub-a11y-tech-12]] for more information on meeting this objective.</p>
@@ -766,8 +768,8 @@
 									<p>If an EPUB publication includes page break markers, the page break markers SHOULD
 										identify all pages reproduced from the source (i.e., blank pages and content not
 										reproduced in the digital edition do not require markers).</p>
-									<p>It is recommended that there be page break markers for all the pages in the
-										source, whether reproduced or not, but this is not a requirement.</p>
+									<p>It is encouraged to include page break markers for all the pages in the source,
+										whether reproduced or not, but this is not a requirement.</p>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
 										of the content (e.g., EPUB 3 media overlays [[?epub]]), the page break markers
 										MUST be identified in the playback instructions (e.g., using the <a
@@ -991,7 +993,7 @@
 										out of.</p>
 									<p>The same ease of escaping from content is only possible if <a
 											data-cite="epub/#dfn-epub-publication">EPUB publications</a> include
-										structural semantics in the synchronized text/audio format. Users may not be
+										structural semantics in the synchronized text/audio format. Users might not be
 										able to escape from lists, sidebars, figures, and other highly structured
 										content, without the structural semantics of those elements being available.</p>
 									<p>When the synchronized text-audio playback instructions include this information,
@@ -1030,8 +1032,8 @@
 									<p>Reading systems typically provide their own interfaces to the navigation aids in
 										the EPUB navigation document. For example, they open the table of contents as a
 										specialized interface on top of the content the user is reading.</p>
-									<p>To access these interfaces, users typically must rely on text-to-speech playback,
-										when available, to hear the entries.</p>
+									<p>To access these interfaces, users typically rely on text-to-speech playback, when
+										available, to hear the entries.</p>
 									<p>Providing synchronized text-audio playback for the EPUB navigation document
 										provides reading systems the ability to use auditory labels for the links,
 										improving the experience for auditory readers.</p>
@@ -1410,7 +1412,7 @@
 
 					<p>How long a conformance evaluation of an <a data-cite="epub/#dfn-epub-publication">EPUB
 							publication</a> is good for is a complex question. Unlike web sites, which are continuously
-						evolving, EPUB publications may not be updated again after their initial publication. As a
+						evolving, EPUB publications often do not get updated again after their initial publication. As a
 						result, an unmodified EPUB publication will always conform to its last evaluation.</p>
 
 					<p>It is common in publishing, however, to release updated versions of an EPUB publication to fix
@@ -1434,10 +1436,10 @@
 						release, only the new modifications will likely need evaluation to re-confirm conformance.</p>
 
 					<p>If an updated version of this specification or [[wcag2]] has been published since the last
-						release of the EPUB publication, a new evaluation is recommended to ensure conformance to the
-						latest standards. A full re-evaluation may not be necessary even in this case (e.g., only new or
-						modified success criteria may need checking unless the standards undergo major changes to
-						methodology or conformance).</p>
+						release of the EPUB publication, a new evaluation is advised to ensure conformance to the latest
+						standards. A full re-evaluation might not be necessary even in this case. For example, only new
+						or modified success criteria might need checking unless the standards undergo major changes to
+						methodology or conformance.</p>
 
 					<p>Conversely, an EPUB publication does not need a re-evaluation when only non-substantive changes
 						are made to it, such as:</p>
@@ -1451,18 +1453,18 @@
 							metadata.</li>
 					</ul>
 
-					<p>Individuals qualified to assess the accessibility of EPUB publications should make the
-						determination of whether changes are substantive or not. An editor, for example, may not realize
-						the impact of seemingly minor formatting changes.</p>
+					<p>Individuals qualified to assess the accessibility of EPUB publications need to determine whether
+						changes are substantive or not. An editor, for example, might not realize the impact of
+						seemingly minor formatting changes.</p>
 
 					<p>Even in the case of non-substantive changes, this specification recommends an updated evaluation
 						(full or partial) if the accessibility standards have changed.</p>
 
-					<p>Even more progressive approaches than those described here should also be considered. Waiting for
-						content changes before reviewing and updating the accessibility of EPUB publications can leave
-						them lacking recent improvements. For example, a publisher might prioritize periodic reviews of
-						their top-selling EPUB publications to ensure they remain maximally usable to the widest
-						possible audience.</p>
+					<p>It is strongly encouraged to consider even more progressive approaches than those described here.
+						Waiting for content changes before reviewing and updating the accessibility of EPUB publications
+						can leave them lacking recent improvements. For example, a publisher might prioritize periodic
+						reviews of their top-selling EPUB publications to ensure they remain maximally usable to the
+						widest possible audience.</p>
 				</section>
 			</section>
 
@@ -1480,7 +1482,7 @@
 					using the <a href="#contactEmail"><code>a11y:contactEmail</code> property</a>.</p>
 
 				<p>The email in this field is expected to direct user feedback and questions directly to the party or
-					individual reponsible for the accessibility of publications. It should not be a general purpose
+					individual reponsible for the accessibility of publications. It SHOULD NOT be a general purpose
 					feedback address.</p>
 
 				<div class="example" title="Publisher contact for accessibility information">
@@ -1585,27 +1587,26 @@
 
 			<p>Defining requirements for optimized publications is outside the scope of this specification, as is
 				formally recognizing other standards and guidelines that address these specific needs. The general model
-				of this specification can be used as a basis for identifying how an EPUB publication has been optimized,
-				however.</p>
+				of this specification can be used as a basis for identifying how an EPUB publication has been
+				optimized.</p>
 
 			<p>In particular, if an EPUB publication meets the requirements of an optimization standard, the following
-				best practices are recommended:</p>
+				best practices are also advised:</p>
 
 			<ul>
-				<li>The EPUB publication should meet the <a href="#sec-discovery">discovery metadata requirements</a> of
-					this specification so its accessible properties are machine-readable.</li>
-				<li>The EPUB publication should identify the standard or guidelines it follows in a
-						<code>conformsTo</code> property in accordance with [[dcterms]] so this information can be made
-					available to users.</li>
+				<li>The EPUB publication meet the <a href="#sec-discovery">discovery metadata requirements</a> of this
+					specification so its accessible properties are machine-readable.</li>
+				<li>The EPUB publication identify the standard or guidelines it follows in a <code>conformsTo</code>
+					property in accordance with [[dcterms]] so this information can be made available to users.</li>
 				<li>If the standard does not define conformance values for use in the <code>conformsTo</code> property,
-					the <code>conformsTo</code> property should include a URL [[url]] to where the standard is publicly
+					the <code>conformsTo</code> property include a URL [[url]] to where the standard is publicly
 					available so users can look up the specific details of the optimization.</li>
 				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
-					not publicly available), the metadata should provide additional information about the content has
-					been optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
+					not publicly available), the metadata provide additional information about the content has been
+					optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
 			</ul>
 
-			<p>When creating guidelines for optimized EPUB publications, it is recommended that these practices be
+			<p>When creating guidelines for optimized EPUB publications, it is advised that these practices be
 				integrated as a formal requirement for conformance.</p>
 
 			<div class="note">
@@ -1677,7 +1678,7 @@
 			<p>While many aspects of the distribution process are outside the scope of this specification, there are
 				factors that can be controlled. For example, while a publisher typically does not control the
 				accessibility of the digital rights management (DRM) scheme applied to their EPUB publications, they do
-				control what usage rights to apply to their EPUB publications. So even though a DRM scheme may allow a
+				control what usage rights to apply to their EPUB publications. So even though a DRM scheme might allow a
 				publisher to block access to the text of the publication, that publisher needs to take care not to apply
 				such a restriction as it could block the ability for <a>assistive technologies</a> to read the text
 				aloud.</p>
@@ -1712,8 +1713,8 @@
 				bookstores and any other interface that can build a profile of the user, on the other hand, has the
 				potential to violate the user's privacy. While it might seem helpful to store and anticipate the type of
 				content a user is most likely to consume, for example, or how best to initiate its playback, developers
-				should not engage in such profiling unless explicit permission is obtained from the user and a means of
-				easily removing the profile is available.</p>
+				are advised not engage in such profiling unless explicit permission is obtained from the user and a
+				means of easily removing the profile is available.</p>
 
 			<p>Even in the case where a user assents to the application maintaining information about their
 				accessibility needs, developers SHOULD ensure that this information is kept private (e.g., not share the
@@ -1946,7 +1947,7 @@ href="https://example.com/a11y-report/"/></pre>
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility 1.1</a> — those that may affect the
+					href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility 1.1</a> — those that can affect the
 				conformance of EPUB publications.</p>
 
 			<p>For a list of all issues addressed, refer to the <a

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -208,9 +208,9 @@
 					<p>At the same time, the language and writing conventions of the authored text will influence the
 						techniques necessary to meet the accessibility requirements. EPUB <a
 							href="https://www.w3.org/TR/epub/#confreq-xml-enc">requires support for Unicode text</a>
-						[[epub]], for example, which ensures the correct character data can be used (i.e., avoiding
-						the need to use images of text). Although this is an important feature, it is often not enough
-						on its own to ensure that the text is fully accessible in any given language (e.g., additional
+						[[epub]], for example, which ensures the correct character data can be used (i.e., avoiding the
+						need to use images of text). Although this is an important feature, it is often not enough on
+						its own to ensure that the text is fully accessible in any given language (e.g., additional
 						information about directionality, emphasis, pronunciation, etc. may also be needed).</p>
 
 					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
@@ -223,8 +223,8 @@
 			<section id="sec-application" class="informative">
 				<h3>Application to older versions of EPUB</h3>
 
-				<p>This specification is applicable to any <a data-cite="epub/#dfn-epub-publication"
-						>EPUB publication</a>, regardless of what version of EPUB it conforms to.</p>
+				<p>This specification is applicable to any <a data-cite="epub/#dfn-epub-publication">EPUB
+						publication</a>, regardless of what version of EPUB it conforms to.</p>
 
 				<p>For example, even though EPUB 2 [[opf-201]] was produced before this specification, and so makes no
 					mention of it, it is possible to create EPUB 2 publications that conform to the accessibility and
@@ -232,11 +232,11 @@
 					version of EPUB 3 to get access to the most advanced accessibility features and techniques.</p>
 
 				<p>Note that not all metadata expressions defined in this specification are supported in EPUB 2 as it
-					does not have an equivalent to the <a data-cite="epub/#attrdef-refines"
-							><code>refines</code> attribute</a> [[epub]]. If metadata expressions that require a
-						<code>refines</code> attribute cannot be avoided, there will be a certain amount of ambiguity in
-					the statements (i.e., relationships between expression may only be apparent by their placement in
-					the package document metadata).</p>
+					does not have an equivalent to the <a data-cite="epub/#attrdef-refines"><code>refines</code>
+						attribute</a> [[epub]]. If metadata expressions that require a <code>refines</code> attribute
+					cannot be avoided, there will be a certain amount of ambiguity in the statements (i.e.,
+					relationships between expression may only be apparent by their placement in the package document
+					metadata).</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -274,10 +274,10 @@
 			<section id="sec-disc-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>Unlike web pages, <a data-cite="epub/#dfn-epub-publication">EPUB publications</a>
-					are distributed through many channels for personal consumption — a model that has made EPUB a
-					successful format for ebooks and other types of digital publications. A consequence of this model,
-					however, is that specific details about the accessibility of a publication must travel with it.</p>
+				<p>Unlike web pages, <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> are distributed
+					through many channels for personal consumption — a model that has made EPUB a successful format for
+					ebooks and other types of digital publications. A consequence of this model, however, is that
+					specific details about the accessibility of a publication must travel with it.</p>
 
 				<p>An online bookstore aggregating content from publishers and authors, for example, does not know the
 					production quality that went into each submission unless the publisher informs them through
@@ -350,8 +350,8 @@
 					</li>
 				</ul>
 
-				<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MAY include
-					additional [[schema-org]] accessibility metadata not specified in this section.</p>
+				<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MAY include additional [[schema-org]]
+					accessibility metadata not specified in this section.</p>
 
 				<div class="note">
 					<p>This specification assumes that conformance and discoverability metadata will be processed and
@@ -395,13 +395,13 @@
 
 				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript, and SVG the core technologies used
 					for content authoring. Leveraging these technologies allows the authoring of <a
-						data-cite="epub/#dfn-epub-publication">EPUB publications</a> with a high degree
-					of accessibility through the application of established web accessibility techniques, such as using
-					native elements and controls whenever possible and enhancing custom interactive content with
-					[[wai-aria]] roles, states, and properties. Plus, whenever possible, the EPUB community adds
-					publishing accessibility needs to these standards &#8212; for example, through the creation of the
-					[[dpub-aria-1.1]] role module. It is not necessary for anyone familiar with web accessibility to
-					learn a new accessibility framework to make EPUB publications accessible.</p>
+						data-cite="epub/#dfn-epub-publication">EPUB publications</a> with a high degree of accessibility
+					through the application of established web accessibility techniques, such as using native elements
+					and controls whenever possible and enhancing custom interactive content with [[wai-aria]] roles,
+					states, and properties. Plus, whenever possible, the EPUB community adds publishing accessibility
+					needs to these standards &#8212; for example, through the creation of the [[dpub-aria-1.1]] role
+					module. It is not necessary for anyone familiar with web accessibility to learn a new accessibility
+					framework to make EPUB publications accessible.</p>
 
 				<p>The primary source for producing accessible web content is the W3C's Web Content Accessibility
 					Guidelines (WCAG) [[wcag2]], which establish benchmarks for accessible content. WCAG defines four
@@ -540,11 +540,10 @@
 							for content to be perceivable, operable, understandable, and robust.</p>
 
 						<p>For example, it is not sufficient to correctly order content within individual <a
-								data-cite="epub/#dfn-epub-content-document">EPUB content documents</a>
-							if the <a data-cite="epub/#dfn-epub-spine">spine</a> ordering of documents
-							is incorrect. Likewise, including a title for every EPUB content document is complementary
-							to providing a title for the publication: the overall accessibility decreases if either is
-							missing.</p>
+								data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> if the <a
+								data-cite="epub/#dfn-epub-spine">spine</a> ordering of documents is incorrect. Likewise,
+							including a title for every EPUB content document is complementary to providing a title for
+							the publication: the overall accessibility decreases if either is missing.</p>
 
 						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-12]] provide more information about
 							applying these guidelines to EPUB publications.</p>
@@ -561,17 +560,16 @@
 							<li>When determining compliance with a conformance level, the whole EPUB publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
-							<li><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MUST
-								NOT use EPUB's fallback mechanisms to provide a <a
-									data-cite="wcag2#dfn-conforming-alternate-versions">conforming alternate version</a>
-								[[wcag2]], as there is no reliable way for users to access such fallbacks. If an EPUB
-								publication uses fallbacks, both the primary content and its fallback(s) MUST meet the
-								requirements for the conformance level claimed. EPUB-specific fallback mechanisms
-								include <a data-cite="epub/#sec-manifest-fallbacks">manifest
-									fallbacks</a> [[epub]], <a data-cite="epub/#sec-opf-bindings"
-									>bindings</a> [[epub]] and content switching via the <a
-									data-cite="epub/#sec-xhtml-content-switch"><code>epub:switch</code>
-									element</a> [[epub]].</li>
+							<li><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MUST NOT use EPUB's
+								fallback mechanisms to provide a <a data-cite="wcag2#dfn-conforming-alternate-versions"
+									>conforming alternate version</a> [[wcag2]], as there is no reliable way for users
+								to access such fallbacks. If an EPUB publication uses fallbacks, both the primary
+								content and its fallback(s) MUST meet the requirements for the conformance level
+								claimed. EPUB-specific fallback mechanisms include <a
+									data-cite="epub/#sec-manifest-fallbacks">manifest fallbacks</a> [[epub]], <a
+									data-cite="epub/#sec-opf-bindings">bindings</a> [[epub]] and content switching via
+								the <a data-cite="epub/#sec-xhtml-content-switch"><code>epub:switch</code> element</a>
+								[[epub]].</li>
 
 							<li>The "<a data-cite="wcag2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
 								page cannot be excluded when making a conformance claim -- applies to every <a
@@ -683,13 +681,12 @@
 									<p>When an EPUB publication includes <a href="#sec-page-breaks">page break
 											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
 										to a statically-paginated version of the publication, the publication MUST
-										identify that source in the <a
-											data-cite="epub/#dfn-package-document">package document</a>
-										metadata.</p>
+										identify that source in the <a data-cite="epub/#dfn-package-document">package
+											document</a> metadata.</p>
 									<p>If, however, these features are added to a digital-only <a
-											data-cite="epub/#dfn-epub-publication">EPUB
-										publication</a>, the publication MUST NOT specify a source (i.e., do not
-										identify the current publication as the source of its own pagination).</p>
+											data-cite="epub/#dfn-epub-publication">EPUB publication</a>, the publication
+										MUST NOT specify a source (i.e., do not identify the current publication as the
+										source of its own pagination).</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageSource">Identifying the
 												pagination source</a> [[epub-a11y-tech-12]] for more information on
@@ -774,9 +771,8 @@
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
 										of the content (e.g., EPUB 3 media overlays [[?epub]]), the page break markers
 										MUST be identified in the playback instructions (e.g., using the <a
-											data-cite="epub/#sec-epub-type-attribute"
-												><code>epub:type</code> attribute</a> [[?epub]] in media overlays SMIL
-										files).</p>
+											data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code>
+											attribute</a> [[?epub]] in media overlays SMIL files).</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageBreakMarkers">Provide page break
 												markers</a> [[epub-a11y-tech-12]] for more information on meeting this
@@ -807,11 +803,11 @@
 							ways to control which parts of the content are read aloud.</p>
 
 						<p>In order to offer users greater control over content presentation, EPUB publications need to
-							include structure and semantics so that the <a
-								data-cite="epub/#dfn-epub-reading-system">reading system</a> has the
-							necessary context to enable this type of user experience. With greater context, a reading
-							system can provide the ability to skip past secondary content that interferes with the
-							primary narrative and escape users from deeply nested structures like tables.</p>
+							include structure and semantics so that the <a data-cite="epub/#dfn-epub-reading-system"
+								>reading system</a> has the necessary context to enable this type of user experience.
+							With greater context, a reading system can provide the ability to skip past secondary
+							content that interferes with the primary narrative and escape users from deeply nested
+							structures like tables.</p>
 
 						<p>Adding structure and semantics to synchronized text-audio playback broadly falls under the
 							objective of the <a data-cite="wcag2#info-and-relationships">Info and Relationships success
@@ -865,9 +861,9 @@
 
 								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a>
-										MUST include synchronized audio playback for all visible textual content as well
-										as all textual alternatives for visual media.</p>
+									<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MUST include
+										synchronized audio playback for all visible textual content as well as all
+										textual alternatives for visual media.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-coverage">Ensuring complete
 												text coverage</a> [[epub-a11y-tech-12]] for more information on meeting
@@ -948,8 +944,7 @@
 								<dt id="sec-sync-skippability-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Being able to read the primary narrative of a work without interruption is
-										central to reading comprehension. <a
-											data-cite="epub/#dfn-epub-publication">EPUB
+										central to reading comprehension. <a data-cite="epub/#dfn-epub-publication">EPUB
 											publications</a> are typically structured to visually represent secondary
 										information such as page break markers and footnotes outside the main narrative
 										flow (e.g., by using different background colors or placement so readers can
@@ -959,8 +954,7 @@
 										structural semantics, synchronized text-audio playback cannot offer skipping
 										content either.</p>
 									<p>When the synchronized text-audio playback instructions include structural
-										semantics, however, <a
-											data-cite="epub/#dfn-epub-reading-system">reading
+										semantics, however, <a data-cite="epub/#dfn-epub-reading-system">reading
 											systems</a> can create reading experiences that allow users to decide which
 										secondary content to skip by default.</p>
 								</dd>
@@ -996,15 +990,14 @@
 										they are visually offset from the primary narrative so easily jumped into and
 										out of.</p>
 									<p>The same ease of escaping from content is only possible if <a
-											data-cite="epub/#dfn-epub-publication">EPUB
-											publications</a> include structural semantics in the synchronized text/audio
-										format. Users may not be able to escape from lists, sidebars, figures, and other
-										highly structured content, without the structural semantics of those elements
-										being available.</p>
+											data-cite="epub/#dfn-epub-publication">EPUB publications</a> include
+										structural semantics in the synchronized text/audio format. Users may not be
+										able to escape from lists, sidebars, figures, and other highly structured
+										content, without the structural semantics of those elements being available.</p>
 									<p>When the synchronized text-audio playback instructions include this information,
-											<a data-cite="epub/#dfn-epub-reading-system">reading
-											systems</a> can simplify playback for auditory readers to enable a
-										comparable reading experience.</p>
+											<a data-cite="epub/#dfn-epub-reading-system">reading systems</a> can
+										simplify playback for auditory readers to enable a comparable reading
+										experience.</p>
 								</dd>
 
 								<dt id="sec-sync-escapability-conf">Meeting this Objective</dt>
@@ -1046,8 +1039,8 @@
 
 								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a>
-										SHOULD include synchronized text-audio playback for the <a
+									<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> SHOULD include
+										synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
 											document</a> [[epub]].</p>
 									<div class="note">
@@ -1415,11 +1408,10 @@
 							It is not a conformance requirement of this specification.</p>
 					</div>
 
-					<p>How long a conformance evaluation of an <a
-							data-cite="epub/#dfn-epub-publication">EPUB publication</a> is good for is
-						a complex question. Unlike web sites, which are continuously evolving, EPUB publications may not
-						be updated again after their initial publication. As a result, an unmodified EPUB publication
-						will always conform to its last evaluation.</p>
+					<p>How long a conformance evaluation of an <a data-cite="epub/#dfn-epub-publication">EPUB
+							publication</a> is good for is a complex question. Unlike web sites, which are continuously
+						evolving, EPUB publications may not be updated again after their initial publication. As a
+						result, an unmodified EPUB publication will always conform to its last evaluation.</p>
 
 					<p>It is common in publishing, however, to release updated versions of an EPUB publication to fix
 						errors and typos in the work, as well as to periodically release new editions. As not all
@@ -1563,7 +1555,9 @@
 							roles specific to identifying common publishing structures.</p>
 					</dd>
 
-					<dt><a data-cite="epub-aria-authoring/#">EPUB Type to ARIA Role Authoring Guide</a></dt>
+					<dt>
+						<a data-cite="epub-aria-authoring/#">EPUB Type to ARIA Role Authoring Guide</a>
+					</dt>
 					<dd>
 						<p>The EPUB Type to ARIA Role authoring guide provides mappings from the semantics used in the
 								<code>epub:type</code> attribute to ARIA and DPUB-ARIA role equivalents.</p>
@@ -1666,20 +1660,19 @@
 			<h2>Distribution</h2>
 
 			<div class="note">
-				<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> do not have
-					to meet the recommendations in this section to conform to this specification, some jurisdictions
-					require EPUB publications to follow similar practices. <a
+				<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> do not have to meet the
+					recommendations in this section to conform to this specification, some jurisdictions require EPUB
+					publications to follow similar practices. <a
 						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
 						2019/882</a>, for example, includes similar requirements for digital publications distributed in
 					the European Union.</p>
 			</div>
 
-			<p>The creation of accessible <a data-cite="epub/#dfn-epub-publication">EPUB
-					publications</a> does not guarantee that the publication will be obtainable or consumable by users
-				in an accessible fashion. Depending on how they are distributed, other factors will influence their
-				overall accessibility. For example, an accessible interface for locating and obtaining content is an
-				essential part of the distribution process, as is the ability to search and review accessibility
-				metadata.</p>
+			<p>The creation of accessible <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> does not
+				guarantee that the publication will be obtainable or consumable by users in an accessible fashion.
+				Depending on how they are distributed, other factors will influence their overall accessibility. For
+				example, an accessible interface for locating and obtaining content is an essential part of the
+				distribution process, as is the ability to search and review accessibility metadata.</p>
 
 			<p>While many aspects of the distribution process are outside the scope of this specification, there are
 				factors that can be controlled. For example, while a publisher typically does not control the
@@ -1712,8 +1705,8 @@
 				new features are introduced by this specification.</p>
 
 			<p>The inclusion of accessibility metadata similarly does not introduce security or privacy issues, as
-				describing an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> only
-				provides a general idea of its suitability for different user groups.</p>
+				describing an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> only provides a general
+				idea of its suitability for different user groups.</p>
 
 			<p>The use of accessibility metadata in <a data-cite="epub/#dfn-epub-reading-system">reading systems</a>,
 				bookstores and any other interface that can build a profile of the user, on the other hand, has the

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1493,7 +1493,7 @@
 					for their needs.</p>
 
 				<p>To assist users in reporting any accessibility issues they encounter, or to discover more about the
-					accessibility of an EPUB publication, EPUB publications MAY include a accessibility contact email
+					accessibility of an EPUB publication, EPUB publications MAY include an accessibility contact email
 					using the <a href="#contactEmail"><code>a11y:contactEmail</code> property</a>.</p>
 
 				<p>The email in this field is expected to direct user feedback and questions directly to the party or

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -162,17 +162,16 @@
 					certification. At a minimum, all EPUB publications that conform to this specification meet the
 					accessibility metadata requirements described in <a href="#sec-discovery"></a>.</p>
 
-				<p>Although <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> have always been
-					able to create EPUB publications with a high degree of accessibility, this specification sets formal
-					requirements for certifying content accessible. These requirements provide EPUB creators a clear set
-					of guidelines to evaluate their content against and allows certification of quality. An accessible
-					EPUB publication is one that meets the accessibility requirements described in <a
+				<p>Although creating EPUB publications with a high degree of accessibility has always been possible,
+					this specification sets formal requirements for certifying content accessible. These requirements
+					provide a clear set of guidelines to evaluate content against and allow certification of quality. An
+					accessible EPUB publication is one that meets the accessibility requirements described in <a
 						href="#sec-accessible-pubs"></a>.</p>
 
 				<p>The specification also discusses the practice of optimizing EPUB publications for specific reading
-					modalities. In these cases, the content cannot meet the broad accessibility requirements of this
-					specification, but by following its discoverability and reporting requirements EPUB creators can
-					improve the ability of users to determine if the content still meets their needs. Refer to <a
+					modalities. In these cases, although the content cannot meet the broad accessibility requirements of
+					this specification, if the publications follow the discoverability and reporting requirements they
+					can improve the ability of users to determine if the content still meets their needs. Refer to <a
 						href="#sec-optimized-pubs"></a> for more information.</p>
 
 				<p>The specification also addresses the impact of distribution on the accessibility and discoverability
@@ -214,11 +213,10 @@
 					<p>At the same time, the language and writing conventions of the authored text will influence the
 						techniques necessary to meet the accessibility requirements. EPUB <a
 							href="https://www.w3.org/TR/epub/#confreq-xml-enc">requires support for Unicode text</a>
-						[[epub-3]], for example, which ensures the correct character data can be used (i.e., <a
-							href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> do not have to use
-						images of text). Although this is an important feature, it is often not enough on its own to
-						ensure that the text is fully accessible in any given language (e.g., additional information
-						about directionality, emphasis, pronunciation, etc. may also be needed).</p>
+						[[epub-3]], for example, which ensures the correct character data can be used (i.e., avoiding
+						the need to use images of text). Although this is an important feature, it is often not enough
+						on its own to ensure that the text is fully accessible in any given language (e.g., additional
+						information about directionality, emphasis, pronunciation, etc. may also be needed).</p>
 
 					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
 						requirements. Whether these practices are defined within this specification and its techniques
@@ -231,20 +229,19 @@
 				<h3>Application to older versions of EPUB</h3>
 
 				<p>This specification is applicable to any <a href="https://www.w3.org/TR/epub/#dfn-epub-publication"
-						>EPUB publication</a>, even if the content conforms to an older version of EPUB that does not
-					refer to this specification (e.g., EPUB 2 [[opf-201]]).</p>
+						>EPUB publication</a>, regardless of what version of EPUB it conforms to.</p>
 
-				<p>Creators of such EPUB publications should create content in conformance with the accessibility and
-					discoverability requirements of this specification. <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> should also upgrade to the
-					latest version of EPUB to get access to the most advanced accessibility features and techniques.</p>
+				<p>For example, even though EPUB 2 [[opf-201]] was produced before this specification, and so makes no
+					mention of it, it is possible to create EPUB 2 publications that conform its the accessibility and
+					discoverability requirements. Ideally, though, EPUB 2 publications will be upgraded to the latest
+					version of EPUB 3 to get access to the most advanced accessibility features and techniques.</p>
 
-				<p>Note that not all metadata expressions defined in this specification are supported in older version
-					of EPUB. EPUB 2, in particular, does not support the <a
-						href="https://www.w3.org/TR/epub/#attrdef-refines"><code>refines</code> attribute</a>
-					[[epub-3]]. If EPUB creators cannot avoid expressions that require this attribute, they will have to
-					accept a certain amount of ambiguity in their statements (i.e., relationships between expression may
-					only be apparent by their placement in the package document metadata).</p>
+				<p>Note that not all metadata expressions defined in this specification are supported in EPUB 2 as it
+					does not have an equivalent to the <a href="https://www.w3.org/TR/epub/#attrdef-refines"
+							><code>refines</code> attribute</a> [[epub-3]]. If metadata expressions that require a
+						<code>refines</code> attribute cannot be avoided, there will be a certain amount of ambiguity in
+					the statements (i.e., relationships between expression may only be apparent by their placement in
+					the package document metadata).</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -281,11 +278,10 @@
 			<section id="sec-disc-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>Unlike web pages, <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> distribute
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> through many
-					channels for personal consumption — a model that has made EPUB a successful format for ebooks and
-					other types of digital publications. A consequence of this model, however, is that specific details
-					about the accessibility of a publication must travel with it.</p>
+				<p>Unlike web pages, <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>
+					are distributed through many channels for personal consumption — a model that has made EPUB a
+					successful format for ebooks and other types of digital publications. A consequence of this model,
+					however, is that specific details about the accessibility of a publication must travel with it.</p>
 
 				<p>An online bookstore aggregating content from publishers and authors, for example, does not know the
 					production quality that went into each submission unless the publisher informs them through
@@ -359,8 +355,8 @@
 					</li>
 				</ul>
 
-				<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> MAY include additional
-					[[schema-org]] accessibility metadata not specified in this section.</p>
+				<p><a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> MAY include
+					additional [[schema-org]] accessibility metadata not specified in this section.</p>
 
 				<div class="note">
 					<p>This specification assumes that conformance and discoverability metadata will be processed and
@@ -402,8 +398,7 @@
 				<h3>Introduction</h3>
 
 				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript, and SVG the core technologies used
-					for content authoring. Leveraging these technologies allows <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> to author <a
+					for content authoring. Leveraging these technologies allows the authoring of <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> with a high degree
 					of accessibility through the application of established web accessibility techniques, such as using
 					native elements and controls whenever possible and enhancing custom interactive content with
@@ -453,9 +448,9 @@
 					that need clarification in the context of an EPUB publication. It does not mean that the rest of the
 					WCAG techniques are not applicable.</p>
 
-				<p>As a result, although <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> can
-					read this section without deep knowledge of WCAG conformance, to implement the accessibility
-					requirements of this specification requires an understanding of WCAG.</p>
+				<p>As a result, although it is possible to read this section without deep knowledge of WCAG conformance,
+					to implement the accessibility requirements of this specification requires an understanding of
+					WCAG.</p>
 
 				<p>Because this specification adds requirements that are not a part of WCAG, an EPUB publication can
 					conform to WCAG without conforming to this specification.</p>
@@ -473,19 +468,18 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[wcag20]],
-								but it is strongly recommended that it meet the requirements of the <a
+								but it is strongly RECOMMENDED that it meet the requirements of the <a
 									data-cite="wcag2#">latest recommended version of WCAG 2</a>.</p>
 						</li>
 
 						<li>
 							<p id="confreq-wcag-a">MUST, for whichever version of WCAG 2 selected, meet the requirements
-								of <a data-cite="wcag2#cc1_A">Level A</a>, but it is strongly recommended that it meet
+								of <a data-cite="wcag2#cc1_A">Level A</a>, but it is strongly RECOMMENDED that it meet
 								the requirements of <a data-cite="wcag2#cc1_AA">Level AA</a>.</p>
 							<div class="note">
 								<p>Although conforming at <a data-cite="wcag2#cc1_AAA">level AAA</a> is not required by
-									this specification, <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB
-										creators</a> are encouraged to follow the practices detailed in AAA success
-									criteria when producing accessible EPUB publications.</p>
+									this specification, following the practices detailed in AAA success criteria when
+									producing accessible EPUB publications is encouraged.</p>
 							</div>
 						</li>
 					</ul>
@@ -495,14 +489,13 @@
 						requirements in effect in those regions.</p>
 
 					<p>This specification sets the baseline requirement to WCAG 2.0 Level A, for example, primarily to
-						provide EPUB creators backwards compatibility for older content and flexibility to encourage
-						adoption of accessible production where no formal requirements exist. Most accessibility
-						practitioners do not recognize this level as providing a high degree of accessibility,
-						however.</p>
+						provide backwards compatibility for older content and flexibility to encourage adoption of
+						accessible production where no formal requirements exist. Most accessibility practitioners do
+						not recognize this level as providing a high degree of accessibility, however.</p>
 
-					<p>Ideally, EPUB creators should try to conform to the latest version of WCAG 2 at Level AA, but
-						local and national laws, or procurer or distributor requirements, will define the formal
-						thresholds they must meet.</p>
+					<p>Ideally, EPUB publications will conform to the latest version of WCAG 2 at Level AA, but local
+						and national laws, or procurer or distributor requirements, will define the formal thresholds
+						they must meet.</p>
 
 					<div class="note">
 						<p>Examples of legislative requirements for accessibility include the <a
@@ -520,18 +513,17 @@
 						while still helpful, can result in a less optimal reading experience.</p>
 
 					<p>Similarly, legal frameworks and policies often cite Level AA conformance as the benchmark for
-						accessibility. The reason is that it provides the greatest range of improvements that EPUB
-						creators can realistically implement. When EPUB creators meet only Level A conformance, they
-						compromise their content for various user groups, resulting in a less optimal reading
-						experience.</p>
+						accessibility as this level provides the greatest range of improvements that are realistic to
+						implement. When only meeting Level A conformance, accessibility is compromised for various user
+						groups, resulting in a less optimal reading experience.</p>
 
 					<div class="note">
 						<p>The <a href="https://www.w3.org/WAI/about/groups/agwg/">W3C Accessibility Guidelines Working
 								Group</a> is currently developing WCAG 3. As this version potentially represents a
 							significant departure from WCAG 2, a future version of this specification will address
-							conformance requirements related to it. EPUB creators are encouraged to adopt WCAG 3 once it
-							is stable and widely recognized, but conformance to the new version is not a requirement of
-							this standard.</p>
+							conformance requirements related to it. Adoption of WCAG 3 is encouraged once it is stable
+							and widely recognized, but conformance to the new version is not a requirement of this
+							standard.</p>
 					</div>
 				</section>
 
@@ -547,21 +539,17 @@
 							closely resembles what WCAG refers to as a <a data-cite="wcag2#dfn-set-of-web-pages">set of
 								web pages</a>: "[a] collection of web pages that share a common purpose" [[wcag2]].</p>
 
-						<p>Consequently, when evaluating the accessibility of an EPUB publication, <a
-								href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> cannot review
-							individual pages — or EPUB content documents, as they are known in EPUB 3 — in isolation.
-							Rather, EPUB creators MUST evaluate their accessibility as part of the larger work.</p>
+						<p>Consequently, when evaluating the accessibility of an EPUB publication, it is not possible to
+							review individual pages — or EPUB content documents, as they are known in EPUB 3 — in
+							isolation. Rather, the full EPUB publication MUST be evaluated against the WCAG guidelines
+							for content to be perceivable, operable, understandable, and robust.</p>
 
-						<p>For example, it is not sufficient for EPUB creators to order the content within individual <a
+						<p>For example, it is not sufficient to correctly order content within individual <a
 								href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content documents</a>
-							if they list the documents in the wrong order in the <a
-								href="https://www.w3.org/TR/epub/#dfn-epub-spine">spine</a>. Likewise, including a title
-							for every EPUB content document is complementary to providing a title for the publication:
-							the overall accessibility decreases if either is missing.</p>
-
-						<p>EPUB creators MUST evaluate the WCAG guidelines for content to be perceivable, operable,
-							understandable, and robust against the full EPUB publication, not only against each EPUB
-							content document within it.</p>
+							if the <a href="https://www.w3.org/TR/epub/#dfn-epub-spine">spine</a> ordering of documents
+							is incorrect. Likewise, including a title for every EPUB content document is complementary
+							to providing a title for the publication: the overall accessibility decreases if either is
+							missing.</p>
 
 						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-12]] provide more information about
 							applying these guidelines to EPUB publications.</p>
@@ -578,11 +566,11 @@
 							<li>When determining compliance with a conformance level, the whole EPUB publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
-							<li><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> MUST NOT use
-								EPUB's fallback mechanisms to provide a <a
+							<li><a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> MUST
+								NOT use EPUB's fallback mechanisms to provide a <a
 									data-cite="wcag2#dfn-conforming-alternate-versions">conforming alternate version</a>
 								[[wcag2]], as there is no reliable way for users to access such fallbacks. If an EPUB
-								creator uses fallbacks, both the primary content and its fallback(s) MUST meet the
+								publication uses fallbacks, both the primary content and its fallback(s) MUST meet the
 								requirements for the conformance level claimed. EPUB-specific fallback mechanisms
 								include <a href="https://www.w3.org/TR/epub/#sec-manifest-fallbacks">manifest
 									fallbacks</a> [[epub-3]], <a href="https://www.w3.org/TR/epub/#sec-opf-bindings"
@@ -652,23 +640,23 @@
 							include page navigation whenever any of the following cases is true:</p>
 
 						<ul>
-							<li>the <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> identifies
-								the EPUB publication as the dynamically paginated equivalent of a statically paginated
+							<li>the EPUB publication is the dynamically paginated equivalent of a statically paginated
 								publication (e.g., included in a print/digital bundle);</li>
 
-							<li>the EPUB creator offers the EPUB publication as an alternative to a statically paginated
-								publication in an environment where they can reasonably predict the use of both versions
-								(e.g., educational settings); or</li>
+							<li>the EPUB publication is offered as an alternative to a statically paginated publication
+								in an environment where it it reasonable to expect the use of both versions (e.g.,
+								educational settings); or</li>
 
-							<li>the EPUB creator generates the EPUB publication and a statically paginated publication
-								from a workflow that allows the retention of page break locations across formats.</li>
+							<li>the EPUB publication is produced from the same workflow as a statically paginated
+								publication and the workflow allows the retention of page break locations across
+								formats.</li>
 						</ul>
 
-						<p>EPUB creators MAY include page navigation in reflowable EPUB publications without statically
-							paginated equivalents.</p>
+						<p>Reflowable EPUB publications without statically paginated equivalents MAY include page
+							navigation.</p>
 
-						<p>When EPUB creators include page navigation, the objectives defined in this section apply to
-							the EPUB publication.</p>
+						<p>Only when an EPUB publication includes page navigation do the objectives defined in this
+							section apply to it.</p>
 					</section>
 
 					<section id="sec-page-nav-obj">
@@ -694,10 +682,6 @@
 									<p>Including a recognizable identifier for the statically paginated source, such as
 										its ISBN or ISSN, ensures that users can determine which version the pagination
 										corresponds to.</p>
-									<p>If <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a>
-										insert pagination as a navigation aid for digital-only publications, they must
-										not specify a source (i.e., do not identify the current publication as the
-										source of its own pagination).</p>
 								</dd>
 
 								<dt id="sec-page-src-conf">Meeting this Objective</dt>
@@ -705,10 +689,14 @@
 								<dd>
 									<p>When an EPUB publication includes <a href="#sec-page-breaks">page break
 											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
-										to a statically-paginated version of the publication, EPUB creators MUST
+										to a statically-paginated version of the publication, the publication MUST
 										identify that source in the <a
 											href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a>
 										metadata.</p>
+									<p>If, however, these features are added to a digital-only <a
+											href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
+										publication</a>, the publication MUST NOT specify a source (i.e., do not
+										identify the current publication as the source of its own pagination).</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageSource">Identifying the
 												pagination source</a> [[epub-a11y-tech-12]] for more information on
@@ -745,14 +733,13 @@
 								<dt id="sec-page-list-conf">Meeting this Objective</dt>
 								<dd>
 									<p>An EPUB publication MUST include a page list.</p>
-									<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> SHOULD
-										include links to all pages of content reproduced from the source (i.e., they do
-										not have to provide links for blank pages or content not reproduced in the
-										digital edition).</p>
-									<p>EPUB creators MUST include links to all <a href="#sec-page-breaks-obj">page break
-											markers</a> in the content.</p>
-									<p>EPUB creators should include links for all pages in the source whether they are
-										reproduced or not, but this is not a requirement.</p>
+									<p>The page list SHOULD include links to all pages of content reproduced from the
+										source (i.e., it does not have to include links for blank pages or content not
+										reproduced in the digital edition).</p>
+									<p>The page list MUST include links to all the <a href="#sec-page-breaks-obj">page
+											break markers</a> in the content.</p>
+									<p>The page list should include links for all pages in the source, whether they are
+										reproduced or not, but this is not a conformance requirement.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageList">Provide a page list</a>
 											[[epub-a11y-tech-12]] for more information on meeting this objective.</p>
@@ -788,18 +775,20 @@
 								<dt id="sec-page-break-conf">Meeting this Objective</dt>
 								<dd>
 									<p>Inclusion of page break markers in an EPUB publication is OPTIONAL.</p>
-									<p>If an <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a>
-										includes page break markers:</p>
+									<p>If an EPUB publication includes page break markers:</p>
 									<ul>
-										<li>they SHOULD include page break markers for all pages reproduced from the
-											source (i.e., blank pages and content not reproduced in the digital edition
-											do not require markers).</li>
-										<li>they should include page break markers for all pages in the source (whether
-											reproduced or not), but this is not a requirement.</li>
+										<li>the page break markers SHOULD identify all pages reproduced from the source
+											(i.e., blank pages and content not reproduced in the digital edition do not
+											require markers).</li>
+										<li>the page break markers should identify all pages in the source, whether
+											reproduced or not, but this is not a requirement.</li>
 									</ul>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
-										of the content (e.g., EPUB 3 media overlays [[?epub-3]]), EPUB creators MUST
-										identify the page numbers in the markup that controls the playback.</p>
+										of the content (e.g., EPUB 3 media overlays [[?epub-3]]), the page break markers
+										MUST be identified in the playback instructions (e.g., using the <a
+											href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
+												><code>epub:type</code> attribute</a> [[?epub-3]] in media overlays SMIL
+										files).</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageBreakMarkers">Provide page break
 												markers</a> [[epub-a11y-tech-12]] for more information on meeting this
@@ -829,9 +818,8 @@
 							contents, and also introduces audio-centric reading features like phrase navigation, and
 							ways to control which parts of the content are read aloud.</p>
 
-						<p>In order to offer users greater control over content presentation, <a
-								href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> need to add
-							structure and semantics so that the <a
+						<p>In order to offer users greater control over content presentation, EPUB publications need to
+							include structure and semantics so that the <a
 								href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading system</a> has the
 							necessary context to enable this type of user experience. With greater context, a reading
 							system can provide the ability to skip past secondary content that interferes with the
@@ -852,13 +840,13 @@
 							conformant with this specification.</p>
 
 						<p>To maximize the effectiveness of synchronized text-audio playback for people with different
-							reading needs, however, <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB
-								creators</a> are strongly encouraged to meet the <a href="#sec-sync-obj">OPTIONAL
-								objectives</a> defined in the next section.</p>
+							reading needs, however, is is strongly encouraged that EPUB publications meet the <a
+								href="#sec-sync-obj">OPTIONAL objectives</a> defined in the next section.</p>
 
 						<div class="note">
-							<p>EPUB creators do not have to include synchronized text-audio playback in their EPUB
-								publications, only ensure it conforms to these requirements when present.</p>
+							<p>These requirements only apply when EPUB publications include synchronized text-audio
+								playback; they do not require that all EPUB publications include synchronized playback
+								to be conforming.</p>
 						</div>
 					</section>
 
@@ -889,9 +877,9 @@
 
 								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> MUST
-										provide synchronized audio playback for all visible textual content as well as
-										all textual alternatives for visual media.</p>
+									<p><a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>
+										MUST include synchronized audio playback for all visible textual content as well
+										as all textual alternatives for visual media.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-coverage">Ensuring complete
 												text coverage</a> [[epub-a11y-tech-12]] for more information on meeting
@@ -942,16 +930,15 @@
 
 								<dt id="sec-sync-order-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> SHOULD
-										order the synchronized text-audio playback instructions such that they reflect
+									<p>The order of the synchronized text-audio playback instructions SHOULD reflect
 										both:</p>
 									<ul>
 										<li>the order of the referenced EPUB content documents in the <a
 												href="https://www.w3.org/TR/epub/#dfn-epub-spine">spine</a>; and</li>
 										<li>the order of each element within its respective EPUB content document.</li>
 									</ul>
-									<p>If EPUB creators use a different ordering, that ordering MUST still result in a
-										logical playback of the content.</p>
+									<p>If an EPUB publication uses a different ordering, that ordering MUST still result
+										in a logical playback of the content.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-reading-order">Specifying the
 												reading order</a> [[epub-a11y-tech-12]] for more information on meeting
@@ -974,25 +961,26 @@
 								<dd>
 									<p>Being able to read the primary narrative of a work without interruption is
 										central to reading comprehension. <a
-											href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a>
-										typically structure <a href="https://www.w3.org/TR/epub/#dfn-epub-publication"
-											>EPUB publications</a> to visually represent secondary information such as
-										page break markers and footnotes outside the main narrative flow (e.g., by using
-										different background colors or placement so readers can filter this information
-										visually out while reading).</p>
+											href="https://www.w3.org/TR/epub/#dfn-epub-publications">EPUB
+											publications</a> are typically structured to visually represent secondary
+										information such as page break markers and footnotes outside the main narrative
+										flow (e.g., by using different background colors or placement so readers can
+										filter this information visually out while reading).</p>
 									<p>Readers who prefer auditory playback, however, cannot skip this information with
 										the same ease in a linear audio-based reading experience. And, without
 										structural semantics, synchronized text-audio playback cannot offer skipping
 										content either.</p>
-									<p>When EPUB creators add structural semantics, however, <a
+									<p>When the synchronized text-audio playback instructions include structural
+										semantics, however, <a
 											href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
 											systems</a> can create reading experiences that allow users to decide which
-										secondary content to skip by default during playback.</p>
+										secondary content to skip by default.</p>
 								</dd>
 
 								<dt id="sec-sync-skippability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB creators SHOULD identify all skippable structures.</p>
+									<p>Synchronized text-audio playback instructions SHOULD identify all skippable
+										structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-skippability">Identifying
 												skippable structures</a> [[epub-a11y-tech-12]] for more information on
@@ -1020,20 +1008,21 @@
 										they are visually offset from the primary narrative so easily jumped into and
 										out of.</p>
 									<p>The same ease of escaping from content is only possible if <a
-											href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> encode
-										the structural semantics into the synchronized text/audio format. Users may not
-										be able to escape from lists, sidebars, figures, and other highly structured
-										content, unless EPUB creators encode the structural semantics of those
-										elements.</p>
-									<p>When EPUB creators provide this information, <a
-											href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
+											href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
+											publications</a> include structural semantics in the synchronized text/audio
+										format. Users may not be able to escape from lists, sidebars, figures, and other
+										highly structured content, without the structural semantics of those elements
+										available.</p>
+									<p>When the synchronized text-audio playback instructions include this information,
+											<a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
 											systems</a> can simplify playback for auditory readers to enable a
 										comparable reading experience.</p>
 								</dd>
 
 								<dt id="sec-sync-escapability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB creators SHOULD identify all escapable structures.</p>
+									<p>Synchronized text-audio playback instructions SHOULD identify all escapable
+										structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-escapability">Identifying
 												escapable structures</a> [[epub-a11y-tech-12]] for more information on
@@ -1070,8 +1059,8 @@
 
 								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> SHOULD
-										provide synchronized text-audio playback for the <a
+									<p><a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>
+										SHOULD include synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
 											document</a> [[epub-3]].</p>
 									<div class="note">
@@ -1170,9 +1159,8 @@
 					</dl>
 
 					<aside class="example" title="A basic conformance statement">
-						<p>In this example, the <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a>
-							is stating that their publication conforms to the EPUB Accessibility 1.2 specification at
-							WCAG 2.2 Level AA.</p>
+						<p>In this example, the EPUB publication metadata indicates that the content conforms to the
+							EPUB Accessibility 1.2 specification at WCAG 2.2 Level AA.</p>
 
 						<pre>&lt;package …>
    &lt;metadata …>
@@ -1229,20 +1217,20 @@
 							publication can have multiple <code>dcterms:conformsTo</code> statements.</p>
 
 						<p>For example, if an EPUB publication only meets WCAG conformance requirements (i.e., does not
-							fully conform to this specification), EPUB creators can add a
+							fully conform to this specification), the metadata could include a
 								<code>dcterms:conformsTo</code> property with a conformance URL defined in the <a
 								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
 								Conformance Claim</a> [[wcag2]].</p>
 
 						<div class="note">
-							<p>As [[wcag2]] does not define how to specify the conformance level in the URL, EPUB
-								creators will have to find an alternative means of relating this information when
-								necessary (e.g., through the accessibility summary).</p>
+							<p>As [[wcag2]] does not define how to specify the conformance level in the URL, an
+								alternative means of relating this information will be necessary (e.g., it could be
+								expressed in an accessibility summary).</p>
 						</div>
 
-						<p>Conversely, EPUB creators might need to indicate that an EPUB publication does not meet any
-							accessibility standards (e.g., in order to claim an exemption). In these cases, they can use
-							a <code>dcterms:conformsTo</code> property with value "<code>none</code>".</p>
+						<p>Conversely, to indicate that an EPUB publication does not meet any accessibility standards
+							(e.g., in order to claim an exemption), the metadata could include a
+								<code>dcterms:conformsTo</code> property with value "<code>none</code>".</p>
 
 						<div class="note">
 							<p>For more information about claiming exemptions, refer to <a
@@ -1430,25 +1418,24 @@
 					<h4>Re-evaluating conformance</h4>
 
 					<div class="note">
-						<p>The following guidance is provided only to help <a
-								href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> determine when a
-							new evaluation is necessary. It is not a conformance requirement of this specification.</p>
+						<p>The following guidance is provided only to help determine when a new evaluation is necessary.
+							It is not a conformance requirement of this specification.</p>
 					</div>
 
 					<p>How long a conformance evaluation of an <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a> is good for is
-						a complex question. Unlike web sites, which are continuously evolving, EPUB creators may not
-						update EPUB publications after their initial publication. As a result, an unmodified EPUB
-						publication will always conform to its last evaluation.</p>
+						a complex question. Unlike web sites, which are continuously evolving, EPUB publications may not
+						be updated again after their initial publication. As a result, an unmodified EPUB publication
+						will always conform to its last evaluation.</p>
 
 					<p>It is common in publishing, however, to release updated versions of an EPUB publication to fix
 						errors and typos in the work, as well as to periodically release new editions. As not all
 						changes to an EPUB publication substantively change its accessibility, this complicates the
-						question of when EPUB creators should perform a new evaluation, as well as whether a full or
-						partial re-evaluation will suffice.</p>
+						question of when to perform a new evaluation, as well as whether a full or partial re-evaluation
+						will suffice.</p>
 
-					<p>As a rule, EPUB creators must re-evaluate their content whenever they make substantive changes to
-						the structure and functionality of an EPUB publication, such as:</p>
+					<p>As a general rule, re-evaluate content whenever substantive changes are made to the structure and
+						functionality of an EPUB publication, such as:</p>
 
 					<ul>
 						<li>modifications to the nature or order of markup in <a
@@ -1460,17 +1447,17 @@
 					</ul>
 
 					<p>If the EPUB publication includes substantively the same markup and content as the previous
-						release, the EPUB creator may only need to evaluate the new modifications to re-confirm
-						conformance.</p>
+						release, only the new modifications will likely need evaluation to re-confirm conformance, so
+						long as the conformance standard has not changed.</p>
 
 					<p>If an updated version of this specification or [[wcag2]] has been published since the last
-						release of the EPUB publication, however, this specification also recommends performing a new
-						evaluation to ensure conformance to the latest standards. EPUB creators may not have to perform
-						a full re-evaluation even in this case (i.e., they may only need to check new or modified
-						success criteria unless the standards undergo major changes to methodology or conformance).</p>
+						release of the EPUB publication, a new evaluation is recommended to ensure conformance to the
+						latest standards. A full re-evaluation may not be necessary even in this case (e.g., only new or
+						modified success criteria may need checking unless the standards undergo major changes to
+						methodology or conformance).</p>
 
-					<p>Conversely, EPUB creators do not need to perform a re-evaluation when making non-substantive
-						changes, such as:</p>
+					<p>Conversely, an EPUB publication does not need a re-evaluation when only non-substantive changes
+						are made to it, such as:</p>
 
 					<ul>
 						<li>fixes for typographic errors in the text (i.e., no markup is changed);</li>
@@ -1488,7 +1475,7 @@
 					<p>Even in the case of non-substantive changes, this specification recommends an updated evaluation
 						(full or partial) if the accessibility standards have changed.</p>
 
-					<p>EPUB creators should consider even more progressive approaches than those described here. Waiting
+					<p>Publishers should consider even more progressive approaches than those described here. Waiting
 						for content changes before reviewing and updating the accessibility of EPUB publications can
 						leave them lacking recent improvements. For example, a publisher might prioritize periodic
 						reviews of their top-selling EPUB publications to ensure they remain maximally usable to the
@@ -1499,15 +1486,15 @@
 			<section id="sec-feedback">
 				<h3>Feedback</h3>
 
-				<p>Although EPUB creators are expected to assess their publications prior to certifying them accessible,
+				<p>Although publishers are expected to assess their publications prior to certifying them accessible,
 					due to the sheer volumes of content produced and the complexity of checking all the markup it is
 					sometimes the case that issues will slip through to the final product. Accessibility reporting can
 					also not be detailed enough for every user to be able to determine the suitability of the content
 					for their needs.</p>
 
 				<p>To assist users in reporting any accessibility issues they encounter, or to discover more about the
-					accessibility of an EPUB publication, EPUB creators MAY include a contact email using the <a
-						href="#contactEmail"><code>a11y:contactEmail</code> property</a>.</p>
+					accessibility of an EPUB publication, EPUB publications MAY include a accessibility contact email
+					using the <a href="#contactEmail"><code>a11y:contactEmail</code> property</a>.</p>
 
 				<p>The email in this field is expected to direct user feedback and questions directly to the party or
 					individual reponsible for the accessibility of publications. It should not be a general purpose
@@ -1595,14 +1582,14 @@
 				the content (i.e., they can listen to the full publication and can navigate between headings), but it is
 				not usable by anyone who cannot hear the audio.</p>
 
-			<p>In other words, when an <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> optimizes
-				an EPUB publication for a specific reading modality, the failure to achieve a WCAG conformance level
-				does not make it any less accessible to the intended audience.</p>
+			<p>In other words, when optimizing an EPUB publication for a specific reading modality, the failure to
+				achieve a WCAG conformance level does not make the publication any less accessible to the intended
+				audience.</p>
 
 			<p>Defining requirements for optimized publications is outside the scope of this specification, as is
 				formally recognizing other standards and guidelines that address these specific needs. The general model
-				of this specification can be used as a basis for identifying how an EPUB creator has optimized their
-				content, however.</p>
+				of this specification can be used as a basis for identifying how an EPUB publication has been optimized,
+				however.</p>
 
 			<p>In particular, if an EPUB publication meets the requirements of an optimization standard, the following
 				best practices are recommended:</p>
@@ -1613,13 +1600,12 @@
 				<li>The EPUB publication should identify the standard or guidelines it follows in a
 						<code>conformsTo</code> property in accordance with [[dcterms]] so this information can be made
 					available to users.</li>
-				<li>If the standard does not define conformance values for the <code>conformsTo</code> property, EPUB
-					creators should use a URL [[url]] to where the standard is publicly available so users can look up
-					the specific details of the standard.</li>
+				<li>If the standard does not define conformance values for use in the <code>conformsTo</code> property,
+					the <code>conformsTo</code> property should include a URL [[url]] to where the standard is publicly
+					available so users can look up the specific details of the optimization.</li>
 				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
-					not publicly available), EPUB creators should provide additional information about they have
-					optimized the content in the <a href="#confreq-schema-accessibilitySummary">accessibility
-						summary</a>.</li>
+					not publicly available), the metadata should provide additional information about the content has
+					been optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
 			</ul>
 
 			<p>When creating guidelines for optimized EPUB publications, it is recommended that these practices be
@@ -1677,9 +1663,9 @@
 			<h2>Distribution</h2>
 
 			<div class="note">
-				<p>Although <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> do not have to
-					follow the recommendations in this section to conform to this specification, some jurisdictions
-					require EPUB creators to follow similar practices. <a
+				<p>Although <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> do not have
+					to meet the recommendations in this section to conform to this specification, some jurisdictions
+					require similar distribution practices. <a
 						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
 						2019/882</a>, for example, includes similar requirements for digital publications distributed in
 					the European Union.</p>
@@ -1687,21 +1673,21 @@
 
 			<p>The creation of accessible <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
 					publications</a> does not guarantee that the publication will be obtainable or consumable by users
-				in an accessible fashion. Depending on how EPUB creators distribute their EPUB publications, other
-				factors will influence their overall accessibility. For example, an accessible interface for locating
-				and obtaining content is an essential part of the distribution process, as is the ability to search and
-				review accessibility metadata.</p>
+				in an accessible fashion. Depending on how they are distributed, other factors will influence their
+				overall accessibility. For example, an accessible interface for locating and obtaining content is an
+				essential part of the distribution process, as is the ability to search and review accessibility
+				metadata.</p>
 
-			<p>While much of the distribution process is outside the control of EPUB creators, so outside the scope of
-				this specification, there are factors an EPUB creator can control. For example, while an EPUB creator
-				typically does not control the accessibility of the digital rights management (DRM) scheme applied to
-				their EPUB publications, they do control what usage rights to apply to their EPUB publications. So even
-				though a DRM scheme may allow an Author to block access to the text of the publication, the EPUB creator
-				needs to take care not to apply such a restriction as it could block the ability for <a>assistive
-					technologies</a> to read the text aloud.</p>
+			<p>While many aspects of the distribution process are outside the scope of this specification, there are
+				factors that publishers can control. For example, while a publisher typically does not control the
+				accessibility of the digital rights management (DRM) scheme applied to their EPUB publications, they do
+				control what usage rights to apply to their EPUB publications. So even though a DRM scheme may allow a
+				publisher to block access to the text of the publication, the publisher needs to take care not to apply
+				such a restriction as it could block the ability for <a>assistive technologies</a> to read the text
+				aloud.</p>
 
-			<p>To minimize the effects of distribution on accessibility, this specification advises EPUB creators adhere
-				to the following distribution practices:</p>
+			<p>To minimize the effects of distribution on accessibility, this specification advises that publishers
+				adhere to the following distribution practices:</p>
 
 			<ul>
 				<li>they must not impose restrictions that impair access by assistive technologies; and</li>
@@ -1711,8 +1697,8 @@
 
 			<div class="note">
 				<p>A distributor may implement a digital rights management scheme that inherently impairs accessibility
-					through no fault of the EPUB creator. Following the guidance in this section does not restrict EPUB
-					creators from using such distributors. The intent is only that the EPUB creator not impair
+					through no fault of the publisher. Following the guidance in this section does not restrict
+					publishers from using such distributors. The intent is only that the publisher not impair
 					accessibility by activating a feature that would normally not be active.</p>
 			</div>
 		</section>
@@ -1723,8 +1709,7 @@
 				users. Meeting accessibility requirements is about optimally using the available technologies, and no
 				new features are introduced by this specification.</p>
 
-			<p>The inclusion of accessibility metadata by <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB
-					creators</a> similarly does not introduce security or privacy issues for the EPUB creator, as
+			<p>The inclusion of accessibility metadata similarly does not introduce security or privacy issues, as
 				describing an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a> only
 				provides a general idea of its suitability for different user groups.</p>
 
@@ -1764,9 +1749,8 @@
 							<code>http://idpf.org/epub/vocab/package/a11y/#</code>.</p>
 
 					<p>This specification reserves the prefix "<code>a11y:</code>" for use with properties in this
-						vocabulary. <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> do not have
-						to declare the prefix in the <a href="https://www.w3.org/TR/epub/#dfn-package-document">package
-							document</a>.</p>
+						vocabulary. It is not required to declare the prefix in the <a
+							href="https://www.w3.org/TR/epub/#dfn-package-document">package document</a>.</p>
 				</section>
 			</section>
 

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1486,7 +1486,7 @@
 			<section id="sec-feedback">
 				<h3>Feedback</h3>
 
-				<p>Although publishers are expected to assess their publications prior to certifying them accessible,
+				<p>While it is expected that publications will be assessed prior to certifying them accessible, 
 					due to the sheer volumes of content produced and the complexity of checking all the markup it is
 					sometimes the case that issues will slip through to the final product. Accessibility reporting can
 					also not be detailed enough for every user to be able to determine the suitability of the content

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1447,8 +1447,7 @@
 					</ul>
 
 					<p>If the EPUB publication includes substantively the same markup and content as the previous
-						release, only the new modifications will likely need evaluation to re-confirm conformance, so
-						long as the conformance standard has not changed.</p>
+						release, only the new modifications will likely need evaluation to re-confirm conformance.</p>
 
 					<p>If an updated version of this specification or [[wcag2]] has been published since the last
 						release of the EPUB publication, a new evaluation is recommended to ensure conformance to the

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1679,15 +1679,15 @@
 				metadata.</p>
 
 			<p>While many aspects of the distribution process are outside the scope of this specification, there are
-				factors that publishers can control. For example, while a publisher typically does not control the
+				factors that can be controlled. For example, while a publisher typically does not control the
 				accessibility of the digital rights management (DRM) scheme applied to their EPUB publications, they do
 				control what usage rights to apply to their EPUB publications. So even though a DRM scheme may allow a
-				publisher to block access to the text of the publication, the publisher needs to take care not to apply
+				publisher to block access to the text of the publication, that publisher needs to take care not to apply
 				such a restriction as it could block the ability for <a>assistive technologies</a> to read the text
 				aloud.</p>
 
-			<p>To minimize the effects of distribution on accessibility, this specification advises that publishers
-				adhere to the following distribution practices:</p>
+			<p>To minimize the effects of distribution on accessibility, this specification advises adherence
+			    to the following distribution practices:</p>
 
 			<ul>
 				<li>they must not impose restrictions that impair access by assistive technologies; and</li>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -253,8 +253,9 @@
 				<p>It also defines the following term:</p>
 
 				<dl>
-					<dt><dfn id="dfn-assistive-technology" data-lt="assistive technologies">assistive
-						technology</dfn></dt>
+					<dt>
+						<dfn id="dfn-assistive-technology" data-lt="assistive technologies">assistive technology</dfn>
+					</dt>
 					<dd>
 						<p>This specification uses the <a data-cite="wcag2#dfn-assistive-technologies">definition of
 								assistive technology</a> from [[wcag2]].</p>
@@ -775,14 +776,11 @@
 								<dt id="sec-page-break-conf">Meeting this Objective</dt>
 								<dd>
 									<p>Inclusion of page break markers in an EPUB publication is OPTIONAL.</p>
-									<p>If an EPUB publication includes page break markers:</p>
-									<ul>
-										<li>the page break markers SHOULD identify all pages reproduced from the source
-											(i.e., blank pages and content not reproduced in the digital edition do not
-											require markers).</li>
-										<li>the page break markers should identify all pages in the source, whether
-											reproduced or not, but this is not a requirement.</li>
-									</ul>
+									<p>If an EPUB publication includes page break markers, the page break markers SHOULD
+										identify all pages reproduced from the source (i.e., blank pages and content not
+										reproduced in the digital edition do not require markers).</p>
+									<p>It is recommended that there be page break markers for all the pages in the
+										source, whether reproduced or not, but this is not a requirement.</p>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
 										of the content (e.g., EPUB 3 media overlays [[?epub-3]]), the page break markers
 										MUST be identified in the playback instructions (e.g., using the <a
@@ -1135,10 +1133,14 @@
 							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
 						><var>WCAG-LVL</var></a></p>
 
-					<p><i>where:</i></p>
+					<p>
+						<i>where:</i>
+					</p>
 
 					<dl class="varlist">
-						<dt id="acc-ver"><var>A11Y-VER</var></dt>
+						<dt id="acc-ver">
+							<var>A11Y-VER</var>
+						</dt>
 						<dd>
 							<p>Specifies the version number of the EPUB Accessibility specification the publication
 								conforms to. The value MUST NOT be lower than <code>1.1</code> as the 1.0 version of
@@ -1146,12 +1148,16 @@
 							<p>The value MUST be <code>1.2</code> to indicate conformance to this version of the
 								specification.</p>
 						</dd>
-						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
+						<dt id="wcag-ver">
+							<var>WCAG-VER</var>
+						</dt>
 						<dd>
 							<p>Specifies the version number of WCAG the publication conforms to. The value MUST be
 									<code>2.0</code> or higher.</p>
 						</dd>
-						<dt id="wcag-lvl"><var>WCAG-LVL</var></dt>
+						<dt id="wcag-lvl">
+							<var>WCAG-LVL</var>
+						</dt>
 						<dd>
 							<p>Specifies the WCAG conformance level the publication conforms to (e.g., <code>A</code> or
 									<code>AA</code>).</p>
@@ -1513,53 +1519,67 @@
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>:</p>
 
 				<dl>
-					<dt><a href="https://www.w3.org/TR/epub-a11y-12/">EPUB Accessibility Techniques 1.2</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/epub-a11y-12/">EPUB Accessibility Techniques 1.2</a>
+					</dt>
 					<dd>
 						<p>The EPUB Accessibility techniques [[epub-a11y-tech-12]] provide specific guidance on how to
 							apply WCAG techniques to EPUB publications as well a guidance on how to meet the
 							EPUB-specific objectives of this document.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 Understanding Docs</a></dt>
+					<dt>
+						<a href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 Understanding Docs</a>
+					</dt>
 					<dd>
 						<p>The WCAG Understanding Docs provide detailed explanations of the purpose and goals of the
 							WCAG success criteria.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG (Quick Reference)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG (Quick Reference)</a>
+					</dt>
 					<dd>
 						<p>The WCAG quick reference guide provides links to techniques showing ways to meet each WCAG
 							success critierion.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a>
+					</dt>
 					<dd>
 						<p>The ARIA standard [[wai-aria]] defines roles, states, and properties for making dynamic
 							content that does not use native HTML elements and attributes accessible. It also provides a
 							set of landmarks for navigating web pages.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
+					</dt>
 					<dd>
 						<p>ARIA in HTML [[html-aria]] specifies how the roles, states, and properties defined ARIA and
 							DPUB-ARIA can be used in HTML documents.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices Guide (APG)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices Guide (APG)</a>
+					</dt>
 					<dd>
 						<p>The ARIA Authoring Practices guide provides examples of how to use ARIA roles, states, and
 							properties to make dynamic content more accessible.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module
-						(DPUB-ARIA)</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a>
+					</dt>
 					<dd>
 						<p>The [[dpub-aria]] specification is an extension of [[wai-aria]] that provides additional
 							roles specific to identifying common publishing structures.</p>
 					</dd>
 
-					<dt><a href="https://www.w3.org/TR/epub-aria-authoring/">EPUB Type to ARIA Role Authoring
-						Guide</a></dt>
+					<dt>
+						<a href="https://www.w3.org/TR/epub-aria-authoring/">EPUB Type to ARIA Role Authoring Guide</a>
+					</dt>
 					<dd>
 						<p>The EPUB Type to ARIA Role authoring guide provides mappings from the semantics used in the
 								<code>epub:type</code> attribute to ARIA and DPUB-ARIA role equivalents.</p>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -232,7 +232,7 @@
 						>EPUB publication</a>, regardless of what version of EPUB it conforms to.</p>
 
 				<p>For example, even though EPUB 2 [[opf-201]] was produced before this specification, and so makes no
-					mention of it, it is possible to create EPUB 2 publications that conform its the accessibility and
+					mention of it, it is possible to create EPUB 2 publications that conform to the accessibility and
 					discoverability requirements. Ideally, though, EPUB 2 publications will be upgraded to the latest
 					version of EPUB 3 to get access to the most advanced accessibility features and techniques.</p>
 

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1665,7 +1665,7 @@
 			<div class="note">
 				<p>Although <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> do not have
 					to meet the recommendations in this section to conform to this specification, some jurisdictions
-					require similar distribution practices. <a
+					require EPUB publications to follow similar practices. <a
 						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
 						2019/882</a>, for example, includes similar requirements for digital publications distributed in
 					the European Union.</p>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -362,8 +362,8 @@
 					<p>This specification assumes that conformance and discoverability metadata will be processed and
 						presented in a human-readable manner, removing the need for a summary unless there is additional
 						information to express. Such processing is not available in all market segments, however,
-						particularly in library systems. Publishers should consider this limitation when deciding
-						whether to include a summary and what to state in it.</p>
+						particularly in library systems. Consequently, that limitation will influence whether to include
+						a summary and what to state in it.</p>
 				</div>
 
 				<div class="note">
@@ -1475,22 +1475,22 @@
 					<p>Even in the case of non-substantive changes, this specification recommends an updated evaluation
 						(full or partial) if the accessibility standards have changed.</p>
 
-					<p>Publishers should consider even more progressive approaches than those described here. Waiting
-						for content changes before reviewing and updating the accessibility of EPUB publications can
-						leave them lacking recent improvements. For example, a publisher might prioritize periodic
-						reviews of their top-selling EPUB publications to ensure they remain maximally usable to the
-						widest possible audience.</p>
+					<p>Even more progressive approaches than those described here should also be considered. Waiting for
+						content changes before reviewing and updating the accessibility of EPUB publications can leave
+						them lacking recent improvements. For example, a publisher might prioritize periodic reviews of
+						their top-selling EPUB publications to ensure they remain maximally usable to the widest
+						possible audience.</p>
 				</section>
 			</section>
 
 			<section id="sec-feedback">
 				<h3>Feedback</h3>
 
-				<p>While it is expected that publications will be assessed prior to certifying them accessible, 
-					due to the sheer volumes of content produced and the complexity of checking all the markup it is
-					sometimes the case that issues will slip through to the final product. Accessibility reporting can
-					also not be detailed enough for every user to be able to determine the suitability of the content
-					for their needs.</p>
+				<p>While it is expected that publications will be assessed prior to certifying them accessible, due to
+					the sheer volumes of content produced and the complexity of checking all the markup it is sometimes
+					the case that issues will slip through to the final product. Accessibility reporting can also not be
+					detailed enough for every user to be able to determine the suitability of the content for their
+					needs.</p>
 
 				<p>To assist users in reporting any accessibility issues they encounter, or to discover more about the
 					accessibility of an EPUB publication, EPUB publications MAY include an accessibility contact email

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -738,7 +738,7 @@
 										reproduced in the digital edition).</p>
 									<p>The page list MUST include links to all the <a href="#sec-page-breaks-obj">page
 											break markers</a> in the content.</p>
-									<p>The page list should include links for all pages in the source, whether they are
+									<p>The page list should include links to all pages in the source, whether they are
 										reproduced or not, but this is not a conformance requirement.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageList">Provide a page list</a>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>
@@ -1686,20 +1686,19 @@
 				such a restriction as it could block the ability for <a>assistive technologies</a> to read the text
 				aloud.</p>
 
-			<p>To minimize the effects of distribution on accessibility, this specification advises adherence
-			    to the following distribution practices:</p>
+			<p>To minimize the effects of distribution on accessibility, this specification advises adherence to the
+				following distribution practices:</p>
 
 			<ul>
-				<li>they must not impose restrictions that impair access by assistive technologies; and</li>
-				<li>they must include accessibility metadata in the record format required for distribution of an EPUB
-					publication (e.g., [[onix]] or [[marc21]]) when the format supports such metadata.</li>
+				<li>do not impose restrictions that impair access by assistive technologies; and</li>
+				<li>include accessibility metadata in the record format required for distribution of an EPUB publication
+					(e.g., [[onix]] or [[marc21]]) when the format supports such metadata.</li>
 			</ul>
 
 			<div class="note">
-				<p>A distributor may implement a digital rights management scheme that inherently impairs accessibility
-					through no fault of the publisher. Following the guidance in this section does not restrict
-					publishers from using such distributors. The intent is only that the publisher not impair
-					accessibility by activating a feature that would normally not be active.</p>
+				<p>The guidance in this section does not restrict EPUB publications from being distributed through
+					inaccessible distribution channels. For example, where the distributor applies DRM that impairs
+					access to the content.</p>
 			</div>
 		</section>
 		<section id="privacy">

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1012,7 +1012,7 @@
 											publications</a> include structural semantics in the synchronized text/audio
 										format. Users may not be able to escape from lists, sidebars, figures, and other
 										highly structured content, without the structural semantics of those elements
-										available.</p>
+										being available.</p>
 									<p>When the synchronized text-audio playback instructions include this information,
 											<a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
 											systems</a> can simplify playback for auditory readers to enable a


### PR DESCRIPTION
This PR removes all use of "epub creator" from the accessibility 1.2 spec and techniques.

While not the most enjoyable thing to do, it wasn't as migraine inducing as I expected. It's also about half as many instances as there are in the authoring spec, so I'll keep going with that one.

It does lead to passive voice having to be used in some cases, but the specs are already full of that. And I had to use "publisher" in place of "epub creator" in the distribution section since there's no way to write out the responsibility on the person distributing the content.

Otherwise, it was kind of a helpful exercise in reviewing some of the statements we were making, as there were some spots that definitely needed some improvement.

(Note to self: don't try to merge this until the new 1.2 docs are published next week.)

***

EPUB Accessibility 1.2:
* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2216/epub34/a11y/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2216/epub34/a11y/index.html)

EPUB Accessibility Techniques 1.2:
* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2216/epub34/a11y-tech/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2216/epub34/a11y-tech/index.html)
