### PR TITLE
Remove epub creator from authoring and rs specs

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5390,8 +5390,8 @@ No Entry</pre>
 						foreign content documents hyperlinked to from hyperlinked documents have to be listed, and so
 						on.).</p>
 
-					<p>All EPUB and foreign content documents hyperlinked to from the [=EPUB navigation document=] also
-						MUST be listed in the <code>spine</code>, regardless of whether the EPUB navigation document is
+					<p>All EPUB and foreign content documents hyperlinked to from the [=EPUB navigation document=] 
+						MUST also be listed in the <code>spine</code>, regardless of whether the EPUB navigation document is
 						included in the <code>spine</code>.</p>
 
 					<div class="note">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -930,12 +930,11 @@
 							of whether XHTML and SVG documents are listed in the spine or embedded in other EPUB content
 							documents they the same requirements for authoring and reading system support.</p>
 
-						<p>In practice, it means that EPUB creators can put XHTML and SVG core media type resources in
-							the spine without any modification or fallback as they are also conforming XHTML and SVG
-							content documents. But, this is a unique case &#8212; all other core media type resources
-							become foreign content documents when used in the spine (i.e., foreign content documents
-							include all foreign resources and all core media type resources except for XHTML and
-							SVG).</p>
+						<p>In practice, it means that XHTML and SVG core media type resources are allowed in the spine
+							without any modification or fallback as they are also conforming XHTML and SVG content
+							documents. But, this is a unique case &#8212; all other core media type resources become
+							foreign content documents when used in the spine (i.e., foreign content documents include
+							all foreign resources and all core media type resources except for XHTML and SVG).</p>
 					</div>
 				</section>
 			</section>
@@ -3272,9 +3271,8 @@
 					<div class="note">
 						<p>The <code>dir</code> attribute is marked <a href="#under-implemented">under-implemented</a>
 							as [=reading systems=] often only support a single default directionality for text display.
-							[=EPUB creators=] are still strongly encouraged to set the proper directionality of text
-							values in the [=package document=] to ensure proper rendering once this situation
-							improves.</p>
+							Regardless, it is still strongly encouraged to set the proper directionality of text values
+							in the [=package document=] to ensure proper rendering once this situation improves.</p>
 					</div>
 
 					<p
@@ -3292,7 +3290,7 @@
 					</ul>
 
 					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading systems will assume the
-						value <code>auto</code> when EPUB creators omit the attribute or use an invalid value.</p>
+						value <code>auto</code> when attribute is not present or has an invalid value.</p>
 
 					<div class="note">
 						<p>The base direction specified in the <code>dir</code> attribute does not affect the ordering
@@ -3407,8 +3405,8 @@
 					<h4>The <code>refines</code> attribute</h4>
 
 					<p>Establishes an association between the current expression and the element or resource identified
-						by its value. [=EPUB creators=] MUST use as the value a [=path-relative-scheme-less-URL
-						string=], optionally followed by <code>U+0023&#160;(#)</code> and a [=URL-fragment string=] that
+						by its value. The value of the attribute MUST be a [=path-relative-scheme-less-URL string=],
+						optionally followed by <code>U+0023&#160;(#)</code> and a [=URL-fragment string=] that
 						references the resource or element they are describing.</p>
 
 					<aside class="example" title="Specifying that a creator is the illustrator">
@@ -3696,12 +3694,12 @@
 						</li>
 					</ol>
 
-					<p>The package document does not provide complex metadata encoding capabilities. If [=EPUB
-						creators=] need to provide more detailed information, they can associate metadata records (e.g.,
-						that conform to an international standard such as [[onix]] or are created for custom purposes)
-						using the [^link^] element. This approach allows reading systems to process the metadata in its
-						native form, avoiding the potential problems and information loss caused by translating to use
-						the minimal package document structure.</p>
+					<p>The package document does not provide complex metadata encoding capabilities. If more detailed
+						information needs to be provided, metadata records (e.g., that conform to an international
+						standard such as [[onix]] or are created for custom purposes) can be associated with the EPUB
+						publication using the [^link^] element. This approach allows reading systems to process the
+						metadata in its native form, avoiding the potential problems and information loss caused by
+						translating to use the minimal package document structure.</p>
 
 					<p id="core-metadata-reqs">In keeping with this philosophy, the package document only has the
 						following minimal metadata requirements: it MUST contain the [[dcterms]] [^dc:title^],
@@ -3733,9 +3731,9 @@
 					</aside>
 
 					<p>The [^meta^] element provides a generic mechanism for including <a href="#sec-vocab-assoc"
-							>metadata properties from any vocabulary</a>. Although EPUB creators MAY use this mechanism
-						for any metadata purposes, they will typically use it to include rendering metadata defined in
-						EPUB specifications.</p>
+							>metadata properties from any vocabulary</a>. Although this mechanism can be used for any
+						metadata purposes, it is typically used to include rendering and accessibility metadata defined
+						in EPUB specifications.</p>
 
 					<div class="note">
 						<p>See [[epub-a11y-111]] for accessibility metadata recommendations.</p>
@@ -3815,9 +3813,9 @@
 								</dd>
 							</dl>
 
-							<p>The [=EPUB creator=] MUST provide an identifier that is unique to one and only one [=EPUB
-								publication=] — its [=unique identifier=] — in an <code>dc:identifier</code> element.
-								This <code>dc:identifier</code> element MUST specify an <code>id</code> attribute whose
+							<p>The <code>dc:identifier</code> element MUST specify an identifier that is unique to one
+								and only one [=EPUB publication=] — its [=unique identifier=]. This
+									<code>dc:identifier</code> element MUST specify an <code>id</code> attribute whose
 								value is referenced from the [^package^] element's <a
 									href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 									attribute</a>.</p>
@@ -3833,27 +3831,25 @@
 &lt;/package&gt;</pre>
 							</aside>
 
-							<p>Although not static, EPUB creators should make changes to the unique identifier for an
-								EPUB publication as infrequently as possible. Unique Identifiers should have maximal
-								persistence both for referencing and distribution purposes. EPUB creators should not
-								issue new identifiers when making minor revisions such as updating metadata, fixing
-								errata, or making similar minor changes.</p>
+							<p>Although not static, changes to the unique identifier should only be made as infrequently
+								as possible. Unique Identifiers should have maximal persistence both for referencing and
+								distribution purposes. Do not issue new identifiers when making minor revisions such as
+								updating metadata, fixing errata, or making similar minor changes.</p>
 
-							<p>EPUB creators MAY specify additional identifiers.</p>
+							<p>Additional identifiers MAY be specified.</p>
 
 							<div class="note">
-								<p>EPUB creators are advised to use <a
-										href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL strings</a>
-									[url] for identifiers whenever possible. The inclusion of a domain owned by the EPUB
-									creator can improve the uniqueness of the identifier, for example, while the use of
-									a URN with a <a href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1"
+								<p>It is advised to use <a href="https://url.spec.whatwg.org/#absolute-url-string"
+										>absolute-URL strings</a> [url] for identifiers whenever possible. The inclusion
+									of a domain can improve the uniqueness of the identifier, for example, while the use
+									of a URN with a <a href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1"
 										>namespace identifier</a> [[rfc8141]] improves processing by reading
 									systems.</p>
 							</div>
 
-							<p>EPUB creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
-									property</a> to indicate that the value of a <code>dc:identifier</code> element
-								conforms to an established system or an issuing authority granted it.</p>
+							<p>The <a href="#identifier-type"><code>identifier-type</code> property</a> MAY be used to
+								indicate that the value of a <code>dc:identifier</code> element conforms to an
+								established system or an issuing authority granted it.</p>
 
 							<aside class="example" title="Specifying the type of the identifier">
 								<p>In this example, the <code>identifier-type</code> property is used with the <a
@@ -3955,8 +3951,8 @@
 </pre>
 							</aside>
 
-							<p>[=EPUB creators=] should use only a single <code>dc:title</code> element to ensure
-								consistent rendering of the title in [=reading systems=].</p>
+							<p>It is advised to use only a single <code>dc:title</code> element to ensure consistent
+								rendering of the title in [=reading systems=].</p>
 
 							<div class="note">
 								<p>Although it is possible to include more than one <code>dc:title</code> element for
@@ -4056,15 +4052,14 @@
 &lt;/metadata&gt;</pre>
 							</aside>
 
-							<p>Although [=EPUB creators=] MAY specify additional <code>dc:language</code> elements for
-								multilingual Publications, [=reading systems=] will treat the first
-									<code>dc:language</code> element in document order as the primary language of the
-								EPUB publication.</p>
+							<p>Although additional <code>dc:language</code> elements MAY be specified for multilingual
+								[=EPUB publications=], [=reading systems=] will treat the first <code>dc:language</code>
+								element in document order as the primary language.</p>
 
 							<div class="note">
 								<p>[=Publication resources=] do not inherit their language from the
-										<code>dc:language</code> element(s). EPUB creators must set the language of a
-									resource using the intrinsic methods of the format.</p>
+										<code>dc:language</code> element(s). The language of each resource has to be set
+									using the intrinsic methods of the format.</p>
 							</div>
 						</section>
 					</section>
@@ -4147,10 +4142,9 @@
 
 							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
 										><code>dc:creator</code></dfn> element [[dcterms]] represents the name of a
-								person, organization, etc. responsible for the creation of the content. [=EPUB
-								creators=] MAY <a href="#subexpression">associate</a> a <a href="#role"
-										><code>role</code> property</a> with the element to indicate the function the
-								creator played.</p>
+								person, organization, etc. responsible for the creation of the content. A <a
+									href="#role"><code>role</code> property</a> MAY be <a href="#subexpression"
+									>associated</a> with the element to indicate the function the creator played.</p>
 
 							<aside class="example" title="Specifying that a creator is an author">
 								<p>In this example, the <a href="https://id.loc.gov/vocabulary/relators.html">MARC
@@ -4174,11 +4168,11 @@
 &lt;/metadata&gt;</pre>
 							</aside>
 
-							<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB
-								creators intend [=reading systems=] to display it to users.</p>
+							<p>The <code>dc:creator</code> element should contain the name of the creator as [=reading
+								systems=] are expected to display it to users.</p>
 
-							<p>EPUB creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
-								<a href="#subexpression">to associate</a> a normalized form of the creator's name, and
+							<p>The <a href="#file-as"><code>file-as</code> property</a> MAY be used <a
+									href="#subexpression">to associate</a> a normalized form of the creator's name, and
 								the <a href="#alternate-script"><code>alternate-script</code> property</a> to represent
 								the creator's name in another language or script.</p>
 
@@ -4204,8 +4198,8 @@
 &lt;/metadata&gt;</pre>
 							</aside>
 
-							<p>If an [=EPUB publication=] has more than one creator, EPUB creators should specify each
-								in a separate <code>dc:creator</code> element.</p>
+							<p>If an [=EPUB publication=] has more than one creator, specify each in a separate
+									<code>dc:creator</code> element.</p>
 
 							<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code>
 								section determines the display priority, where the first <code>dc:creator</code> element
@@ -4228,8 +4222,7 @@
 &lt;/metadata&gt;</pre>
 							</aside>
 
-							<p>EPUB creators should represent secondary contributors using the [^dc:contributor^]
-								element.</p>
+							<p>Secondary contributors are represented using the [^dc:contributor^] element.</p>
 						</section>
 
 						<section id="sec-opf-dcdate" data-epubcheck="true"
@@ -4239,8 +4232,8 @@
 							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
 									><code>dc:date</code></dfn> element [[dcterms]] defines the publication date of the
 								[=EPUB publication=]. The publication date is not the same as the <a
-									href="#last-modified-date">last modified date</a> (the last time the [=EPUB
-								creator=] changed the EPUB publication).</p>
+									href="#last-modified-date">last modified date</a> (the last time the EPUB
+								publication was changed).</p>
 
 							<p>It is RECOMMENDED that the date string conform to [[iso8601-1]], particularly the subset
 								expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
@@ -4256,8 +4249,8 @@
 &lt;/metadata&gt;</pre>
 							</aside>
 
-							<p>EPUB creators should express additional dates using the specialized date properties
-								available in the [[dcterms]] vocabulary, or similar.</p>
+							<p>Additional dates can be expressed using the specialized date properties available in the
+								[[dcterms]] vocabulary, or similar.</p>
 
 							<p>EPUB publications MUST NOT contain more than one <code>dc:date</code> element.</p>
 						</section>
@@ -4267,15 +4260,16 @@
 
 							<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
 										><code>dc:subject</code></dfn> element [[dcterms]] identifies the subject of the
-								[=EPUB publication=]. [=EPUB creators=] should set the [=value=] of the element to the
-								human-readable heading or label, but may use a code value if the subject taxonomy does
-								not provide a separate descriptive label.</p>
+								[=EPUB publication=]. It is advised to set the [=value=] of the element to the
+								human-readable heading or label, but a code value can be used if the subject taxonomy
+								does not provide a separate descriptive label.</p>
 
-							<p>EPUB creators MAY identify the system or scheme they drew the element's [=value=] from
-								using the <a href="#authority"><code>authority</code> property</a>.</p>
+							<p>The system or scheme the element's [=value=] is drawn from can be identified using the <a
+									href="#authority"><code>authority</code> property</a>.</p>
 
-							<p>When a scheme is identified, EPUB creators MUST <a href="#subexpression">associate</a> a
-								subject code using the <a href="#term"><code>term</code> property</a>.</p>
+							<p>When a scheme is identified, a subject code MUST be <a href="#subexpression"
+									>associated</a> with the element using the <a href="#term"><code>term</code>
+									property</a>.</p>
 
 							<aside class="example" title="Specifying a BISAC code and heading">
 								<pre>&lt;metadata …&gt;
@@ -4328,7 +4322,7 @@
 								publication=] is of a specialized type (e.g., annotations or a dictionary packaged in
 								EPUB format).</p>
 
-							<p>[=EPUB creators=] MAY use any text string as a [=value=].</p>
+							<p>The element's [=value=] MAY be any text string.</p>
 
 							<div class="note">
 								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
@@ -4426,8 +4420,8 @@
 						of the element represents the assertion. (Refer to <a href="#sec-vocab-assoc"></a> for more
 						information.)</p>
 
-					<p id="meta-expr-types">This specification defines two types of metadata expressions that [=EPUB
-						creators=] can define using the <code>meta</code> element:</p>
+					<p id="meta-expr-types">This specification defines two types of metadata expressions that can be
+						defined using the <code>meta</code> element:</p>
 
 					<ul>
 						<li id="primary-expression">A <em>primary expression</em> is one in which the expression defined
@@ -4441,8 +4435,8 @@
 							expression by defining the role of the person.</li>
 					</ul>
 
-					<p>EPUB creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
-						creating chains of information.</p>
+					<p>Subexpressions MAY be used to refine the meaning of other subexpressions, thereby creating chains
+						of information.</p>
 
 					<p class="note">All the [[dcterms]] elements represent primary expressions, and permit refinement by
 						meta element subexpressions.</p>
@@ -4451,8 +4445,7 @@
 							href="#sec-default-vocab">default vocabulary</a> for use with the <code>property</code>
 						attribute.</p>
 
-					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-						></a>.</p>
+					<p>Terms from other vocabularies MAY be added as defined in <a href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="Using properties with reserved prefixes">
 						<p>For the full list of reserved prefixes, refer to <a href="#sec-reserved-prefixes"></a>.</p>
@@ -4475,8 +4468,8 @@
 &lt;/metadata&gt;</pre>
 					</aside>
 
-					<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the EPUB
-						creator obtained the element's [=value=] from. The value of the attribute MUST be a <a
+					<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the
+						element's [=value=] was obtained from. The value of the attribute MUST be a <a
 							href="#sec-property-datatype"><var>property</var> data type value</a> that resolves to the
 						resource that defines the scheme. The <code>scheme</code> attribute does not have a <a
 							href="#sec-default-vocab">default vocabulary</a> (i.e., all values require a <a
@@ -4525,11 +4518,11 @@
 &lt;/metadata&gt;</pre>
 					</aside>
 
-					<p>EPUB creators should update the last modified date whenever they make changes to the [=EPUB
+					<p>It is advised to update the last modified date whenever changes are made to the [=EPUB
 						publication=].</p>
 
-					<p>EPUB creators MAY specify additional modified properties in the [=package document=] metadata,
-						but they MUST have a different subject (i.e., they require a <code>refines</code> attribute that
+					<p>Additional modified properties MAY be specified in the [=package document=] metadata, but they
+						MUST have a different subject (i.e., they require a <code>refines</code> attribute that
 						references an element or resource).</p>
 
 					<div class="note">
@@ -4648,8 +4641,8 @@
 
 					<p>In all other cases (e.g., when linking to standalone [[?onix]] records), the resources referenced
 						are not [=publication resources=] (i.e., are not subject to <a href="#sec-core-media-types">core
-							media type requirements</a>) and [=EPUB creators=] MUST NOT list them in the <a
-							href="#sec-manifest-elem">manifest</a>.</p>
+							media type requirements</a>) and MUST NOT be listed in the <a href="#sec-manifest-elem"
+							>manifest</a>.</p>
 
 					<aside class="example" title="Reference to a record embedded in an XHTML content document">
 						<p>In this example, the metadata record is embedded in a <code>script</code> element. Note that
@@ -4689,14 +4682,14 @@ XHTML:
 &lt;/html&gt;</pre>
 					</aside>
 
-					<p id="linked-res-location">EPUB creators MAY locate linked resources within the [=EPUB container=]
-						or externally, but should consider that [=reading systems=] are not required to retrieve
-						resources outside the EPUB container.</p>
+					<p id="linked-res-location">Linked resources MAY be located outside the [=EPUB container=], but
+						consider that [=reading systems=] are not required to retrieve resources outside the EPUB
+						container before hosting them remotely.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container, as
-						more than one media type could be served from the same URL [[url]]. EPUB creators MUST specify
-						the attribute for all linked resources within the EPUB container.</p>
+							attribute</a> attribute MUST be specified for all linked resources within the EPUB container
+						but is OPTIONAL when a linked resource is located outside the EPUB container as more than one
+						media type could be served from the same URL [[url]].</p>
 
 					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the
 						linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
@@ -4720,8 +4713,8 @@ XHTML:
 					<p>The value of the <code>media-type</code> attribute is not always sufficient to identify the type
 						of linked resource (e.g., many XML-based record formats use the media type
 							"<code>application/xml</code>"). To aid reading systems in the identification of such
-						generic resources, EPUB creators MAY specify a semantic identifier in the
-							<code>properties</code> attribute.</p>
+						generic resources, a semantic identifier MAY be specified in the <code>properties</code>
+						attribute.</p>
 
 					<aside class="example" title="Identifying a record type via a property">
 						<p>In this example, the <code>properties</code> attribute identifies the link is to an ONIX
@@ -4740,7 +4733,7 @@ XHTML:
 					<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a href="#sec-default-vocab"
 							>default vocabulary</a> for the <code>rel</code> and <code>properties</code> attributes.</p>
 
-					<p>EPUB creators MAY add relationships and properties from other vocabularies as defined in <a
+					<p>Relationships and properties from other vocabularies MAY be added as defined in <a
 							href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="Declaring a new link relationship">
@@ -4765,8 +4758,8 @@ XHTML:
 </pre>
 					</aside>
 
-					<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB creators MAY provide one or more <a
-							href="#record">linked metadata records</a>.</p>
+					<p id="sec-linked-records" data-tests="#pkg-linked-records">One or more <a href="#record">linked
+							metadata records</a> MAY be provided.</p>
 
 					<aside class="example" title="Specifying linked records">
 						<p>In this example, an ONIX record is hosted remotely while a JSON-LD record is included in the
@@ -4786,13 +4779,13 @@ XHTML:
 					</aside>
 
 					<div class="note">
-						<p>Due to the variety of metadata record formats and serializations that an EPUB creator can
-							link to an EPUB publication, and the complexity of comparing metadata properties between
-							them, this specification does not require reading systems to process linked records.</p>
+						<p>Due to the variety of metadata record formats and serializations that can be linked to an
+							EPUB publication, and the complexity of comparing metadata properties between them, this
+							specification does not require reading systems to process linked records.</p>
 					</div>
 
-					<p>In addition to full records, EPUB creators MAY also use the <code>link</code> element to identify
-						individual metadata properties available in an alternative format.</p>
+					<p>In addition to full records, the <code>link</code> element MAY be used to identify individual
+						metadata properties available in an alternative format.</p>
 
 					<aside class="example" title="Link to a description">
 						<p>In this example, the description of the EPUB publication is contained in an HTML
@@ -4954,14 +4947,14 @@ XHTML:
 						URL [[url]] in its <a href="#attrdef-href"><code>href</code> attribute</a>. The value MUST be an
 							<a data-lt="absolute-url string">absolute-</a> or <a
 							data-lt="path-relative-scheme-less-url string">path-relative-scheme-less-URL</a>
-						string&#160;[[url]]. [=EPUB creators=] MUST ensure each URL is unique within the
-							<code>manifest</code> scope after <a href="#sec-parse-package-urls">parsing</a>.</p>
+						string&#160;[[url]]. Each URL MUST be unique within the <code>manifest</code> scope after <a
+							href="#sec-parse-package-urls">parsing</a>.</p>
 
 					<p id="attrdef-item-media-type">The publication resource identified by an <code>item</code> element
 						MUST conform to the applicable specification(s) as inferred from the MIME media type [[rfc2046]]
 						provided in the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For [=core
-						media type resources=], EPUB creators MUST use the media type designated in <a
-							href="#sec-core-media-types"></a>.</p>
+						media type resources=], the media type designated in <a href="#sec-core-media-types"></a> MUST
+						be used.</p>
 
 					<p id="attrdef-item-fallback">The <code>fallback</code> attribute specifies the fallback for the
 						referenced publication resource. The <code>fallback</code> attribute's <a data-cite="xml#idref"
@@ -4995,8 +4988,8 @@ XHTML:
 								Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 								<code>properties</code> attribute.</p>
 
-						<p>[=EPUB creators=] MUST set the following properties whenever a resource referenced by an
-								<code>item</code> element matches their respective definitions:</p>
+						<p>The following properties MUST be set whenever a resource referenced by an <code>item</code>
+							element matches their respective definitions:</p>
 
 						<ul>
 							<li><a href="#sec-mathml">mathml</a></li>
@@ -5022,8 +5015,8 @@ XHTML:
 								<code>item</code>
 							<code>properties</code> attribute will have the <code>scripted</code> value.</p>
 
-						<p>EPUB creators MUST declare exactly one <code>item</code> as the EPUB navigation document
-							using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
+						<p>Exactly one <code>item</code> MUST be declared as the EPUB navigation document using the <a
+								href="#sec-nav-prop"><code>nav</code> property</a>.</p>
 
 						<aside class="example" id="example-item-properties-nav"
 							title="Identifying the EPUB navigation document">
@@ -5047,8 +5040,7 @@ XHTML:
     media-type="image/svg+xml" /&gt;</pre>
 						</aside>
 
-						<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-							></a>.</p>
+						<p>Terms from other vocabularies MAY be added as defined in <a href="#sec-vocab-assoc"></a>.</p>
 					</section>
 
 					<section id="sec-item-elem-examples">
@@ -5156,8 +5148,8 @@ XHTML:
 								(e.g., for easier zooming). Although embedding the image using the <code>img</code> tag
 								does not require it to be listed in the [=EPUB spine | spine=] or have a fallback,
 								adding the hyperlink causes the document to open as a [=top-level content document=]. As
-								its use in the spine makes it a [=foreign content document=], the [=EPUB creator=] must
-								include a fallback to an EPUB content document.</p>
+								its use in the spine makes it a [=foreign content document=], a fallback to an EPUB
+								content document is included.</p>
 
 							<pre>XHTML:
 &lt;html …&gt;
@@ -5205,11 +5197,11 @@ Package document:
 
 						<aside class="example" title="Link to View foreign resource as top-level content document">
 							<p>The following example shows a link to the raw CSV data file. As the data will open in the
-								[=reading system=] as a [=top-level content document=], the [=EPUB creator=] must list
-								it in the spine. As its use in the spine makes it a [=foreign content document=], the
-								EPUB creator must also provide a fallback to an [=EPUB content document=]. Because there
-								is no guarantee users will be able to access the data in its raw form, instructions on
-								how to extract the file from the [=EPUB container=] are also provided.</p>
+								[=reading system=] as a [=top-level content document=], it has to be listed in the
+								spine. As its use in the spine makes it a [=foreign content document=], a fallback is
+								provided to an [=EPUB content document=]. Because there is no guarantee users will be
+								able to access the data in its raw form, instructions on how to extract the file from
+								the [=EPUB container=] are also provided.</p>
 
 							<pre>XHTML:
 &lt;html …&gt;
@@ -5260,9 +5252,9 @@ Package document:
 						<aside class="example" title="Remote resources that are publication resources">
 							<p>The following example shows a reference to a remote audio file. Because the
 									<code>audio</code> element embeds the audio in its [=EPUB content document=], the
-								file is considered a [=publication resource=]. The [=EPUB creator=] therefore must list
-								the audio file in the manifest and indicate that its host EPUB content document contains
-								a [=remote resource=].</p>
+								file is considered a [=publication resource=]. The audio file is therefore listed in the
+								manifest and the entry for its host EPUB content document indicates it contains a
+								[=remote resource=].</p>
 
 							<pre>XHTML:
 &lt;html …&gt;
@@ -5300,8 +5292,8 @@ Package document:
 						<aside class="example" title="External Resources that are not publication resources">
 							<p>The following example shows a hyperlink to an audio file hosted on the web. [=Reading
 								systems=] will open such external content in a new browser window; the audio file is not
-								rendered within the publication. In this case, the [=EPUB creator=] does not list the
-								file in the manifest because it is not a [=publication resource=].</p>
+								rendered within the publication. In this case, the file is not listed in the manifest
+								because it is not a [=publication resource=].</p>
 
 							<pre>XHTML:
 &lt;html …&gt;
@@ -5388,18 +5380,18 @@ No Entry</pre>
 					<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one [=EPUB content
 						document=] or [=foreign content document=].</p>
 
-					<p id="spine-inclusion-req">[=EPUB creators=] MUST list in the <code>spine</code> all EPUB and
-						foreign content documents that are hyperlinked to from publication resources in the
-							<code>spine</code>, where hyperlinking encompasses any linking mechanism that requires the
-						user to navigate away from the current resource. Common hyperlinking mechanisms include the
-						[^a/href^] attribute of the [[html]] [^a^] and [^area^] elements and scripted links (e.g., using
-						DOM Events and/or form elements). The requirement to list hyperlinked resources applies
-						recursively (i.e., EPUB creators must list all EPUB and foreign content documents hyperlinked to
-						from hyperlinked documents, and so on.).</p>
+					<p id="spine-inclusion-req">All EPUB and foreign content documents that are hyperlinked to from
+						publication resources in the <code>spine</code> MUST be list in the <code>spine</code>, where
+						hyperlinking encompasses any linking mechanism that requires the user to navigate away from the
+						current resource. Common hyperlinking mechanisms include the [^a/href^] attribute of the
+						[[html]] [^a^] and [^area^] elements and scripted links (e.g., using DOM Events and/or form
+						elements). The requirement to list hyperlinked resources applies recursively (i.e., all EPUB and
+						foreign content documents hyperlinked to from hyperlinked documents have to be listed, and so
+						on.).</p>
 
-					<p>EPUB creators also MUST list in the <code>spine</code> all EPUB and foreign content documents
-						hyperlinked to from the [=EPUB navigation document=], regardless of whether EPUB creators
-						include the EPUB navigation document in the <code>spine</code>.</p>
+					<p>All EPUB and foreign content documents hyperlinked to from the [=EPUB navigation document=] also
+						MUST be listed in the <code>spine</code>, regardless of whether the EPUB navigation document is
+						included in the <code>spine</code>.</p>
 
 					<div class="note">
 						<p>As hyperlinks to resources outside the EPUB container are not [=publication resources=], they
@@ -5413,8 +5405,8 @@ No Entry</pre>
 					<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
 						attribute sets the global direction in which the content flows. Allowed values are
 							<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and <code>default</code>.
-						When EPUB creators specify the <code>default</code> value, they are expressing no preference and
-						the [=reading system=] can choose the rendering direction.</p>
+						When the <code>default</code> value is specified, no preference is being expressed and the
+						[=reading system=] can choose the rendering direction.</p>
 
 					<p>Although the <code>page-progression-direction</code> attribute sets the global flow direction,
 						individual EPUB content documents and parts of EPUB content documents MAY override this setting
@@ -5523,8 +5515,8 @@ No Entry</pre>
 						the spine.</p>
 
 					<div class="note">
-						<p>[=EPUB creators=] should list non-linear content at the end of the spine except when it makes
-							sense for users to encounter it between linear spine items.</p>
+						<p>It is advised to list non-linear content at the end of the spine except when it makes sense
+							for users to encounter it between linear spine items.</p>
 					</div>
 
 					<p id="linear-itemrefs">A linear <code>itemref</code> element is one whose <code>linear</code>
@@ -5533,16 +5525,15 @@ No Entry</pre>
 							<code>itemref</code> elements without the attribute. The spine MUST contain at least one
 						linear <code>itemref</code> element.</p>
 
-					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB creators MUST provide a means
-						of accessing all non-linear content (e.g., hyperlinks in the content or from the <a
-							href="#sec-nav">EPUB navigation document</a>).</p>
+					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">A means of accessing all
+						non-linear content (e.g., hyperlinks in the content or from the <a href="#sec-nav">EPUB
+							navigation document</a>) MUST be provided.</p>
 
 					<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine Properties
 							Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 							<code>properties</code> attribute.</p>
 
-					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-						></a>.</p>
+					<p>Terms from other vocabularies MAY be added as defined in <a href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="A basic spine">
 						<p>In this example, the spine entries correspond to <a href="#example-manifest-cmt">the manifest
@@ -5646,16 +5637,15 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p>The <code>collection</code> element allows [=EPUB creators=] to assemble resources into logical
-						groups for a variety of potential uses: enabling reassembly into a meaningful unit of content
-						split across multiple [=EPUB content documents=] (e.g., an index split across multiple
-						documents), identifying resources for specialized purposes (e.g., preview content), or
-						collecting together resources that present additional information about the [=EPUB
-						publication=].</p>
+					<p>The <code>collection</code> element allows resources to be assembled into logical groups for a
+						variety of potential uses: enabling reassembly into a meaningful unit of content split across
+						multiple [=EPUB content documents=] (e.g., an index split across multiple documents),
+						identifying resources for specialized purposes (e.g., preview content), or collecting together
+						resources that present additional information about the [=EPUB publication=].</p>
 
-					<p id="attrdef-collection-role">EPUB creators MUST identify the role of each <code>collection</code>
-						element in its <code>role</code> attribute, whose value MUST be one or more NMTOKENs
-						[[xmlschema-2]] and/or [=absolute-URL-with-fragment strings=] [[url]].</p>
+					<p id="attrdef-collection-role">The role of each <code>collection</code> element MUST be identified
+						in its <code>role</code> attribute, whose value MUST be one or more NMTOKENs [[xmlschema-2]]
+						and/or [=absolute-URL-with-fragment strings=] [[url]].</p>
 
 					<p>The requirements for authoring specialized collections are defined by their respective
 						specifications.</p>
@@ -5683,32 +5673,32 @@ No Entry</pre>
 				<section id="sec-pkg-legacy-intro">
 					<h4>Introduction</h4>
 
-					<p>The package document <strong>legacy</strong> features are retained from EPUB 2 only to allow
-						[=EPUB creators=] to author content that can function, to some degree, in [=reading systems=]
-						that only support EPUB 2 publications.</p>
+					<p>The package document <strong>legacy</strong> features are retained from EPUB 2 only to allow the
+						authoring of content that can function, to some degree, in [=reading systems=] that only support
+						EPUB 2 publications.</p>
 
 					<p>These features were added primarily to address the overlap period as EPUB 3 reading systems were
 						developed, as there was still a high probability at that time that users would be opening EPUB 3
 						publications on EPUB 2 reading systems.</p>
 
-					<p>As reading systems that only handle EPUB 2 publications are now rare, EPUB creators should
-						consider the likelihood of their publications still being opened on these types of older devices
-						before making the effort to add these legacy features.</p>
+					<p>As reading systems that only handle EPUB 2 publications are now rare, consider how likely it is
+						that EPUB publications will still be opened on these types of older devices before making the
+						effort to add these legacy features.</p>
 				</section>
 
 				<section id="pkg-legacy-support">
 					<h4>Support</h4>
 
-					<p>[=EPUB creators=] MAY include the legacy features defined in this section for compatibility
+					<p>[=EPUB publications=] MAY include the legacy features defined in this section for compatibility
 						purposes with EPUB 2 reading systems.</p>
 
 					<p>EPUB 3 reading systems will not use these features when presenting publications to users.</p>
 
 					<div class="note">
-						<p>[=EPUB conformance checkers=] should not alert EPUB creators about the presence of legacy
-							features in an [=EPUB publication=], as their inclusion is valid for backwards
-							compatibility. EPUB conformance checkers must alert EPUB creators if a legacy feature does
-							not conform to its definition or otherwise breaks a usage requirement.</p>
+						<p>[=EPUB conformance checkers=] should not issue alerts about the presence of legacy features
+							in an [=EPUB publication=], as their inclusion is valid for backwards compatibility. EPUB
+							conformance checkers must issue alerts if a legacy feature does not conform to its
+							definition or otherwise breaks a usage requirement.</p>
 					</div>
 				</section>
 
@@ -5726,8 +5716,8 @@ No Entry</pre>
 						<p>The EPUB 3 [^meta^] element, which uses different attributes and requires text content,
 							provides metadata capabilities for EPUB 3 reading systems.</p>
 
-						<p>The [[opf-201]] <code>meta</code> element also allows [=EPUB creators=] to identify a cover
-							image for EPUB 2 reading systems. In EPUB 3, the cover image must be identified using the <a
+						<p>The [[opf-201]] <code>meta</code> element also allows a cover image to be specified for EPUB
+							2 reading systems. In EPUB 3, the cover image has to be identified using the <a
 								href="#sec-cover-image"><code>cover-image</code> property</a> on the manifest [^item^]
 							for the image.</p>
 					</div>
@@ -5855,8 +5845,8 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L656,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L661">
 						<h5>Structural semantics</h5>
 
-						<p>[=EPUB creators=] MAY use the [^/epub:type^] attribute in [=XHTML content documents=] to
-							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
+						<p>The [^/epub:type^] attribute MAY be used in [=XHTML content documents=] to express <a
+								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
 						<p>The attribute MUST NOT be used on the <a data-cite="html#the-head-element"
 								><code>head</code></a> element or [=metadata content=] [[html]].</p>
@@ -5866,32 +5856,31 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L703">
 						<h5>RDFa</h5>
 
-						<p>The [[html-rdfa]] specification defines a set of attributes that [=EPUB creators=] MAY use in
-							[=XHTML content documents=] to semantically enrich the content. The use of these attributes
-							MUST conform to the requirements defined in [[html-rdfa]].</p>
+						<p>The [[html-rdfa]] specification defines a set of attributes that MAY be used in [=XHTML
+							content documents=] to semantically enrich the content. The use of these attributes MUST
+							conform to the requirements defined in [[html-rdfa]].</p>
 
 						<p>The [[html-rdfa]] specification defines changes to the [[html]] content model when authors
 							use RDFa attributes. This modified content model is valid in XHTML content documents.</p>
 
 						<div class="note">
 							<p>The listing of RDFa does not express a preference on the part of the Working Group, only
-								that these attributes represent an extension of the HTML grammar. EPUB creators can also
-								specify <a data-cite="html#microdata">microdata attributes</a> [[html]] and <a
-									data-cite="json-ld11#">linked data</a> [[json-ld11]] in XHTML content documents as
-								both are natively supported.</p>
+								that these attributes represent an extension of the HTML grammar. <a
+									data-cite="html#microdata">Microdata attributes</a> [[html]] and <a
+									data-cite="json-ld11#">linked data</a> [[json-ld11]] are natively supported in XHTML
+								content documents.</p>
 						</div>
 					</section>
 
 					<section id="sec-xhtml-its">
 						<h5>Internationalization tag set (ITS)</h5>
 
-						<p>The [[its20]] specification defines a set of attributes that [=EPUB creators=] MAY use in
-							[=XHTML content documents=] to add support for internationalization, translation, and
-							localization.</p>
+						<p>The [[its20]] specification defines a set of attributes that MAY be used in [=XHTML content
+							documents=] to add support for internationalization, translation, and localization.</p>
 
-						<p>EPUB creators MUST only use ITS attributes as they are defined in <a
-								data-cite="its20#html5-markup">Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does
-							not support the namespaced attributes).</p>
+						<p>ITS attributes MUST only be used as they are defined in <a data-cite="its20#html5-markup"
+								>Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does not support the namespaced
+							attributes).</p>
 
 						<p>The use of these attributes MUST conform to the requirements defined in [[its20]].</p>
 					</section>
@@ -5945,16 +5934,15 @@ No Entry</pre>
 
 							<dt id="math-cont">Content MathML</dt>
 							<dd>
-								<p id="confreq-mathml-annot-cont">[=EPUB creators=] MAY include <a
-										data-cite="mathml3/chapter4.html#">Content MathML</a> within MathML markup in
-									XHTML content documents, and, when present, MUST include it within an
-										<code>annotation-xml</code> child element of a <code>semantics</code>
-									element.</p>
-								<p id="confreq-mathml-annot-cont-attrs">When EPUB creators include Content MathML per
-									the previous condition, they MUST set the given <code>annotation-xml</code>
-									element's <code>encoding</code> attribute to either of the functionally-equivalent
-									values <code>MathML-Content</code> or <code>application/mathml-content+xml</code>,
-									and the <code>name</code> attribute to <code>contentequiv</code>.</p>
+								<p id="confreq-mathml-annot-cont"><a data-cite="mathml3/chapter4.html#">Content
+										MathML</a> MAY be included within MathML markup in XHTML content documents, and,
+									when present, MUST be included within an <code>annotation-xml</code> child element
+									of a <code>semantics</code> element.</p>
+								<p id="confreq-mathml-annot-cont-attrs">When Content MathML is included per the previous
+									condition, the given <code>annotation-xml</code> element's <code>encoding</code>
+									attribute MUST be set to either of the functionally-equivalent values
+										<code>MathML-Content</code> or <code>application/mathml-content+xml</code>, and
+									the <code>name</code> attribute to <code>contentequiv</code>.</p>
 							</dd>
 						</dl>
 
@@ -6006,8 +5994,8 @@ No Entry</pre>
 								resources=]. It may also cause [=reading systems=] to misinterpret the location of
 								hyperlinks (e.g., relative links to other documents in the publication might appear as
 								links to a web site if the <code>base</code> element specifies an absolute URL). To
-								avoid significant interoperability issues, [=EPUB creators=] should not use the
-									<code>base</code> element. </p>
+								avoid significant interoperability issues, use of the <code>base</code> element is
+								discouraged. </p>
 						</section>
 
 						<section id="sec-xhtml-deviations-rp">
@@ -6016,18 +6004,17 @@ No Entry</pre>
 							<p id="confreq-html-vocab-rp">The [[html]] [^rp^] element is intended to provide a fallback
 								for older [=reading systems=] that do not recognize ruby markup (i.e., a parenthesis
 								display around <code>ruby</code> markup). As EPUB 3 reading systems are ruby-aware, and
-								can provide fallbacks, [=EPUB creators=] should not use <code>rp</code> elements.</p>
+								can provide fallbacks, use of <code>rp</code> elements is discouraged.</p>
 						</section>
 
 						<section id="sec-xhtml-deviations-embed">
 							<h6>The <code>embed</code> element</h6>
 
 							<p id="confreq-html-vocab-embed">Since the [[html]] <a data-lt="embed"><code>embed</code>
-									element</a> element does not include intrinsic facilities to provide fallback
-								content for [=reading systems=] that do not support scripting, [=EPUB creators=] are
-								discouraged from using the element when the referenced resource includes scripting. The
-								[[html]] [^object^] element is a better alternative, as it includes intrinsic fallback
-								capabilities.</p>
+									element</a> element does not include intrinsic fallback facilities for [=reading
+								systems=] that do not support scripting, using the element with scripted resources is
+								discouraged. The [[html]] [^object^] element is a better alternative as it includes
+								intrinsic fallback capabilities.</p>
 						</section>
 					</section>
 				</section>
@@ -6038,8 +6025,8 @@ No Entry</pre>
 
 				<div class="caution">
 					<p>[=Reading systems=] may not support all the features of [[svg]] or support them across all
-						platforms that reading systems run on. When utilizing such features, [=EPUB creators=] should
-						consider the inherent risks on interoperability and document longevity.</p>
+						platforms that reading systems run on. When utilizing such features, consider the risks to
+						interoperability and document longevity.</p>
 				</div>
 
 				<section id="sec-svg-intro" class="informative">
@@ -6048,11 +6035,11 @@ No Entry</pre>
 					<p>The Scalable Vector Graphics (SVG) specification [[svg]] defines a format for representing
 						final-form vector graphics and text.</p>
 
-					<p>Although [=EPUB creators=] typically use <a href="#sec-xhtml">XHTML content documents</a> as the
-						[=top-level content document | top-level=] document type, the use of [=SVG content documents=]
-						is also permitted. EPUB creators will typically only need SVGs for certain special cases, such
-						as when final-form page images are the only suitable representation of the content (e.g., for
-						cover art or in the context of manga or comic books).</p>
+					<p>Although <a href="#sec-xhtml">XHTML content documents</a> are more commonly used as [=top-level
+						content documents], the use of [=SVG content documents=] is also permitted. SVGs are typically
+						only needed for certain special cases, such as when final-form page images are the only suitable
+						representation of the content (e.g., for cover art or in the context of manga or comic
+						books).</p>
 
 					<p>This section defines a profile for [[svg]] documents. An instance of an XML document that
 						conforms to this profile is a [=core media type resource=] and is referred to in this
@@ -6116,8 +6103,8 @@ No Entry</pre>
 									data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
 							<div class="note">
 								<p>Although the [[svg]] <code>title</code> element allows markup elements, support for
-									this feature is limited. [=EPUB creators=] are advised to use text-only titles for
-									maximum interoperability.</p>
+									this feature is limited. The use of text-only titles is advised for maximum
+									interoperability.</p>
 							</div>
 						</li>
 						<li>
@@ -6165,9 +6152,8 @@ No Entry</pre>
 								data-cite="epub-rs-34#confreq-css-rs-support">CSS as defined in the CSS snapshot</a>
 							[[epub-rs-34]], the reality is that most reading systems currently do not support all
 							desired features of CSS, and often will modify, and allow users to change, the default
-							presentation defined by the [=EPUB creator=]. As a result, EPUB creators will need to adapt
-							their styling to these realities. For more information, refer to <a href="#sec-css-rs"
-							></a>.</p>
+							presentation defined in an EPUB publication. As a result, styling has to be adapted to these
+							realities. For more information, refer to <a href="#sec-css-rs"></a>.</p>
 					</section>
 
 					<section id="sec-css-req" data-epubcheck="true"
@@ -6205,8 +6191,8 @@ No Entry</pre>
 						<div class="note">
 							<p>This specification restricts the use of the <code>direction</code> and
 									<code>unicode-bidi</code> properties because [=reading systems=] might not
-								implement, or might switch off, CSS processing. [=EPUB creators=] must use the following
-								format-specific methods when they need control over these aspects of the rendering:</p>
+								implement, or might switch off, CSS processing. The following format-specific methods
+								have to be used when control over these aspects of the rendering is needed:</p>
 
 							<ul>
 								<li>
@@ -6245,10 +6231,9 @@ No Entry</pre>
 
 						<p>Reading systems will typically set some aspects of an [=EPUB publication | EPUB
 							publication's=] style (e.g., setting margins appropriate to the application), potentially
-							overriding the [=EPUB creator | EPUB creator's=] instructions. To mitigate conflicts, and
-							any potential rendering problems, EPUB creators are advised to consult reading systems' user
-							agent style sheets, when made publicly available, and adapt their styling choices for
-							optimal display.</p>
+							overriding the default instructions. To mitigate conflicts, and any potential rendering
+							problems, it is advised to consult reading systems' user agent style sheets, when made
+							publicly available, and adapt styling choices for optimal display.</p>
 
 						<p>Furthermore, reading systems that allow users to change the appearance (e.g., choice of
 							fonts, text justification, or foreground and background colors) will also modify some CSS
@@ -6267,18 +6252,16 @@ No Entry</pre>
 							using these prefixes, they have been retained in this specification. Unless otherwise noted,
 							prefixed properties and values behave exactly as their unprefixed equivalents as described
 							in the appropriate CSS specification. The prefixed properties are documented in <a
-								href="#css-prefixes"></a>. </p>
+								href="#css-prefixes"></a>.</p>
 
 						<div class="caution">
-							<p>[=EPUB creators=] should use unprefixed properties and [=reading systems=] should support
-								current CSS specifications. This specification retains the widely used prefixed
-								properties from [[epubcontentdocs-301]] but removes support for the less-used ones. EPUB
-								creators should use CSS-native solutions for the removed properties whenever
-								available.</p>
-
-							<p>The Working Group recommends that EPUB creators currently using these prefixed properties
-								move to unprefixed versions as soon as support allows, as the Working Group does not
+							<p>The Working Group recommends anyone still using <code>-epub-</code> prefixed properties
+								move to the unprefixed versions as soon as support allows, as the Working Group does not
 								anticipate supporting them in the next major version of EPUB.</p>
+
+							<p>This specification retains the widely used prefixed properties from
+								[[epubcontentdocs-301]] but removes support for the less-used ones. It is strongly
+								advised to use CSS-native solutions for the removed properties whenever available.</p>
 						</div>
 					</section>
 				</section>
@@ -6307,8 +6290,8 @@ No Entry</pre>
 								if a future update adds the concept.</p>
 						</div>
 
-						<p>[=EPUB creators=] should note that [=reading systems=] are required to behave as though a
-							unique <a data-cite="html#origin">origin</a> [[html]] has been assigned to each [=EPUB
+						<p>Note that [=Reading systems=] are required to behave as though a unique <a
+								data-cite="html#origin">origin</a> [[html]] has been assigned to each [=EPUB
 							publication=]. In practice, this means that it is not possible for scripts to share data
 							between EPUB publications.</p>
 
@@ -6344,13 +6327,11 @@ No Entry</pre>
 								[[epub-rs-34]] for more information.</p>
 						</div>
 
-						<p>Whether [=EPUB creators=] embed the code directly in a <code>script</code> element or
-							reference it via the element's <code>src</code> attribute makes no difference to its
-							executing context.</p>
+						<p>Whether code is embedded directly in a <code>script</code> element or referenced via the
+							element's <code>src</code> attribute makes no difference to its executing context.</p>
 
-						<p>Which context EPUB creators use for their scripts affects both what actions the scripts can
-							perform and the likelihood of support in reading systems, as described in the following
-							subsections.</p>
+						<p>Which context is used for scripts affects both what actions the scripts can perform and the
+							likelihood of support in reading systems, as described in the following subsections.</p>
 
 						<div class="note">
 							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference
@@ -6382,18 +6363,18 @@ No Entry</pre>
 								(i.e., the one that contains the <code>iframe</code> element). It also MUST NOT contain
 								instructions for manipulating the size of its containing rectangle.</p>
 
-							<p>[=EPUB creators=] should note that <a data-cite="epub-rs-34#sec-scripted-content">support
-									for container-constrained scripting in reading systems</a> is only recommended in
+							<p>Note that <a data-cite="epub-rs-34#sec-scripted-content">support for
+									container-constrained scripting in reading systems</a> is only recommended in
 								reflowable documents [[epub-rs-34]]. Furthermore, [=reading system=] support in
 								[=fixed-layout documents=] is optional.</p>
 
-							<p>EPUB creators should ensure container-constrained scripts degrade gracefully in reading
-								systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
+							<p>Ensure that container-constrained scripts degrade gracefully in reading systems without
+								scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
 
 							<div class="note">
-								<p>EPUB creators choosing to restrict the usage of scripting to the
-									container-constrained model will ensure a more consistent user experience between
-									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
+								<p>Opting to restrict the usage of scripting to the container-constrained model will
+									ensure a more consistent user experience between scripted and non-scripted content
+									(e.g., consistent pagination behavior).</p>
 							</div>
 						</section>
 
@@ -6404,8 +6385,7 @@ No Entry</pre>
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 								element contained in a [=top-level content document=].</p>
 
-							<p>[=EPUB creators=] should note that support for spine-level scripting in [=reading
-								systems=] is only recommended in <a
+							<p>Note that support for spine-level scripting in [=reading systems=] is only advised in <a
 									data-cite="epub-rs-34#confreq-rs-scripted-fxl-support">fixed-layout documents</a>
 								and <a data-cite="epub-rs-34#confreq-rs-scripted-scrolled">reflowable documents set to
 									scroll</a> [[epub-rs-34]]. Furthermore, reading system support in all other contexts
@@ -6423,11 +6403,11 @@ No Entry</pre>
 					<section id="sec-scripted-content-events" class="informative">
 						<h4>Event model</h4>
 
-						<p>[=EPUB creators=] should consider the wide variety of possible [=reading system=]
-							implementations when adding scripting functionality to their [=EPUB publications=] (e.g.,
-							not all devices have physical keyboards, and in many cases a soft keyboard is activated only
-							for text input elements). Consequently, EPUB creators should not rely on keyboard events
-							alone; they should always provide alternative ways to trigger a desired action.</p>
+						<p>The wide variety of possible [=reading system=] implementations need to be considered when
+							adding scripting functionality to [=EPUB publications=] (e.g., not all devices have physical
+							keyboards, and in many cases a soft keyboard is activated only for text input elements).
+							Consequently, do not rely on keyboard events alone; always provide alternative ways to
+							trigger a desired action.</p>
 					</section>
 
 					<section id="sec-scripted-a11y">
@@ -6447,9 +6427,8 @@ No Entry</pre>
 							fallback is not applicable, by using a <a href="#sec-manifest-fallbacks">manifest-level
 								fallback</a>.</p>
 
-						<p id="confreq-cd-scripted-foreign-resources">[=EPUB creators=] MUST ensure that scripts only
-							generate <a href="#sec-core-media-types">core media type resources</a> or fragments
-							thereof.</p>
+						<p id="confreq-cd-scripted-foreign-resources">Scripts MUST only generate <a
+								href="#sec-core-media-types">core media type resources</a> or fragments thereof.</p>
 					</section>
 				</section>
 			</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10380,7 +10380,7 @@ html.my-document-playing * {
 						used in [=EPUB content documents=] and [=media overlay documents=].</p>
 
 					<aside class="example" title="Declaring prefixes in an XHTML content document">
-						<p>In this example, the a prefix is declared for the Z39.98 Structural Semantics Vocabulary.</p>
+						<p>In this example, a prefix is declared for the Z39.98 Structural Semantics Vocabulary.</p>
 
 						<pre>&lt;html …
       xmlns:epub="http://www.idpf.org/2007/ops"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
@@ -121,8 +121,8 @@
 					functionality normatively referenced as part of the standard. The development of extension
 					specifications periodically adds new functionality to EPUB publications. Features and functionality
 					defined outside of core revisions to the standard, while not formally recognized in this
-					specification, are nonetheless available for [=EPUB creators=] and reading system developers to
-					use.</p>
+					specification, are nonetheless available for use in EPUB publications and implementation in reading
+					systems.</p>
 
 				<p>The non-normative <a data-cite="epub-overview-34#">EPUB 3 Overview</a> [[epub-overview-34]] provides
 					a general introduction to EPUB 3. A list of technical changes from the previous version is also
@@ -169,9 +169,9 @@
 				<p>An EPUB publication also includes another key file called the [=EPUB navigation document=]. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
 					to navigate the content quickly and easily. The navigation document is a specialized type of [=XHTML
-					content document=] which also allows EPUB creators to use it in the content (i.e., avoiding one
-					table of contents for machine processing and another for user consumption). Refer to <a
-						href="#sec-nav"></a> for more information about this document.</p>
+					content document=] which also allows for its use in the content (i.e., avoiding one table of
+					contents for machine processing and another for user consumption). Refer to <a href="#sec-nav"></a>
+					for more information about this document.</p>
 
 				<p>EPUB publications by default are intended to reflow to fit the available screen space. It is also
 					possible to create publications that have pixel-precise fixed layouts using images and/or CSS
@@ -190,9 +190,8 @@
 					EPUB 3 is provided in the non-normative [[epub-overview-34]].</p>
 
 				<p>Refer to [[epub-rs-34]] for the processing requirements for reading systems. Although it is not
-					necessary that [=EPUB creators=] read that document to create EPUB publications, an understanding of
-					how reading systems present the content can help craft publications for optimal presentation to
-					users.</p>
+					necessary to read that document to create EPUB publications, an understanding of how reading systems
+					present the content can help craft publications for optimal presentation to users.</p>
 			</section>
 
 			<section id="sec-intro-relations" class="informative">
@@ -204,9 +203,8 @@
 						of EPUB publications is immediate. Others are updated less frequently and the changes may not
 						affect [=EPUB publications=] until EPUB 3 undergoes a new revision.</p>
 					<p>In all cases, it is possible that previously valid features may become obsolete (e.g., due to a
-						lack of support or because of security issues). [=EPUB creators=] should therefore be cautious
-						about using any feature without broad support and keep their [=EPUB conformance checkers=] up to
-						date.</p>
+						lack of support or because of security issues). Consequently, it is advised to only use features
+						without broad support sparingly and keep [=EPUB conformance checkers=] up to date.</p>
 				</div>
 
 				<section id="sec-overview-relations-html">
@@ -217,9 +215,9 @@
 						MathML, SVG, CSS, and JavaScript.</p>
 
 					<p>The benefit of this approach for EPUB is that [=EPUB publications=] always keep pace with changes
-						to the web without the need for new revisions. [=EPUB creators=], however, must keep track of
-						the various changes to HTML and the technologies it references to ensure they keep their
-						processes up to date.</p>
+						to the web without the need for new revisions. Anyone who creates EPUB publications, however,
+						will have to keep track of the various changes to HTML and the technologies it references to
+						ensure they keep their processes up to date.</p>
 
 					<p>The [[html]] standard defines a single content model with rules for expressing a tag set using
 						either the <a data-cite="html#syntax">HTML syntax</a> or the <a
@@ -241,7 +239,7 @@
 						of semantics, structure and processing behaviors from [[html]] unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the [[html]] document model that EPUB creators may include in [=HTML content documents=].</p>
+						to the [[html]] document model that can be included in [=HTML content documents=].</p>
 				</section>
 
 				<section id="sec-overview-relations-svg">
@@ -251,9 +249,9 @@
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
 
-					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. [=EPUB
-						creators=], however, must keep track of changes to the SVG standard to ensure they keep their
-						processes up to date.</p>
+					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Anyone
+						who creates EPUB publications, however, will have to keep track of changes to the SVG standard
+						to ensure they keep their processes up to date.</p>
 				</section>
 
 				<section id="sec-overview-relations-css">
@@ -327,7 +325,7 @@
 					</dt>
 					<dd>
 						<p>The [=URL=]&#160;[[url]] of the [=root directory=] representing the [=OCF abstract
-							container=]. It is implementation specific, but EPUB creators must assume it has properties
+							container=]. Although the container root URL is implementation specific, it has properties
 							defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
 
@@ -380,27 +378,8 @@
 							document=] definitions.</p>
 						<p>EPUB content documents contain all or part of the content of an [=EPUB publication=] (i.e.,
 							the textual, visual and/or audio content).</p>
-						<p>[=EPUB creators=] can include EPUB content documents in the spine without the provision of <a
-								href="#sec-foreign-resources">fallbacks</a>.</p>
-					</dd>
-
-					<dt>
-						<dfn class="export">EPUB creator</dfn>
-					</dt>
-					<dd>
-						<p>An individual, organization, or process that produces an [=EPUB publication=].</p>
-						<div class="note">
-							<p> The creation of an EPUB publication often involves the work of many individuals, and may
-								be split across multiple organizations (e.g., when a publisher outsources all or part of
-								the work). Depending on the process used to produce an EPUB publication,
-								responsibilities may fall on the organization (e.g., the publisher), the individuals
-								preparing the publication (e.g., technical editors), or automatic procedures (e.g., as
-								part of a publication pipeline). As a result, not every party or process may be
-								responsible for ensuring every requirement is met, but there is always an EPUB creator
-								responsible for the conformance of the final EPUB publication. </p>
-							<p>Previous versions of this specification referred to the EPUB creator as the <span
-									id="dfn-author">Author</span>.</p>
-						</div>
+						<p>EPUB publications can reference EPUB content documents from the spine without the provision
+							of <a href="#sec-foreign-resources">fallbacks</a>.</p>
 					</dd>
 
 					<dt>
@@ -451,8 +430,8 @@
 					</dt>
 					<dd>
 						<p>Exempt resources are a special class of [=publication resources=] that reading systems are
-							not required to support the rendering of, but [=EPUB creators=] do not have to provide <a
-								href="#sec-foreign-resources">fallbacks</a> for.</p>
+							not required to support the rendering of but do not require <a href="#sec-foreign-resources"
+								>fallbacks</a>.</p>
 						<p>Refer to <a href="#sec-exempt-resources"></a> for more information.</p>
 					</dd>
 
@@ -593,13 +572,13 @@
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
 							of an [=EPUB publication=]. In the absence of this resource, [=reading systems=] may not
-							render the EPUB publication as the [=EPUB creator=] intends. Examples of publication
-							resources include the [=package document=], [=EPUB content documents=], CSS Style Sheets,
-							audio, video, images, embedded fonts, and scripts.</p>
-						<p>EPUB creators must list publication resources in the package document [=EPUB manifest |
-							manifest=] and typically bundle them all in the [=EPUB container=] (the exception being they
-							may locate resources listed in <a href="#sec-resource-locations"></a> outside the EPUB
-							container).</p>
+							render the EPUB publication as intended. Examples of publication resources include the
+							[=package document=], [=EPUB content documents=], CSS Style Sheets, audio, video, images,
+							embedded fonts, and scripts.</p>
+						<p>The package document [=EPUB manifest | manifest=] has to include a list of all publication
+							resources and they typically have to be bundled in the [=EPUB container=] (the exception
+							being they may locate resources listed in <a href="#sec-resource-locations"></a> outside the
+							EPUB container).</p>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
 									<code>href</code> attribute of an [[html]] [^a^] element) are not publication
@@ -740,8 +719,7 @@
 				<h3>Conformance checking</h3>
 
 				<p>Due to the complexity of this specification and number of technologies used in [=EPUB publications=],
-					[=EPUB creators=] are advised to use an [=EPUB conformance checker=] to verify the conformance of
-					their content.</p>
+					the use an [=EPUB conformance checker=] is advised to verify the conformance of their content.</p>
 
 				<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB conformance
 					checker used by the publishing industry and has been updated with each new version of EPUB. It is
@@ -750,22 +728,22 @@
 						href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
 					page</a>).</p>
 
-				<p>When verifying their EPUB publications, EPUB creators should ensure they do not violate the
-					requirements of this specification (practices identified by the keywords "MUST", "MUST NOT", and
-					"REQUIRED"). These types of issues will often result in EPUB publications not rendering or rendering
-					in inconsistent ways. These issues are typically reported as errors or critical errors.</p>
+				<p>When verifying EPUB publications, ensure they do not violate the requirements of this specification
+					(practices identified by the keywords "MUST", "MUST NOT", and "REQUIRED"). These types of issues
+					will often result in EPUB publications not rendering or rendering in inconsistent ways. These issues
+					are typically reported as errors or critical errors.</p>
 
-				<p>EPUB creators should also ensure that their EPUB publications do not violate the recommendations of
-					this specification (practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED").
-					Failure to follow these practices does not result in an invalid EPUB publication but may lead to
-					interoperability problems and other issues that impact the user reading experience. These issues are
-					typically reported as warnings.</p>
+				<p>Also ensure that EPUB publications do not violate the recommendations of this specification
+					(practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED"). Failure to follow
+					these practices does not result in an invalid EPUB publication but can lead to interoperability
+					problems and other issues that impact the user reading experience. These issues are typically
+					reported as warnings.</p>
 
 				<div class="note">
 					<p>Vendors, distributors, and other retailers of EPUB publications should consider the importance of
 						recommended practices before basing their acceptance or rejection on a zero-issue outcome from
-						an EPUB conformance checker. There will be legitimate reasons why EPUB creators cannot follow
-						recommended practices in all cases.</p>
+						an EPUB conformance checker. There will be legitimate reasons why EPUB publications cannot
+						adhere to recommended practices in all cases.</p>
 				</div>
 			</section>
 		</section>
@@ -817,8 +795,8 @@
 						but includes resources not present in that list.</p>
 
 					<p>The primary resources in this group are designated [=publication resources=], which are all the
-						resources used in rendering an EPUB publication to the user. [=EPUB creators=] always have to
-						list these resources in the [^manifest^] element.</p>
+						resources used in rendering an EPUB publication to the user. The [^manifest^] element has to
+						contain a complete list these resources.</p>
 
 					<p>Publication resources are further classified by their use(s) in the [=spine plane=] and [=content
 						plane=].</p>
@@ -864,13 +842,13 @@
 						publication=]. Although many resources may be bundled in an [=EPUB container=], they are not all
 						allowed by default in the spine.</p>
 
-					<p>EPUB 3 defines a special class of resources called [=EPUB content documents=] that [=EPUB
-						creators=] can use in the spine without any restrictions. EPUB content documents encompass both
-						[=XHTML content documents=] and [=SVG content documents=].</p>
+					<p>EPUB 3 defines a special class of resources called [=EPUB content documents=] that can be used in
+						the spine without any restrictions. EPUB content documents encompass both [=XHTML content
+						documents=] and [=SVG content documents=].</p>
 
 					<p>To use any other type of resource in the spine, called a [=foreign content document=], requires
-						including a fallback to an EPUB content document. This extensibility model allows EPUB creators
-						to experiment with formats while ensuring that reading systems are always able to render
+						including a fallback to an EPUB content document. This extensibility model allows
+						experimentation with formats while ensuring that reading systems are always able to render
 						something for the user to read, as there is no guarantee of support for foreign content
 						documents.</p>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -7951,11 +7951,11 @@ No Entry</pre>
 				<h4>Introduction</h4>
 
 				<p>Mainstream ebooks, educational tools and ebooks formatted for persons with print disabilities are
-					some examples of works that contain synchronized audio narration. In EPUB 3, [=EPUB creators=] can
-					create these types of books using media overlay documents to describe the timing for the
-					pre-recorded audio narration and how it relates to the [=EPUB content document=] markup. The
-					specification defines the file format for media overlays as a subset of [[smil3]], a W3C
-					recommendation for representing synchronized multimedia information in XML.</p>
+					some examples of works that contain synchronized audio narration. In EPUB 3, these types of books
+					can be created using media overlay documents to describe the timing for the pre-recorded audio
+					narration and how it relates to the [=EPUB content document=] markup. The specification defines the
+					file format for media overlays as a subset of [[smil3]], a W3C recommendation for representing
+					synchronized multimedia information in XML.</p>
 
 				<p>The text and audio synchronization enabled by media overlays provides enhanced accessibility for any
 					user who has difficulty following the text of a traditional book. Media overlays also provide a
@@ -8426,12 +8426,12 @@ No Entry</pre>
 						</dl>
 
 						<p class="note">This specification places no restriction on the <code>src</code> attribute of a
-								<code>text</code> element. [=EPUB creators=] should, however, refer to a content that
+								<code>text</code> element, but it is advised that the attribute reference content that
 							can be styled with CSS to make the <a href="#sec-docs-assoc-style">association with style
-								information</a> effective (i.e., [=palpable content=] for XHTML or <a
-								href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
+								information</a> effective. For XHTML, this means referencing [=palpable content=]. For
+							SVG, it means referencing <a href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
 								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
-								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG). </p>
+								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements. </p>
 
 						<p class="note">[[epub-rs-34]] no longer provides guidance for reading systems on the playback
 							of timed media (i.e., the automatic starting of the referenced media). Although the
@@ -8526,11 +8526,11 @@ No Entry</pre>
 				<section id="sec-docs-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>[=EPUB creators=] can represent a pre-recorded narration of a publication as a series of audio
-						clips, each corresponding to part of an [=EPUB content document=]. A single audio clip, for
-						example, typically represents a single phrase or paragraph, but infers no order relative to the
-						other clips or to the text of a document. Media overlays solve this problem of synchronization
-						by tying the structured audio narration to its corresponding text (or other media) in the EPUB
+					<p>A pre-recorded narration of a publication can be represented as a series of audio clips, each
+						corresponding to part of an [=EPUB content document=]. A single audio clip, for example,
+						typically represents a single phrase or paragraph, but infers no order relative to the other
+						clips or to the text of a document. Media overlays solve this problem of synchronization by
+						tying the structured audio narration to its corresponding text (or other media) in the EPUB
 						content document using [[smil3]] markup. Media overlays are, in fact, a simplified subset of
 						SMIL 3.0 that define the playback sequence of these clips.</p>
 
@@ -8565,8 +8565,8 @@ No Entry</pre>
 &lt;/par&gt;</pre>
 					</aside>
 
-					<p>EPUB creators place <code>par</code> elements together sequentially to form a series of phrases
-						or sentences. Not every element of the EPUB content document will have a corresponding
+					<p><code>par</code> elements are placed together sequentially to form a series of phrases or
+						sentences. Not every element of the EPUB content document will have a corresponding
 							<code>par</code> element in a media overlay document, only those relevant to the audio
 						narration.</p>
 
@@ -8606,9 +8606,8 @@ No Entry</pre>
 &lt;/smil&gt;</pre>
 					</aside>
 
-					<p>EPUB creators can also add <code>par</code> elements to <code>seq</code> elements to define more
-						complex structures such as parts and chapters (see <a href="#sec-media-overlays-structure"
-						></a>).</p>
+					<p><code>par</code> elements can also be added to <code>seq</code> elements to define more complex
+						structures such as parts and chapters (see <a href="#sec-media-overlays-structure"></a>).</p>
 				</section>
 
 				<section id="sec-docs-relations">
@@ -8616,14 +8615,12 @@ No Entry</pre>
 
 					<div class="note">
 						<p>In this section, the [=EPUB content document=] is assumed to be an [=XHTML content
-							document=]. While [=EPUB creators=] may use media overlays with [=SVG content documents=],
-							playback behavior might not be consistent and therefore interoperability is not
-							guaranteed.</p>
+							document=]. While media overlays can be used with [=SVG content documents=], playback
+							behavior might not be consistent and therefore interoperability is not guaranteed.</p>
 
-						<p>EPUB creators should also be aware that [=reading system=] support for playback of both
-							reflowable and fixed-layout EPUB content documents is not guaranteed. Differences in reading
-							system pagination strategies mean that some reading systems will only support media overlays
-							in one or the other layout format.</p>
+						<p>[=reading system=] support for playback of both reflowable and fixed-layout EPUB content
+							documents is not guaranteed. Differences in reading system pagination strategies mean that
+							some reading systems will only support media overlays in one or the other layout format.</p>
 					</div>
 
 					<section id="sec-media-overlays-structure">
@@ -8640,9 +8637,9 @@ No Entry</pre>
 
 						<p>The <code>seq</code> element represents sequences — sets of <code>seq</code> and/or
 								<code>par</code> elements that together represent a logical component of the content.
-							[=EPUB creators=] can use it to represent nested containers such as sections, asides,
-							headers, tables, lists, and footnotes. It allows EPUB creators to retain the structure
-							inherent in these containers in the media overlay document.</p>
+							The element is used to represent nested containers such as sections, asides, headers,
+							tables, lists, and footnotes. It allows the structure inherent in these containers to be
+							retained in the media overlay document.</p>
 
 						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
 									><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not
@@ -8814,16 +8811,16 @@ No Entry</pre>
 								href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
 								Identifier</a> [[svg]], respectively.</p>
 
-						<p>EPUB creators MAY use other fragment identifier schemes, but [=reading systems=] may not
-							support such identifiers.</p>
+						<p>Other fragment identifier schemes MAY be used but [=reading systems=] might not support such
+							identifiers.</p>
 					</section>
 
 					<section id="sec-media-overlays-granularity" class="informative">
 						<h5>Overlay granularity</h5>
 
-						<p>The granularity level of the media overlay depends on how [=EPUB creators=] mark up the
-							[=EPUB content document=] and the type of fragment identifier they use in the [^text^]
-							elements' <code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
+						<p>The granularity level of the media overlay depends on how the [=EPUB content document=] are
+							marked up and the type of fragment identifier used in the [^text^] elements'
+								<code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
 							attributes. For example, when referencing [[html]] elements, if the finest level of markup
 							is at the paragraph level, then that is the finest possible level for media overlay
 							synchronization. Likewise, if sub-paragraph markup is available, such as [[html]] [^span^]
@@ -8857,8 +8854,8 @@ No Entry</pre>
 					<h4>Structural semantics in overlays</h4>
 
 					<p>To express <a href="#app-structural-semantics">structural semantics</a> in [=media overlay
-						documents=], [=EPUB creators=] MAY specify the [^/epub:type^] attribute on [^par^], [^seq^], and
-						[^body^] elements.</p>
+						documents=], the [^/epub:type^] attribute MAY be specified on [^par^], [^seq^], and [^body^]
+						elements.</p>
 
 					<p>The <code>epub:type</code> attribute facilitates [=reading system=] behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
@@ -8913,27 +8910,26 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L206,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L213,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L220,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L227,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L234,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L241,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L255,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L261,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L267,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L273,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L280,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L287,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L294">
 					<h4>Associating style information</h4>
 
-					<p>[=EPUB creators=] MAY express visual rendering information for the currently playing [=EPUB
-						content document=] element in a CSS Style Sheet using author-defined classes.</p>
+					<p>Visual rendering information for the currently playing [=EPUB content document=] element MAY be
+						expressed in a CSS Style Sheet using author-defined classes.</p>
 
-					<p>When used, EPUB creators MUST declare the class names in the [=package document=] using the <a
+					<p>When used, the class names MUST be declared in the [=package document=] using the <a
 							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 								><code>playback-active-class</code></a> properties.</p>
 
-					<p>EPUB creators MUST define exactly one CSS class name in each property they define. Each property
-						MUST define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class
-							name</a> not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a>
-						[[css2]]. This specification <strong>does not</strong> reserve names for use with these
-						properties.</p>
+					<p>Exactly one CSS class name MUST be defined in each property they define. Each property MUST
+						define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class name</a>
+						not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a> [[css2]].
+						This specification <strong>does not</strong> reserve names for use with these properties.</p>
 
-					<p>EPUB creators MAY define any CSS properties for the specified CSS classes but must ensure that
-						each EPUB content document with an associated [=media overlay document=] includes a CSS
-						stylesheet (either embedded or linked) containing the class definitions. In the absence of such
-						definitions [=reading systems=] might provide their own styling, or no styling at all.</p>
+					<p>Any CSS properties MAY be defined for the specified CSS classes. Each EPUB content document with
+						an associated [=media overlay document=] has to include a CSS stylesheet (either embedded or
+						linked) containing the class definitions. In the absence of such definitions [=reading systems=]
+						might provide their own styling, or no styling at all.</p>
 
-					<p>EPUB creators MUST NOT use the <code>active-class</code> and <code>playback-active-class</code>
-						properties in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>
-						as they always apply to the entire [=EPUB publication=].</p>
+					<p>The <code>active-class</code> and <code>playback-active-class</code> properties MUST NOT be used
+						in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a> as they
+						always apply to the entire [=EPUB publication=].</p>
 
 					<aside class="example" title="Associating style information with the
 						currently playing EPUB content document">
@@ -9021,8 +9017,8 @@ html.my-document-playing * {
 								data-cite="xml#id">ID</a> [[xml]] of the manifest <code>item</code> for the
 							corresponding media overlay document.</p>
 
-						<p>[=EPUB creators=] MUST only specify the <code>media-overlay</code> attribute on manifest
-								<code>item</code> elements that reference EPUB content documents.</p>
+						<p>The <code>media-overlay</code> attribute MUST only be specified on manifest <code>item</code>
+							elements that reference EPUB content documents.</p>
 
 						<p>Manifest items for media overlay documents MUST have the media type
 								<code>application/smil+xml</code>.</p>
@@ -9052,14 +9048,13 @@ html.my-document-playing * {
 						data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L342,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L349,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L356,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L362">
 						<h5>Overlays package metadata</h5>
 
-						<p id="total-duration">[=EPUB creators=] MUST specify the duration of the entire [=EPUB
-							publication=] in the [=package document=] using a [^meta^] element with the <a
-								href="#duration"><code>duration</code> property</a>.</p>
+						<p id="total-duration">The duration of the entire [=EPUB publication=] MUST be specified in the
+							[=package document=] using a [^meta^] element with the <a href="#duration"
+									><code>duration</code> property</a>.</p>
 
-						<p>In addition, EPUB creators MUST provide the duration of each [=media overlay document=]. EPUB
-							creators MUST use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
-							associate each duration declaration to the corresponding [=EPUB manifest | manifest=]
-							[^item^].</p>
+						<p>In addition, the duration of each [=media overlay document=] MUST be provided using the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> to associate each duration
+							declaration to its corresponding [=EPUB manifest | manifest=] [^item^].</p>
 
 						<p>The sum of the durations for each media overlay document SHOULD equal the <a
 								href="#total-duration">total duration</a> plus or minus one second.</p>
@@ -9070,8 +9065,8 @@ html.my-document-playing * {
 								indicates a mismatch arising from other issues.</p>
 						</div>
 
-						<p>[=EPUB creators=] MAY also specify <a href="#narrator"><code>narrator</code></a> information
-							in the package document, as well as <a href="#sec-docs-assoc-style">author-defined CSS class
+						<p><a href="#narrator"><code>narrator</code></a> information MAY also be specified in the
+							package document, as well as the <a href="#sec-docs-assoc-style">author-defined CSS class
 								names</a> to apply to the currently playing [=EPUB content document=] element.</p>
 
 						<div class="note">
@@ -9140,7 +9135,7 @@ html.my-document-playing * {
 						elements' <a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to
 						determine when to offer users the option of skippable features.</p>
 
-					<p>[=EPUB creators=] MAY use the following semantics to enable skippability:</p>
+					<p>The following semantics MAY be used to enable skippability:</p>
 
 					<ul>
 						<li>
@@ -9235,7 +9230,7 @@ html.my-document-playing * {
 						of items, but provides an exit from them (e.g., a user can listen to some of the content before
 						choosing to escape).</p>
 
-					<p>[=EPUB creators=] MAY use the following semantics to enable escapability:</p>
+					<p>The following semantics MAY be used to enable escapability:</p>
 
 					<ul>
 						<li>
@@ -9260,8 +9255,8 @@ html.my-document-playing * {
 						<p>Sometimes escapable structures may contain escapable structures. For example, tables are
 							composed of many rows and cells that users may want to separately escape from. Reading
 							system support for escaping from such structures is complex and not well supported at this
-							time. EPUB creators should avoid identifying nested escapable structures until better
-							support is available.</p>
+							time. It is advised to avoid identifying nested escapable structures until better support is
+							available.</p>
 					</div>
 
 					<aside class="example" title="Escapable structures">
@@ -9388,10 +9383,10 @@ html.my-document-playing * {
 			<section id="sec-mo-nav-doc" class="informative">
 				<h3>Navigation document overlays</h3>
 
-				<p>As the [=EPUB navigation document=] is an [=XHTML content document=], [=EPUB creators=] may associate
-					a [=media overlay document=] with it. Unlike traditional XHTML content documents, however, [=reading
-					systems=] must present the EPUB navigation document to users even when it is not included in the
-					[=EPUB spine | spine=] (see <a data-cite="epub-rs-34#sec-nav">Navigation document processing</a>
+				<p>As the [=EPUB navigation document=] is an [=XHTML content document=], a [=media overlay document=]
+					can be associated with it. Unlike traditional XHTML content documents, however, [=reading systems=]
+					have to present the EPUB navigation document to users even when it is not included in the [=EPUB
+					spine | spine=] (see <a data-cite="epub-rs-34#sec-nav">Navigation document processing</a>
 					[[epub-rs-34]]). As a result, the method in which an associated media overlay behaves can change
 					depending on the context:</p>
 
@@ -9409,8 +9404,8 @@ html.my-document-playing * {
 				<div class="note">
 					<p>Specific implementation details are beyond the scope of this specification. The <a
 							href="https://daisy.org/info-help/document-archive/archived-publications/media-overlays-playback-requirements/"
-							>DAISY Media Overlays Playback Requirements</a> document describes best practices for [=EPUB
-						creators=] and provides recommendations for reading system developers.</p>
+							>DAISY Media Overlays Playback Requirements</a> document describes best practices for
+						authoring and provides recommendations for reading system developers.</p>
 				</div>
 			</section>
 		</section>
@@ -9460,9 +9455,9 @@ html.my-document-playing * {
 				that it helps to ensure that EPUB publications meet the accessibility requirements legislated in
 				jurisdictions around the world.</p>
 
-			<p>[=EPUB creators=], however, should look beyond legal imperatives and treat accessibility as a requirement
-				for all their content. The more accessible that EPUB publications are, the greater the potential
-				audience for them.</p>
+			<p>It is strongly advised to look beyond legal imperatives and treat accessibility as a requirement for all
+				EPUB publications. The more accessible that EPUB publications are, the greater the potential audience
+				for them.</p>
 
 			<div class="note">
 				<p>This specification does not integrate the accessibility requirements to allow them to adapt and
@@ -9487,10 +9482,10 @@ html.my-document-playing * {
 				<p>This means that EPUB 3's security and privacy issues are primarily linked to the features of those
 					formats, and closely mirror the threats presented by web content.</p>
 
-				<p>Although content risks are often equated with deliberately malicious authoring intent, [=EPUB
-					creators=] need to be aware that many practices followed with the best of intentions may expose
-					users to privacy and security issues. The rest of this section explores the risk model of EPUB 3
-					with the aim of helping EPUB creators recognize and mitigate these risks.</p>
+				<p>Although content risks are often equated with deliberately malicious authoring intent, be aware that
+					many practices followed with the best of intentions can expose users to privacy and security issues.
+					The rest of this section explores the risk model of EPUB 3 to help recognize and mitigate these
+					risks.</p>
 
 				<div class="note">
 					<p>For the risks associated with [=reading systems=], refer to the <a
@@ -9505,8 +9500,7 @@ html.my-document-playing * {
 				<p>[=EPUB publications=] pose a variety of privacy and security threats to unsuspecting users. Many of
 					these threats intersect with web content, but EPUB also introduces its own unique methods of attack
 					that can be used to trick users into accessing malicious content or into providing sensitive
-					information. Some of the more important attack vectors that [=EPUB creators=] and users need to be
-					aware of include:</p>
+					information. Some of the more important attack vectors to be aware of include:</p>
 
 				<dl>
 					<dt>Embedding of remote resources</dt>
@@ -9516,16 +9510,17 @@ html.my-document-playing * {
 							opening of the EPUB publication (e.g., audio, video, and fonts). Although helpful for users
 							when used as intended, these exemptions can also be used to inject malicious content into a
 							publication.</p>
-						<p>This threat is not limited to accessing content created by a bad actor. If EPUB creators
-							embed content from untrustworthy sources (e.g., third party audio and video), there is
-							always the possibility that users may receive compromised resources.</p>
+						<p>This threat is not limited to accessing content created by a bad actor. If content from
+							untrustworthy sources (e.g., third party audio and video) is embedded in an EPUB
+							publication, there is always the possibility that users may receive compromised
+							resources.</p>
 						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
 							malicious content can be swapped in any time after publication, unlike resources that come
 							embedded in the [=EPUB container=].</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB creator
-							and specific to each reading system implementation. Consequently, if the EPUB creator hosts
-							[=remote resources=] on a web server they control, the server effectively cannot use
-							security features that require specifying allowable origins, such as headers for <a
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is specific to each reading system
+							implementation and not knowable outside of the reading system. Consequently, even if
+							[=remote resources=] are hosted on a secure web server, it is not possible to use security
+							features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
 									><code>Content-Security-Policy</code></a>, or <a
@@ -9538,12 +9533,11 @@ html.my-document-playing * {
 							potential exploits that can compromise their reading system or operating system. Although
 							external links will typically open in a web browser, and be subject to the browser security
 							model, this does not protect users from all exploits.</p>
-						<p>Even if the intentions of the EPUB creator are not malicious, adding tracking information to
-							external links is problematic for user privacy as it can allow a user's activity to be
-							tracked without their consent.</p>
+						<p>Even if the intent is not malicious, adding tracking information to external links is
+							problematic for user privacy as it can allow a user's activity to be tracked without their
+							consent.</p>
 						<p>Broken-link hijacking — when a domain expires and is bought by another party to exploit the
-							links to it — can also lead to users being taken to resources the EPUB creator did not
-							intend.</p>
+							links to it — can also lead to users being taken to unintended resources.</p>
 					</dd>
 
 					<dt>Including malicious content</dt>
@@ -9553,8 +9547,8 @@ html.my-document-playing * {
 							forms that may submit sensitive information to unintended parties. Such actors may also try
 							to gain access to [=remote resources=] using file indirection techniques, such as symbolic
 							links or file aliases. </p>
-						<p>The use of third-party content, such as games and quizzes, may also lead to security and
-							privacy issues if the EPUB creator is not able to fully vet the content.</p>
+						<p>The use of third-party content, such as games and quizzes, can also lead to security and
+							privacy issues if the content cannot be fully vetted.</p>
 					</dd>
 
 					<dt>Allowing scripts network access</dt>
@@ -9569,8 +9563,7 @@ html.my-document-playing * {
 								site to get the user to submit login information); and</li>
 							<li>injecting malicious content from external sites into the EPUB publication.</li>
 						</ul>
-						<p>Network access may allow third-party content to exploit the user even if it was not the EPUB
-							creator's intent.</p>
+						<p>Network access can also allow third-party content to exploit the user.</p>
 					</dd>
 
 					<dt>Securing content with digital rights management</dt>
@@ -9588,9 +9581,9 @@ html.my-document-playing * {
 				<dl>
 					<dt>Falsified publication information</dt>
 					<dd>
-						<p>The EPUB publication may include false information about itself to trick users into believing
-							that it comes from a legitimate source. A malicious EPUB creator might, for example, fake
-							the title, authors, identifiers, and publisher for the work.</p>
+						<p>An EPUB publication can include false information about itself to trick users into believing
+							that it comes from a legitimate source. A malicious actor might, for example, fake the
+							title, authors, identifiers, and publisher for the work.</p>
 						<p>Although this misinformation itself does not present an immediate harm, it could lead users
 							to trust malicious forms, links, and other content within the EPUB publication believing it
 							comes from a reliable source.</p>
@@ -9598,7 +9591,7 @@ html.my-document-playing * {
 
 					<dt>Spoofed platforms</dt>
 					<dd>
-						<p>Malicious EPUB creators may also design their content to imitate or replicate a platform's
+						<p>Malicious actors can also design their content to imitate or replicate a platform's
 							experience to trick users into trusting their content.</p>
 					</dd>
 				</dl>
@@ -9625,27 +9618,26 @@ html.my-document-playing * {
 					</ul>
 
 					<p>The one potential exception is the <a data-cite="epub-rs-34#app-epubReadingSystem"
-								><code>epubReadingSystem</code> object</a> [[epub-rs-34]] that allows [=EPUB creators=]
-						to query information about the current [=reading system=]. EPUB creators need to be mindful that
-						they only use the information exposed by this object to improve the rendering of their content
-						(i.e., avoid using the information to profile the user and their environment).</p>
+								><code>epubReadingSystem</code> object</a> [[epub-rs-34]] that allows information about
+						the current [=reading system=] to be queried. It is advised to only use the information exposed
+						by this object to improve the rendering of an EPUB publication (i.e., avoid using the
+						information to profile the user and their environment).</p>
 				</section>
 			</section>
 
 			<section id="security-privacy-recommendations">
 				<h3>Recommendations</h3>
 
-				<p>Although [=EPUB creators=] cannot prevent every method of exploiting users, they are ultimately
-					responsible for the secure construction of their content. That means that they need to take
-					precautions to limit the exposure of their [=EPUB publications=] to the types of <a
-						href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
+				<p>Although it is not possible to prevent every method of exploiting users, responsibility for the
+					secure construction of the content lies with its creator. That requires taking precautions to limit
+					the exposure of [=EPUB publications=] to the types of <a href="#epub-threat-model">malicious
+						exploits</a> described in the previous section.</p>
 
 				<p>Some practical steps include:</p>
 
 				<ul>
 					<li>Ensuring the use of stable links to [=remote resources=].</li>
-					<li>Avoiding third-party resources, especially those hosted on servers outside the control of the
-						EPUB creator.</li>
+					<li>Avoiding third-party resources, especially those hosted on third-party servers.</li>
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
@@ -9657,42 +9649,41 @@ html.my-document-playing * {
 						implementations.</li>
 				</ul>
 
-				<p>EPUB creators also need to consider the privacy rights of users and avoid situations where they are
-					intentionally collecting data. Ideally, EPUB creators SHOULD NOT track their users, but this is not
-					realistic for all types of publishing.</p>
+				<p>Also consider the privacy rights of users and avoid intentionally collecting data. Ideally, users
+					SHOULD NOT be tracked, but this is not realistic for all types of publishing.</p>
 
-				<p>When EPUB creators have to track users, they SHOULD obtain the approval of the user to collect
-					information prior to opening the EPUB publication (e.g., in educational course work). If this is not
-					possible, they SHOULD obtain permission when users access the EPUB publication for the first time.
-					EPUB creators SHOULD also allow users to opt out of tracking, and provide users the ability to
-					manage and delete any data that is collected about them.</p>
+				<p>When users have to be tracked (e.g., in educational course work), the approval of the user to collect
+					information SHOULD be obtained prior to opening the EPUB publication. If this is not possible,
+					permission SHOULD be obtained when users access the EPUB publication for the first time. Users
+					SHOULD be allowed to opt out of tracking and provided the ability to manage and delete any data that
+					is collected about them.</p>
 
-				<p>EPUB creators also need to consider the inadvertent collection of information about users. Linking to
-					content on a publisher's web site, or remotely hosting resources on their servers, can lead to
-					profiling users, especially if unique tracking identifiers are added to the URLs.</p>
+				<p>The inadvertent collection of information about users also needs to be considered. Linking to content
+					on a publisher's web site, or remotely hosting resources on their servers, can lead to profiling
+					users, especially if unique tracking identifiers are added to the URLs.</p>
 
 				<p>When collecting and storing user information within an EPUB publication (e.g., through the use of <a
 						data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
-						storage</a> [[?html]]), EPUB creators need to consider to potential for data theft by other EPUB
-					publications on a [=reading system=]. Although [[epub-rs-34]] introduces a <a
+						storage</a> [[?html]]), the potential for data theft by other EPUB publications on a [=reading
+					system=] needs to be considered. Although [[epub-rs-34]] introduces a <a
 						data-cite="epub-rs-34#sec-container-iri">unique origin requirement</a> for EPUB publications,
 					which limits the potential for attacks, there is still a risk that reading systems will allow EPUB
 					publications access to shared persistent storage (e.g., older reading systems that have not been
-					updated and non-conforming newer reading systems). Consequently, EPUB creators SHOULD NOT store
-					sensitive user data in persistent storage. If EPUB creators must store sensitive data, they SHOULD
-					encrypt the data to prevent trivial access to it in the case of an exploit.</p>
+					updated and non-conforming newer reading systems). Consequently, sensitive user data SHOULD NOT be
+					stored in persistent storage. If sensitive data has to be stored, it SHOULD be encrypted to prevent
+					trivial access to it in the case of an exploit.</p>
 
-				<p>When publishers and vendors must use digital rights management schemes, they should prefer schemes
-					that do not utilize or transmit information about the user or their content to external parties to
-					perform encryption or decryption.</p>
+				<p>When digital rights management schemes have to be used, prefer schemes that do not utilize or
+					transmit information about the user or their content to external parties to perform encryption or
+					decryption.</p>
 
-				<p>To maximally reduce security and privacy risks, EPUB creators SHOULD produce their EPUB publications
-					with the goal of long-term preservation. EPUB publications created this way are normally
-					self-contained, not dependent on network access, and not encrypted with digital rights management,
-					removing many of the possible attack vectors. [[?iso22424]] is an example of such a preservation
-					format for EPUB publications. While it is understood that not all EPUB creators can achieve these
-					levels of self-containment, following as many of these practices as possible will still benefit
-					overall user privacy and security.</p>
+				<p>To maximally reduce security and privacy risks, EPUB publications SHOULD be produced with the goal of
+					long-term preservation. EPUB publications created this way are normally self-contained, not
+					dependent on network access, and not encrypted with digital rights management, removing many of the
+					possible attack vectors. [[?iso22424]] is an example of such a preservation format for EPUB
+					publications. While it is understood that not all EPUB publications can meet these levels of
+					self-containment, following as many of these practices as possible will still benefit overall user
+					privacy and security.</p>
 			</section>
 		</section>
 		<section id="app-unsupported" class="appendix">
@@ -9715,12 +9706,12 @@ html.my-document-playing * {
 					Although it lacks the necessary reading system support, it is integral to the content model on which
 					EPUB is built (i.e., for internationalization support in the package document).</p>
 
-				<p>EPUB creators MAY use this feature as described.</p>
+				<p>This feature MAY be used as described.</p>
 
 				<div class="note">
-					<p>[=EPUB conformance checkers=] should alert EPUB creators to the presence of under-implemented
-						features when encountered in EPUB publications but must not treat their inclusion as a violation
-						of the standard (i.e., not emit errors or warnings).</p>
+					<p>[=EPUB conformance checkers=] should alert about the presence of under-implemented features when
+						encountered in EPUB publications but must not treat their inclusion as a violation of the
+						standard (i.e., not emit errors or warnings).</p>
 				</div>
 
 				<div class="note">
@@ -9733,9 +9724,8 @@ html.my-document-playing * {
 			<section id="deprecated">
 				<h3>Deprecated features</h3>
 
-				<p>[=EPUB creators=] SHOULD NOT use the following <strong>deprecated</strong> features in their [=EPUB
-					publications=]. These features have limited or no support in [=reading systems=] and/or usage in
-					[=EPUB publications=].</p>
+				<p>The following <strong>deprecated</strong> features SHOULD NOT be used. These features have limited or
+					no support in [=reading systems=] and/or usage in [=EPUB publications=].</p>
 
 				<p>When used, their usage MUST conform to their referenced definitions.</p>
 
@@ -9880,8 +9870,8 @@ html.my-document-playing * {
 				</dl>
 
 				<div class="note">
-					<p>[=EPUB conformance checkers=] should alert EPUB creators to the presence of deprecated features
-						when encountered in EPUB publications.</p>
+					<p>[=EPUB conformance checkers=] should alert about the presence of deprecated features when
+						encountered in EPUB publications.</p>
 				</div>
 			</section>
 		</section>
@@ -9893,8 +9883,8 @@ html.my-document-playing * {
 					<a data-cite="xml#dt-sysid">system identifiers</a> [[xml]] allowed in <a data-cite="xml#dt-doctype"
 					>document type declarations</a>. [[xml]]</p>
 
-			<p>[=EPUB creators=] MAY use these external identifiers only in [=publication resources=] with the listed
-				media types [[rfc2046]] specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a
+			<p>These external identifiers MAY be used only in [=publication resources=] with the listed media types
+				[[rfc2046]] specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a
 					href="#sec-xml-constraints"></a> for more information.)</p>
 
 			<table class="zebra">
@@ -9974,8 +9964,8 @@ html.my-document-playing * {
 					overlays).</p>
 
 				<p>This specification defines a method for adding structural semantics using <em>the attribute
-					axis</em>: instead of adding new elements, [=EPUB creators=] can append the <code>epub:type</code>
-					attribute to existing elements to add the desired semantics.</p>
+					axis</em>: instead of adding new elements, the <code>epub:type</code> attribute can be appended to
+					existing elements to add the desired semantics.</p>
 			</section>
 
 			<section id="sec-epub-type-attribute">
@@ -10090,9 +10080,9 @@ html.my-document-playing * {
 					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The prefix URL for
 					referencing its properties is <code>http://idpf.org/epub/vocab/structure/#</code>.</p>
 
-				<p>EPUB creators MAY include unprefixed terms that are not part of this vocabulary, but the preferred
-					method for adding custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer
-					to <a href="#sec-vocab-assoc"></a> for more information.</p>
+				<p>Unprefixed terms that are not part of this vocabulary MAY be used, but the preferred method for
+					adding custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
+						href="#sec-vocab-assoc"></a> for more information.</p>
 
 				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
 					<pre>&lt;html
@@ -10178,8 +10168,8 @@ html.my-document-playing * {
 						use to map to a URL is predefined.</p>
 
 					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
-						terms and properties, [=EPUB creators=] only need to declare a <a href="#sec-prefix-attr"
-							>prefix</a>. In another authoring convenience, this specification also <a
+						terms and properties, it is only necessary to declare a <a href="#sec-prefix-attr">prefix</a>.
+						In another authoring convenience, this specification also <a
 							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
 						publishing vocabularies (i.e., their declaration is optional).</p>
 
@@ -10265,9 +10255,8 @@ html.my-document-playing * {
 								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
 					</aside>
 
-					<p>When an [=EPUB creator=] omits a prefix from a <var>property</var> value, the expressed reference
-						represents a term from the <a href="#sec-default-vocab">default vocabulary</a> for that
-						attribute.</p>
+					<p>When a prefix is omitted from a <var>property</var> value, the specified term is taken from the
+							<a href="#sec-default-vocab">default vocabulary</a> for that attribute.</p>
 
 					<aside class="example" title="Expanding a manifest property value">
 						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
@@ -10286,13 +10275,12 @@ html.my-document-playing * {
 				<section id="sec-default-vocab">
 					<h5>Default vocabularies</h5>
 
-					<p>A default vocabulary is one that [=EPUB creators=] do not have to declare a <a
-							href="#sec-prefix-attr">prefix</a> for in order to use its terms and properties where a <a
-							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB creators MUST
-						NOT add a prefix to terms and properties from a default vocabulary.</p>
+					<p>A default vocabulary is one whose terms and properties MUST NOT have a <a href="#sec-prefix-attr"
+							>prefix</a> when a <a href="#sec-property-datatype"><var>property</var> value</a> is
+						expected.</p>
 
-					<p>EPUB creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
-							<a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+					<p>A prefix MUST NOT be assigned to the URLs associated with these vocabularies using the <a
+							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
 					<div class="note">
 						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
@@ -10373,16 +10361,15 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, [=EPUB creators=]
-						MUST declare all prefixes used in a document. [=EPUB creators=] MUST only specify the
-							<code>prefix</code> attribute on the <a data-cite="xml#dt-root">root element</a> [[xml]] of
-						the respective format.</p>
+					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, all prefixes used
+						in a document MUST be declared. The <code>prefix</code> attribute MUST be specified only on the
+							<a data-cite="xml#dt-root">root element</a> [[xml]] of the respective format.</p>
 
 					<p>The attribute is not namespaced when used in the [=package document=].</p>
 
 					<aside class="example" title="Declaring prefixes in the package document">
-						<p>In this example, the EPUB creator declares prefixes for the Friend of a Friend
-								(<code>foaf</code>) and DBPedia (<code>dbp</code>) vocabularies.</p>
+						<p>In this example, the prefixes for the Friend of a Friend (<code>foaf</code>) and DBPedia
+								(<code>dbp</code>) vocabularies are declared in the <code>prefix</code> attribute.</p>
 
 						<pre>&lt;package
     …
@@ -10392,13 +10379,11 @@ html.my-document-playing * {
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>EPUB creators MUST declare the attribute in the namespace
-							<code>http://www.idpf.org/2007/ops</code> in [=EPUB content documents=] and [=media overlay
-						documents=].</p>
+					<p>The attribute MUST be declared in the namespace <code>http://www.idpf.org/2007/ops</code> when
+						used in [=EPUB content documents=] and [=media overlay documents=].</p>
 
 					<aside class="example" title="Declaring prefixes in an XHTML content document">
-						<p>In this example, the EPUB creator declares a prefix for the Z39.98 Structural Semantics
-							Vocabulary.</p>
+						<p>In this example, the a prefix is declared for the Z39.98 Structural Semantics Vocabulary.</p>
 
 						<pre>&lt;html …
       xmlns:epub="http://www.idpf.org/2007/ops"
@@ -10409,7 +10394,7 @@ html.my-document-playing * {
 
 					<div class="note">
 						<p>Although the <code>prefix</code> attribute is modeled on the identically named
-								<code>prefix</code> attribute in [[rdfa-core]], EPUB creators cannot use the attributes
+								<code>prefix</code> attribute in [[rdfa-core]], the attributes cannot be used
 							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB content
 							documents is the RDFa attribute.</p>
 
@@ -10425,44 +10410,43 @@ html.my-document-playing * {
 					<p>Note that for <a href="#sec-xhtml-svg-inclusion">SVG embedded by inclusion</a>, prefixes MUST be
 						declared on the [[html]] root [^html^] element.</p>
 
-					<p>To avoid conflicts, EPUB creators MUST NOT use the <code>prefix</code> attribute to declare a
-						prefix that maps to a <a href="#sec-default-vocab">default vocabulary</a>.</p>
+					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
+						maps to a <a href="#sec-default-vocab">default vocabulary</a>.</p>
 
-					<p>EPUB creators MUST NOT declare the prefix '_' as this specification reserves this prefix for
-						future compatibility with RDFa [[rdfa-core]] processing.</p>
+					<p>The prefix '_' MUST NOT be declared as this specification reserves this prefix for future
+						compatibility with RDFa [[rdfa-core]] processing.</p>
 
-					<p>For future compatibility with alternative serializations of the package document, EPUB creators
-						MUST NOT declare a prefix for the Dublin Core <em>/elements/1.1/</em> namespace [[dcterms]].
-						[=EPUB creators=] MUST use only the [[dcterms]] elements <a href="#sec-pkg-metadata">allowed in
-							the package document metadata</a>.</p>
+					<p>For future compatibility with alternative serializations of the package document, a prefix MUST
+						NOT be declared for the Dublin Core <em>/elements/1.1/</em> namespace [[dcterms]]. Only the
+						[[dcterms]] elements are <a href="#sec-pkg-metadata">allowed in the package document
+							metadata</a>.</p>
 				</section>
 
 				<section id="sec-reserved-prefixes">
 					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, [=EPUB creators=] should avoid
-							relying on them as they may cause interoperability issues. [=EPUB conformance checkers=]
-							will often reject new prefixes until their developers update the tools to the latest version
-							of the specification, for example. EPUB creators should declare all prefixes they use to
-							avoid such issues.</p>
+						<p>Although reserved prefixes are an authoring convenience, they can cause interoperability
+							issues. [=EPUB conformance checkers=] will often reject new prefixes until their developers
+							update the tools to the latest version of the specification, for example. It is advised to
+							declare all prefixes to avoid any issues.</p>
 					</div>
 
-					<p>[=EPUB creators=] MAY use reserved prefixes in attributes that expect a <a
-							href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a
-							href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
-
-
-					<p>EPUB creators SHOULD NOT override reserved prefixes in the <a href="#sec-prefix-attr"
+					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"
+								><var>property</var> value</a> without declaring them in a <a href="#sec-prefix-attr"
 								><code>prefix</code> attribute</a>.</p>
 
-					<p>The reserved prefixes an EPUB creators can use depends on the context:</p>
+
+					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
+							attribute</a>.</p>
+
+					<p>The reserved prefixes that can be used depends on the context:</p>
 
 					<dl class="conformance-list">
 						<dt>Package document</dt>
 						<dd id="sec-metadata-reserved-prefixes">
-							<p>EPUB creators MAY use the following prefixes in [=package document=] attributes without
-								having to declare them.</p>
+							<p>The following prefixes MAY be used in [=package document=] attributes without having to
+								declare them.</p>
 							<table id="tbl-pkg-reserved-prefixes" class="prefix">
 								<thead>
 									<tr>
@@ -10540,23 +10524,22 @@ html.my-document-playing * {
 
 					<dt>Applies To</dt>
 					<dd>
-						<p>Specifies which publication resource type(s) [=EPUB creators=] MAY specify the property
-							on.</p>
+						<p>Specifies which publication resource type(s) that the property MAY be specified on.</p>
 						<p>This field appears for properties used in the <a href="#attrdef-properties"
 									><code>properties</code> attribute</a>.</p>
 					</dd>
 
 					<dt>Cardinality</dt>
 					<dd>
-						<p>Specifies the number of times EPUB creators MAY specify the property, whether globally or
-							attached to another element or property.</p>
+						<p>Specifies the number of times the property MAY be specified, whether globally or attached to
+							another element or property.</p>
 						<p>Properties with a minimum cardinality of one MUST be specified.</p>
 					</dd>
 
 					<dt>Description</dt>
 					<dd>
 						<p>Describes the purpose of the property and specifies any additional usage requirements that
-							EPUB creators must follow.</p>
+							have to be followed.</p>
 					</dd>
 
 					<dt>Example</dt>
@@ -10566,7 +10549,7 @@ html.my-document-playing * {
 
 					<dt>Extends</dt>
 					<dd>
-						<p>Identifies what EPUB creators MAY associate the property with.</p>
+						<p>Identifies what metadata the property MAY be associated with.</p>
 						<p>This field appears for properties that define <a href="#meta-expr-types">primary expressions
 								and subexpressions</a> and <a href="#attrdef-link-rel">relationships</a>.</p>
 					</dd>
@@ -10597,8 +10580,8 @@ html.my-document-playing * {
 
 			<p class="note">The prefix definitions are no longer being synchronized with their CSS counterparts. In some
 				cases, the unprefixed versions of these properties now support additional values. [=Reading systems=]
-				may not support the new syntax with the prefixed properties, so [=EPUB creators=] are advised to use the
-				unprefixed versions for newer features.</p>
+				may not support the new syntax with the prefixed properties, so it is advised to use the unprefixed
+				versions for newer features.</p>
 
 			<section id="sec-css-prefixed-writing-modes">
 				<h5>CSS writing modes</h5>
@@ -10941,8 +10924,8 @@ html.my-document-playing * {
 						href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6"
 						>Safari HTML definition</a> of the <code>viewport meta</code> tag, that was used in earlier
 					versions of EPUB&#160;3, is not an officially recognized standard, this specification defines a
-					basic syntax in order to allow [=EPUB creators=] to express <a href="#sec-fxl-icb-html">width and
-						height dimensions</a> for use rendering [=fixed-layout documents=].</p>
+					basic syntax to allow <a href="#sec-fxl-icb-html">width and height dimensions</a> to be expressed
+					for [=fixed-layout documents=].</p>
 
 				<p>The syntax of this grammar is also influenced by the parsing algorithm for the <code>viewport
 						meta</code> tag, as defined in [[css-viewport-1]].</p>
@@ -11047,9 +11030,8 @@ html.my-document-playing * {
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). EPUB creators MAY include any <a data-cite="xml#NT-S"
-						>whitespace characters</a> [[xml]] in the authored tag so long as the result is valid to this
-					definition.</p>
+					within the attribute to single spaces). Any <a data-cite="xml#NT-S">whitespace characters</a>
+					[[xml]] MAY be included in the authored tag so long as the result is valid to this definition.</p>
 
 				<div class="note">
 					<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
@@ -11065,10 +11047,11 @@ html.my-document-playing * {
 					<p>For more information about specifying the required <code>height</code> and <code>width</code>
 						properties, and their required values, refer to <a href="#sec-fxl-content-dimensions"></a>.</p>
 
-					<p>Although the <code>viewport meta</code> tag allows EPUB creators to use properties other than
-							<code>height</code> and <code>width</code>, and to not include values for these properties,
-						such use is strongly discouraged. Setting other properties may have unintended consequences on
-						the rendering of fixed-layout documents.</p>
+					<p>Although the <code>viewport meta</code> tag allows the use of properties other than
+							<code>height</code> and <code>width</code>, as well as to omit values for the
+							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting
+						other properties may have unintended consequences on the rendering of fixed-layout
+						documents.</p>
 				</div>
 			</section>
 		</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -8814,7 +8814,7 @@ No Entry</pre>
 					<section id="sec-media-overlays-granularity" class="informative">
 						<h5>Overlay granularity</h5>
 
-						<p>The granularity level of the media overlay depends on how the [=EPUB content document=] are
+						<p>The granularity level of the media overlay depends on how the [=EPUB content document=] is
 							marked up and the type of fragment identifier used in the [^text^] elements'
 								<code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
 							attributes. For example, when referencing [[html]] elements, if the finest level of markup

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -927,8 +927,8 @@
 						<p>A common point of confusion arising from core media type resources is the listing of XHTML
 							and SVG as core media type resources with the requirement that the markup conform to their
 							respective EPUB content document definitions. This common definition ensures that regardless
-							of whether XHTML and SVG documents are listed in the spine or embedded in other EPUB content
-							documents they have the same requirements for authoring and reading system support.</p>
+							of whether XHTML and SVG documents are listed in the spine, or embedded in other EPUB content
+							documents, they have the same requirements for authoring and reading system support.</p>
 
 						<p>In practice, it means that XHTML and SVG core media type resources are allowed in the spine
 							without any modification or fallback as they are also conforming XHTML and SVG content

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6905,7 +6905,7 @@ No Entry</pre>
 
 				<p>In these cases, it is advised to use the [[html]] [^html-global/hidden^] attribute to indicate which
 					(if any) portions of the navigation data are excluded from rendering in the content flow. The <a
-						data-cite="epub-rs-34#confreq-nav-hidden">the attribute has no effect</a> [[epub-rs-34]] on how
+						data-cite="epub-rs-34#confreq-nav-hidden">attribute has no effect</a> [[epub-rs-34]] on how
 					reading systems render the navigation document outside of the spine.</p>
 
 				<div class="note">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -7410,7 +7410,7 @@ No Entry</pre>
 
 						<aside class="example" id="spread-both-with-intro-example"
 							title="Overriding the global spread behavior">
-							<p>In this example, the global reflowable setting in the spine is overridden for the
+							<p>In this example, the global reflowable setting is overridden in the spine for the
 								introductory page. The intention is for reading systems to render it as a reflowable
 								document.</p>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -2774,7 +2774,7 @@
 								<p>The <code>signature</code> element contains child elements of type
 										<code>Signature</code>, as defined by [[xmldsig-core1]]. Signatures can be
 									applied to an EPUB publication as a whole or to its parts. They can also be used to
-									sign of any kind of data (i.e., not just XML).</p>
+									sign any kind of data (i.e., not just XML).</p>
 
 								<p class="note">An <a href="#app-schema-signatures">XML Schema</a> also informally
 									defines the content of the <code>signatures.xml</code> file.</p>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5382,7 +5382,7 @@ No Entry</pre>
 						document=] or [=foreign content document=].</p>
 
 					<p id="spine-inclusion-req">All EPUB and foreign content documents that are hyperlinked to from
-						publication resources in the <code>spine</code> MUST be list in the <code>spine</code>, where
+						publication resources in the <code>spine</code> MUST be listed in the <code>spine</code>, where
 						hyperlinking encompasses any linking mechanism that requires the user to navigate away from the
 						current resource. Common hyperlinking mechanisms include the [^a/href^] attribute of the
 						[[html]] [^a^] and [^area^] elements and scripted links (e.g., using DOM Events and/or form

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
@@ -191,7 +191,7 @@
 
 				<p>Refer to [[epub-rs-34]] for the processing requirements for reading systems. Although it is not
 					necessary to read that document to create EPUB publications, an understanding of how reading systems
-					present the content can help craft publications for optimal presentation to users.</p>
+					present the content can help in crafting publications for optimal presentation to users.</p>
 			</section>
 
 			<section id="sec-intro-relations" class="informative">
@@ -325,7 +325,7 @@
 					</dt>
 					<dd>
 						<p>The [=URL=]&#160;[[url]] of the [=root directory=] representing the [=OCF abstract
-							container=]. Although the container root URL is implementation specific, it has properties
+							container=]. Although the container root URL is implementation specific, its properties are
 							defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
 
@@ -429,9 +429,9 @@
 						<dfn class="export">exempt resource</dfn>
 					</dt>
 					<dd>
-						<p>Exempt resources are a special class of [=publication resources=] that reading systems are
-							not required to support the rendering of but do not require <a href="#sec-foreign-resources"
-								>fallbacks</a>.</p>
+						<p>Exempt resources are a special class of [=publication resources=] that do not require <a
+								href="#sec-foreign-resources">fallbacks</a> but that reading systems are not required to
+							support the rendering of.</p>
 						<p>Refer to <a href="#sec-exempt-resources"></a> for more information.</p>
 					</dd>
 
@@ -576,9 +576,9 @@
 							[=package document=], [=EPUB content documents=], CSS Style Sheets, audio, video, images,
 							embedded fonts, and scripts.</p>
 						<p>The package document [=EPUB manifest | manifest=] has to include a list of all publication
-							resources and they typically have to be bundled in the [=EPUB container=] (the exception
-							being they can locate resources listed in <a href="#sec-resource-locations"></a> outside the
-							EPUB container).</p>
+							resources and the resources typically have to be bundled in the [=EPUB container=] (the
+							exception being that resources listed in <a href="#sec-resource-locations"></a> can be
+							located outside the EPUB container).</p>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
 									<code>href</code> attribute of an [[html]] [^a^] element) are not publication
@@ -671,9 +671,9 @@
 				<p>In [=package document=] metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
 						prefixes</a> are used without declaration.</p>
 
-				<p>References to Dublin Core elements [[dcterms]] use the <code>dc:</code> prefix. This prefix have to
-					be declared in the [=package document=] for their use to be valid
-						(<code>xmlns:dc="http://purl.org/dc/elements/1.1/"</code>)</p>
+				<p>References to Dublin Core elements [[dcterms]] use the <code>dc:</code> prefix. This prefix has to be
+					declared in the [=package document=] for their use to be valid
+						(<code>xmlns:dc="http://purl.org/dc/elements/1.1/"</code>).</p>
 
 				<p>The <code>epub</code> namespace prefix [[xml-names]] is also used on elements and attributes without
 					always having an explicit declaration (<code>xmlns:epub="http://www.idpf.org/2007/ops"</code>).</p>
@@ -719,19 +719,19 @@
 				<h3>Conformance checking</h3>
 
 				<p>Due to the complexity of this specification and number of technologies used in [=EPUB publications=],
-					the use an [=EPUB conformance checker=] is advised to verify the conformance of their content.</p>
+					it is advised to use an [=EPUB conformance checker=] to verify content conformance.</p>
 
 				<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB conformance
 					checker used by the publishing industry and has been updated with each new version of EPUB. It is
-					integrated into a number of authoring tools and also available in alternative interfaces and other
-					languages (for more information, refer to its <a
+					integrated into a number of authoring tools and is also available in alternative interfaces and
+					other languages (for more information, refer to its <a
 						href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
 					page</a>).</p>
 
-				<p>When verifying EPUB publications, ensure they do not violate the requirements of this specification
-					(practices identified by the keywords "MUST", "MUST NOT", and "REQUIRED"). These types of issues
-					will often result in EPUB publications not rendering or rendering in inconsistent ways. These issues
-					are typically reported as errors or critical errors.</p>
+				<p>When verifying EPUB publications, ensure that they do not violate the requirements of this
+					specification (practices identified by the keywords "MUST", "MUST NOT", and "REQUIRED"). These types
+					of issues will often result in EPUB publications not rendering or rendering in inconsistent ways.
+					These issues are typically reported as errors or critical errors.</p>
 
 				<p>Also ensure that EPUB publications do not violate the recommendations of this specification
 					(practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED"). Failure to follow
@@ -856,8 +856,8 @@
 						document in a [=manifest fallback chain=].</p>
 
 					<p>Although they are not directly listed in the spine, all of the resources in the fallback chain
-						are considered part of the spine, and by extension part of the spine plane, since any can be
-						used by a reading system.</p>
+						are considered part of the spine, and by extension part of the spine plane, since any of the
+						resources can be used by a reading system.</p>
 
 					<p>This extensibility model allows experimentation with formats while ensuring that reading systems
 						are always able to render something for the user to read, as there is no guarantee of support
@@ -928,7 +928,7 @@
 							and SVG as core media type resources with the requirement that the markup conform to their
 							respective EPUB content document definitions. This common definition ensures that regardless
 							of whether XHTML and SVG documents are listed in the spine or embedded in other EPUB content
-							documents they the same requirements for authoring and reading system support.</p>
+							documents they have the same requirements for authoring and reading system support.</p>
 
 						<p>In practice, it means that XHTML and SVG core media type resources are allowed in the spine
 							without any modification or fallback as they are also conforming XHTML and SVG content
@@ -942,15 +942,15 @@
 			<section id="sec-core-media-types">
 				<h3>Core media types</h3>
 
-				<p>[=EPUB publications=] MAY include [=publication resources=] that conform to the MIME media type
-					[[rfc2046]] specifications defined in the following table without fallbacks when they are used in
+				<p>[=Publication resources=] that conform to the MIME media type [[rfc2046]] specifications defined in
+					the following table MAY be included in [=EPUB publications=] without fallbacks when they are used in
 					[=EPUB content documents=] and [=foreign content documents=]. These resources are classified as
 					[=core media type resources=].</p>
 
-				<p>With the exception of [=XHTML content documents=] and [=SVG content documents=], EPUB publications
-					MUST include <a href="#sec-manifest-fallbacks">manifest fallbacks</a> for core media type resources
-					referenced directly from the [=EPUB spine | spine=]. In this case, they are [=foreign content
-					documents=].</p>
+				<p>Only [=XHTML content documents=] and [=SVG content documents=] can be referenced from the spine
+					without a <a href="#sec-manifest-fallbacks">manifest fallback</a>. All other core media type
+					resources MUST include a manifest fallback if referenced directly from the [=EPUB spine | spine=].
+					In this case, they are [=foreign content documents=].</p>
 
 				<p>The columns in the table represent the following information:</p>
 
@@ -958,11 +958,11 @@
 					<li>
 						<p><strong>Media Type</strong>—The MIME media type [[rfc2046]] used to represent the given
 							publication resource in the [=EPUB manifest | manifest=].</p>
-						<p>If the table lists more than one media type, the first one is the preferred media type. The
-							preferred media type SHOULD be used for all EPUB publications.</p>
+						<p>If a resource has more than one media type, the first one listed is the preferred media type.
+							It is advised to use this media type to declare resources.</p>
 					</li>
 					<li><strong>Content Type Definition</strong>—The specification to which the given core media type
-						resource MUST conform.</li>
+						resource has to conform.</li>
 					<li><strong>Applies to</strong>—The publication resource type(s) that the Media Type and Content
 						Type Definition applies to.</li>
 				</ul>
@@ -1150,8 +1150,8 @@
 				</table>
 
 				<div class="note">
-					<p>Inclusion as a core media type resource does not mean that all reading systems will support the
-						rendering of a resource. Reading system support also depends on the capabilities of the
+					<p>Inclusion as a core media type resource does not mean that all [=reading systems=] will support
+						the rendering of a resource. Reading system support also depends on the capabilities of the
 						application (e.g., a reading system with a [=viewport=] has to support image core media type
 						resources, but a reading system without a viewport does not). Refer to <a
 							data-cite="epub-rs-34#sec-epub-rs-conf-cmt">Core media types</a> [[epub-rs-34]] for more
@@ -1160,7 +1160,7 @@
 
 					<p>The Working Group typically only includes formats as core media type resources when they have
 						broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
-						upon — as at that stage they ensure predictable rendering in EPUB publications.</p>
+						upon — as at that stage they can be relied on for rendering in reading systems.</p>
 				</div>
 			</section>
 
@@ -1172,8 +1172,8 @@
 					which is not guaranteed [=reading system=] support when used in an [=EPUB content document=] or
 					[=foreign content document=].</p>
 
-				<p id="confreq-cmt">[=EPUB publications=] MUST include fallbacks for foreign resources, where fallbacks
-					take one of the following forms:</p>
+				<p id="confreq-cmt">Fallbacks MUST be provided for foreign resources, where fallbacks take one of the
+					following forms:</p>
 
 				<ul>
 					<li>
@@ -1214,8 +1214,8 @@
 
 				<p>There are only a small set of special cases for exempt resources. Video, for example, are exempt from
 					fallbacks because there is no consensus on a core media type video format at this time (i.e., there
-					is no format to fallback to). Similarly, audio and video tracks are exempt to allow the use of
-					whatever format reading systems support best.</p>
+					is no format to fallback to). Similarly, audio and video tracks are exempt for accessibility
+					purposes so whatever format reading systems support best can be used.</p>
 
 				<p>The following list details cases of content-specific exempt resources, including any restrictions on
 					where they can be used.</p>
@@ -1255,8 +1255,8 @@
 						<div class="note">
 							<p>Although reading systems are encouraged to support at least one of the H.264 [[?h264]]
 								and VP8 [[?rfc6386]] video codecs, support for video codecs is not a conformance
-								requirement. When deciding which video formats to include, consider factors such as
-								breadth of adoption, playback quality, and technology royalties.</p>
+								requirement. When deciding which video formats to include, consider factors such as the
+								breadth of support in reading systems, playback quality, and technology royalties.</p>
 						</div>
 					</dd>
 				</dl>
@@ -1327,14 +1327,14 @@
 					<dl>
 						<dt id="spine-fallbacks">Spine fallbacks</dt>
 						<dd>
-							<p>[=foreign content document=] MUST specify a fallback chain that MUST include at least one
-								[=EPUB content document=] to ensure that reading systems can always render the [=EPUB
-								spine | spine=] item.</p>
+							<p>A [=foreign content document=] MUST specify a fallback chain that MUST include at least
+								one [=EPUB content document=] to ensure that reading systems can always render the
+								[=EPUB spine | spine=] item.</p>
 							<p>EPUB content documents MAY specify a fallback. For example, to provide a <a
 									href="#confreq-cd-scripted-flbk">fallback for scripted content</a>.</p>
-							<p>When a fallback chain includes more than one EPUB content document, use the <a
-									href="#attrdef-properties"><code>properties</code> attribute</a> to differentiate
-								the purpose of each.</p>
+							<p>When a fallback chain includes more than one EPUB content document, the <a
+									href="#attrdef-properties"><code>properties</code> attribute</a> can be used to
+								differentiate the purpose of each.</p>
 						</dd>
 
 						<dt id="content-fallbacks">Content fallbacks</dt>
@@ -1342,8 +1342,8 @@
 							<div class="note">
 								<p>The original reason for defining a content fallback mechanism was to handle foreign
 									resource images in the [[html]] [^img^] element. As HTML now has intrinsic fallback
-									mechanisms for images, such as the [^img/src^] attribute and [^source^] element, the
-									use of content fallbacks is strongly discouraged.</p>
+									mechanisms for images, such as the [^img/srcset^] attribute and [^source^] element,
+									the use of content fallbacks is strongly discouraged.</p>
 							</div>
 							<p>When elements that reference [=foreign resources=] do not have intrinsic fallback
 								capabilities, a content fallback MUST be provided. In this case, the fallback chain MUST
@@ -1373,11 +1373,11 @@
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L256,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L262,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L272">
 						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-media">[=XHTML content documents=] MUST NOT include
-							embedded [[html]]&#160;[=flow content=] within <a data-cite="html#the-audio-element"
-									><code>audio</code></a> or <a data-cite="html#the-video-element"
-								><code>video</code></a> elements as an intrinsic fallback for [=foreign resources=].
-							Only child [^source^] elements&#160;[[html]] provide intrinsic fallback capabilities.</p>
+						<p id="confreq-resources-cd-fallback-media">[[html]]&#160;[=flow content=] embedded within <a
+								data-cite="html#the-audio-element"><code>audio</code></a> or <a
+								data-cite="html#the-video-element"><code>video</code></a> elements does not count as an
+							intrinsic fallback for [=foreign resources=]. Only child [^source^] elements&#160;[[html]]
+							provide intrinsic fallback capabilities.</p>
 
 						<p>Only older [=reading systems=] that do not recognize the <code>audio</code> or the
 								<code>video</code> elements (e.g., EPUB 2 reading systems) will render the embedded
@@ -1576,8 +1576,8 @@
 					system.</p>
 
 				<p>Using a file URL in an [=EPUB publication=], which can be transferred among different hosts,
-					represents a security risk and is also non-interoperable. Consequently, EPUB publications MUST NOT
-					include file URLs.</p>
+					represents a security risk and is also non-interoperable. Consequently, file URLs MUST NOT be used
+					in EPUB publications.</p>
 			</section>
 
 			<section id="sec-xml-constraints" data-epubcheck="true"
@@ -1768,7 +1768,7 @@
 								container MUST NOT exceed 65535 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-fn-chars">File names MUST NOT use the following [[unicode]] characters, as
+							<p id="ocf-fn-chars">File names MUST NOT use the following [[unicode]] characters as
 								commonly used operating systems might not support these characters consistently:</p>
 							<ul>
 								<li>
@@ -1871,7 +1871,7 @@
 					<div class="note">
 						<p>Use an abundance of caution naming files when interoperability of content is key. The <a
 								href="#ocf-fn-chars">list of restricted characters</a> is intended to help avoid some
-							known problem areas, but it does not ensure that all other Unicode characters are supported.
+							known problem areas but it does not ensure that all other Unicode characters are supported.
 							Although Unicode support is much better now than in earlier iterations of EPUB, older tools
 							and toolchains can still be encountered (e.g., ZIP tools that only support
 							[[us-ascii]]).</p>
@@ -1972,8 +1972,8 @@
 						</li>
 
 						<li>
-							<p>Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that MUST be
-								used to parse <var>url</var> as defined by the context (document or environment) where
+							<p>Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that is used
+								to parse <var>url</var> as defined by the context (document or environment) where
 									<var>url</var> is used, and according to the content URL of the [=package document=]
 								(see <a href="#sec-parse-package-urls"></a>).</p>
 							<details class="explanation">
@@ -2007,8 +2007,8 @@
 							</details>
 						</li>
 
-						<li>Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that MUST be
-							used to parse <var>url</var> as defined by the context (document or environment) where
+						<li>Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that is used
+							to parse <var>url</var> as defined by the context (document or environment) where
 								<var>url</var> is used, and according to the content URL of the package document (see <a
 								href="#sec-parse-package-urls"></a>).</li>
 
@@ -2498,8 +2498,7 @@
 								<p>Encrypted data replaces unencrypted data in an OCF abstract container. For example,
 									if an image named <code>photo.jpeg</code> is encrypted, the contents of the
 										<code>photo.jpeg</code> resource is replaced with its encrypted contents.
-									Encrypted files within the ZIP directory SHOULD be stored rather than
-									Deflate-compressed.</p>
+									Encrypted files within the ZIP directory SHOULD NOT be compressed.</p>
 
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
 									of embedded fonts referenced by an [=EPUB publication=] to make them more difficult
@@ -2774,14 +2773,14 @@
 
 								<p>The <code>signature</code> element contains child elements of type
 										<code>Signature</code>, as defined by [[xmldsig-core1]]. Signatures can be
-									applied to an EPUB publication as a whole or to its parts, and can specify the
-									signing of any kind of data (i.e., not just XML).</p>
+									applied to an EPUB publication as a whole or to its parts. They can also be used to
+									sign of any kind of data (i.e., not just XML).</p>
 
 								<p class="note">An <a href="#app-schema-signatures">XML Schema</a> also informally
 									defines the content of the <code>signatures.xml</code> file.</p>
 
 								<p>When a <code>signatures.xml</code> file is not included, no part of the [=OCF
-									abstract container=] is being signed at the container level. Digital signing might
+									abstract container=] is signed at the container level but digital signing might
 									exist within the EPUB publication.</p>
 
 								<p id="sig-container">When a data signature is created for the OCF abstract container,
@@ -2802,27 +2801,30 @@
 
 								<p id="sig-restrictions">Any or all files in the OCF abstract container can be signed in
 									their entirety, except for the <code>signatures.xml</code> file since that file will
-									contain the computed signature information. Whether and how the
-										<code>signatures.xml</code> file is signed depends on the objective of the
-									signer.</p>
+									contain the computed signature information.</p>
 
-								<p>To allow signatures to be added or removed from the OCF abstract container without
-									invalidating their signature, the signer SHOULD NOT sign the
-										<code>signatures.xml</code> file.</p>
+								<p>How to sign the <code>signatures.xml</code> file depends on the objective:</p>
 
-								<p>To have any addition or removal of a signature invalidate their signature, the signer
-									can use the Enveloped Signature transform defined in <a
-										data-cite="xmldsig-core#sec-EnvelopedSignature">Section 6.6.4</a> of
-									[[xmldsig-core1]] to sign the entire pre-existing signature file excluding the
-										<code>Signature</code> being created. This transform would sign all previous
-									signatures, and it would become invalid if a subsequent signature were added to the
-									package.</p>
+								<ul>
+									<li>To allow signatures to be added or removed from the OCF abstract container
+										without invalidating its signature, the <code>signatures.xml</code> file SHOULD
+										NOT be signed.</li>
+
+									<li>To have any addition or removal of a signature invalidate the signature for the
+										OCF abstract container, the signer can use the Enveloped Signature transform
+										defined in <a data-cite="xmldsig-core#sec-EnvelopedSignature">Section 6.6.4</a>
+										of [[xmldsig-core1]] to sign the entire pre-existing signature file excluding
+										the <code>Signature</code> being created. This transform would sign all previous
+										signatures, and it would become invalid if a subsequent signature were added to
+										the package.</li>
+								</ul>
 
 								<div class="note">
-									<p>If the signer wants the removal of an existing signature to invalidate their
-										signature, but also wants to allow the addition of signatures, they could use an
-										XPath transform to sign just the existing signatures. The details of such a
-										transform are outside the scope of this specification, however.</p>
+									<p>If it is desired to have only the removal of an existing signature invalidate the
+										signature for the OCF abstract container (i.e., allow the addition of new
+										signatures), an XPath transform could be used to sign just the existing
+										signatures. The details of such a transform are outside the scope of this
+										specification.</p>
 								</div>
 
 								<p>The [[xmldsig-core1]] specification does not associate any semantics with a
@@ -3020,12 +3022,11 @@
 						files means that their contents might appear like any other native container on some systems
 						(e.g., a folder).</p>
 
-					<p>While this simplicity of ZIP files is quite useful, it also poses a problem when ease of
-						extraction of fonts is not a desired side-effect of not encrypting them. When a publisher wishes
-						to include a third-party font, for example, they typically do not want that font extracted and
-						re-used by others. More critically, many commercial fonts allow embedding, but embedding a font
-						implies making it an integral part of the [=EPUB publication=], not just providing the original
-						font file along with the content.</p>
+					<p>While this simplicity of ZIP files is quite useful, it also poses a problem as it makes it easy
+						for others to extract and re-use the fonts in an [=EPUB publication=] if they are not encrypted.
+						More critically, many commercial fonts allow embedding, but embedding a font implies making it
+						an integral part of the EPUB publication, not just providing the original font file along with
+						the content.</p>
 
 					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
 						in the [=OCF ZIP container=] is insufficient to signify that the font cannot be reused in other
@@ -3066,8 +3067,8 @@
 					</ul>
 
 					<p>As a result, whether this method of obfuscation satisfies the requirements of individual font
-						licenses remains a question for the licensor and licensee. Publishers are responsible for
-						ensuring their use of obfuscation meets font licensing requirements.</p>
+						licenses remains a question for the licensor and licensee. Licensees are responsible for
+						ensuring the use of obfuscation meets their font licensing requirements.</p>
 
 					<p>It is also worth noting that obfuscation can lead to interoperability issues in reading systems
 						as they are not required to deobfuscate fonts. As a result, the visual presentation of a
@@ -3192,7 +3193,7 @@
 					</aside>
 
 					<p>To prevent trivial copying of the embedded font to other EPUB publications, the <a
-							href="#obfus-keygen">obfuscation key</a> MUST NOT be provided in the
+							href="#obfus-keygen">obfuscation key</a> MUST NOT be stored in the
 							<code>encryption.xml</code> file.</p>
 				</section>
 			</section>
@@ -3291,7 +3292,7 @@
 					</ul>
 
 					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading systems will assume the
-						value <code>auto</code> when attribute is not present or has an invalid value.</p>
+						value <code>auto</code> when the attribute is not present or has an invalid value.</p>
 
 					<div class="note">
 						<p>The base direction specified in the <code>dir</code> attribute does not affect the ordering
@@ -3408,7 +3409,7 @@
 					<p>Establishes an association between the current expression and the element or resource identified
 						by its value. The value of the attribute MUST be a [=path-relative-scheme-less-URL string=],
 						optionally followed by <code>U+0023&#160;(#)</code> and a [=URL-fragment string=] that
-						references the resource or element they are describing.</p>
+						references the resource or element being described.</p>
 
 					<aside class="example" title="Specifying that a creator is the illustrator">
 						<pre>&lt;package …&gt;
@@ -3814,10 +3815,9 @@
 								</dd>
 							</dl>
 
-							<p>The <code>dc:identifier</code> element MUST specify an identifier that is unique to one
-								and only one [=EPUB publication=] — its [=unique identifier=]. This
-									<code>dc:identifier</code> element MUST specify an <code>id</code> attribute whose
-								value is referenced from the [^package^] element's <a
+							<p>An [=EPUB publication=] MUST include a <code>dc:identifier</code> element that specifies
+								an identifier that is unique to itself &#8212; its [=unique identifier=]. This element
+								MUST be referenced from the [^package^] element's <a
 									href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 									attribute</a>.</p>
 
@@ -4058,9 +4058,9 @@
 								element in document order as the primary language.</p>
 
 							<div class="note">
-								<p>[=Publication resources=] do not inherit their language from the
-										<code>dc:language</code> element(s). The language of each resource has to be set
-									using the intrinsic methods of the format.</p>
+								<p>[=Publication resources=] do not inherit their language from <code>dc:language</code>
+									element(s). The language of each resource has to be set using the intrinsic methods
+									of the format.</p>
 							</div>
 						</section>
 					</section>
@@ -4522,9 +4522,9 @@
 					<p>It is advised to update the last modified date whenever changes are made to the [=EPUB
 						publication=].</p>
 
-					<p>Additional modified properties MAY be specified in the [=package document=] metadata, but they
-						MUST have a different subject (i.e., they require a <code>refines</code> attribute that
-						references an element or resource).</p>
+					<p>Additional <code>dcterms:modified</code> properties MAY be specified in the [=package document=]
+						metadata, but they MUST have a different subject (i.e., they require a <code>refines</code>
+						attribute that references an element or resource).</p>
 
 					<div class="note">
 						<p>The requirements for the last modification date are to ensure compatibility with earlier
@@ -4683,14 +4683,14 @@ XHTML:
 &lt;/html&gt;</pre>
 					</aside>
 
-					<p id="linked-res-location">Linked resources MAY be located outside the [=EPUB container=], but
-						consider that [=reading systems=] are not required to retrieve resources outside the EPUB
-						container before hosting them remotely.</p>
+					<p id="linked-res-location">Although linked resources MAY be located outside the [=EPUB container=],
+						[=reading systems=] are not required to retrieve [=remote resources=]. It is advised to consider
+						what impact this might have on the user's reading experience before hosting them remotely.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-							attribute</a> attribute MUST be specified for all linked resources within the EPUB container
-						but is OPTIONAL when a linked resource is located outside the EPUB container as more than one
-						media type could be served from the same URL [[url]].</p>
+							attribute</a> MUST be specified for all linked resources within the EPUB container. It is
+						OPTIONAL for linked resources located outside the EPUB container as more than one media type
+						could be served from the same URL [[url]].</p>
 
 					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the
 						linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
@@ -5149,8 +5149,8 @@ XHTML:
 								(e.g., for easier zooming). Although embedding the image using the <code>img</code> tag
 								does not require it to be listed in the [=EPUB spine | spine=] or have a fallback,
 								adding the hyperlink causes the document to open as a [=top-level content document=]. As
-								its use in the spine makes it a [=foreign content document=], a fallback to an EPUB
-								content document is included.</p>
+								its use in the spine makes it a [=foreign content document=], it includes a fallback to
+								an EPUB content document.</p>
 
 							<pre>XHTML:
 &lt;html …&gt;
@@ -5199,10 +5199,10 @@ Package document:
 						<aside class="example" title="Link to View foreign resource as top-level content document">
 							<p>The following example shows a link to the raw CSV data file. As the data will open in the
 								[=reading system=] as a [=top-level content document=], it has to be listed in the
-								spine. As its use in the spine makes it a [=foreign content document=], a fallback is
-								provided to an [=EPUB content document=]. Because there is no guarantee users will be
-								able to access the data in its raw form, instructions on how to extract the file from
-								the [=EPUB container=] are also provided.</p>
+								spine. As its use in the spine makes it a [=foreign content document=], it includes a
+								fallback to an [=EPUB content document=]. Because there is no guarantee users will be
+								able to access the data in its raw form, it also provides instructions on how to extract
+								the file from the [=EPUB container=].</p>
 
 							<pre>XHTML:
 &lt;html …&gt;
@@ -5511,9 +5511,9 @@ No Entry</pre>
 						might, for example, present in a popup window or omit from an aural rendering.</p>
 
 					<p>Specifying that content is non-linear does not require reading systems to present it in a
-						specific way, however; it is only a hint to the purpose. Reading systems might present
-						non-linear content where it occurs in the spine, for example, or might skip it until users reach
-						the end of the spine.</p>
+						specific way; it is only a hint to the purpose. Reading systems might present non-linear content
+						where it occurs in the spine, for example, or might skip it until users reach the end of the
+						spine.</p>
 
 					<div class="note">
 						<p>It is advised to list non-linear content at the end of the spine except when it makes sense
@@ -5526,9 +5526,10 @@ No Entry</pre>
 							<code>itemref</code> elements without the attribute. The spine MUST contain at least one
 						linear <code>itemref</code> element.</p>
 
-					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">A means of accessing all
-						non-linear content (e.g., hyperlinks in the content or from the <a href="#sec-nav">EPUB
-							navigation document</a>) MUST be provided.</p>
+					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">As reading systems might not
+						provide access to non-linear content while progressing through the spine, a secondary means of
+						accessing all non-linear content MUST be provided (e.g., via hyperlinks in the content or the <a
+							href="#sec-nav">EPUB navigation document</a>).</p>
 
 					<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine Properties
 							Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
@@ -6233,8 +6234,8 @@ No Entry</pre>
 						<p>Reading systems will typically set some aspects of an [=EPUB publication | EPUB
 							publication's=] style (e.g., setting margins appropriate to the application), potentially
 							overriding the default instructions. To mitigate conflicts, and any potential rendering
-							problems, it is advised to consult reading systems' user agent style sheets, when made
-							publicly available, and adapt styling choices for optimal display.</p>
+							problems, it is advised to consult reading systems' user agent style sheets, when they are
+							made publicly available, and adapt styling choices for optimal display.</p>
 
 						<p>Furthermore, reading systems that allow users to change the appearance (e.g., choice of
 							fonts, text justification, or foreground and background colors) will also modify some CSS
@@ -6291,7 +6292,7 @@ No Entry</pre>
 								if a future update adds the concept.</p>
 						</div>
 
-						<p>Note that [=Reading systems=] are required to behave as though a unique <a
+						<p>Note that [=reading systems=] are required to behave as though a unique <a
 								data-cite="html#origin">origin</a> [[html]] has been assigned to each [=EPUB
 							publication=]. In practice, this means that it is not possible for scripts to share data
 							between EPUB publications.</p>
@@ -7007,9 +7008,9 @@ No Entry</pre>
 						when a reflowable EPUB is not suitable for the content.</p>
 
 					<p>Fixed layouts are defined using a <a href="#sec-fxl-package">set of package document
-							properties</a> to control the rendering in [=reading systems=]. In addition, <a
-							href="#sec-fxl-package">the dimensions of each fixed-layout document</a> is set in its
-						respective [=EPUB content document=].</p>
+							properties</a> to control the presentation in [=reading systems=] while the <a
+							href="#sec-fxl-package">layout dimensions</a> are obtained from each respective [=EPUB
+						content document=].</p>
 
 					<div class="note" id="note-mechanisms">
 						<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
@@ -7258,7 +7259,7 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>The <code>rendition:spread</code> property MUST NOT be declare more than once. In addition,
+						<p>The <code>rendition:spread</code> property MUST NOT be declared more than once. In addition,
 							it MUST NOT be declared using the <a href="#attrdef-refines"><code>refines</code>
 								attribute</a>. Refer to <a href="#spread-overrides"></a> for setting the property for
 							individual [=EPUB content documents=].</p>
@@ -7875,19 +7876,18 @@ No Entry</pre>
 
 						<dl>
 							<dt id="flow-auto">rendition:flow-auto</dt>
-							<dd>Indicates no preference for overflow content handling.</dd>
+							<dd>No preference for overflow content handling.</dd>
 
 							<dt id="flow-paginated">rendition:flow-paginated</dt>
-							<dd>Indicates the preference is to dynamically paginate content overflow.</dd>
+							<dd>Dynamically paginate content overflow.</dd>
 
 							<dt id="flow-scrolled-continuous">rendition:flow-scrolled-continuous</dt>
-							<dd>Indicates the preference is to provide a scrolled view for overflow content, and that
-								consecutive spine items with this property are to be rendered as a continuous
-								scroll.</dd>
+							<dd>Provide a scrolled view for overflow content. Consecutive spine items with this property
+								are to be rendered as a continuous scroll.</dd>
 
 							<dt id="flow-scrolled-doc">rendition:flow-scrolled-doc</dt>
-							<dd>Indicates the preference is to provide a scrolled view for overflow content, and each
-								spine item with this property is to be rendered as a separate scrollable document.</dd>
+							<dd>Provide a scrolled view for overflow content. Each spine item with this property is to
+								be rendered as a separate scrollable document.</dd>
 						</dl>
 
 						<p>A spine item MUST NOT declare more than one of these overrides.</p>
@@ -8546,7 +8546,7 @@ No Entry</pre>
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
 						sentence, or other segment of the EPUB content document by its URL [[url]] reference. The
 							<code>audio</code> element <code>src</code> attribute similarly references the location of
-						the corresponding audio clip and adds the OPTIONAL <a href="#attrdef-smil-clipBegin"
+						the corresponding audio clip and adds the optional <a href="#attrdef-smil-clipBegin"
 								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
 						attributes to indicate a specific offset within the clip.</p>
 
@@ -8561,7 +8561,7 @@ No Entry</pre>
 &lt;/par&gt;</pre>
 					</aside>
 
-					<p><code>par</code> elements are placed together sequentially to form a series of phrases or
+					<p><code>par</code> elements are placed together sequentially to form series of phrases or
 						sentences. Not every element of the EPUB content document will have a corresponding
 							<code>par</code> element in a media overlay document, only those relevant to the audio
 						narration.</p>
@@ -9014,7 +9014,7 @@ html.my-document-playing * {
 							corresponding media overlay document.</p>
 
 						<p>The <code>media-overlay</code> attribute MUST only be specified on manifest <code>item</code>
-							elements that reference EPUB content documents.</p>
+							elements for EPUB content documents.</p>
 
 						<p>Manifest items for media overlay documents MUST have the media type
 								<code>application/smil+xml</code>.</p>
@@ -9061,9 +9061,10 @@ html.my-document-playing * {
 								second indicates a mismatch arising from other issues.</p>
 						</div>
 
-						<p><a href="#narrator"><code>narrator</code></a> information MAY also be specified in the
-							package document, as well as the <a href="#sec-docs-assoc-style">author-defined CSS class
-								names</a> to apply to the currently playing [=EPUB content document=] element.</p>
+						<p>Narrator information MAY also be specified in the package document using the <a
+								href="#narrator"><code>narrator</code> property</a>. <a href="#sec-docs-assoc-style"
+								>Author-defined CSS class names</a> to apply to the currently playing [=EPUB content
+							document=] element can also be specified.</p>
 
 						<div class="note">
 							<p>The <code>media:</code> prefix is <a href="#sec-metadata-reserved-prefixes">reserved</a>
@@ -9506,7 +9507,7 @@ html.my-document-playing * {
 							opening of the EPUB publication (e.g., audio, video, and fonts). Although helpful for users
 							when used as intended, these exemptions can also be used to inject malicious content into a
 							publication.</p>
-						<p>This threat is not limited to accessing content created by a bad actor. If content from
+						<p>This threat is not limited to accessing content created by a malicious actor. If content from
 							untrustworthy sources (e.g., third party audio and video) is embedded in an EPUB
 							publication, there is always the possibility that users could receive compromised
 							resources.</p>
@@ -10076,8 +10077,8 @@ html.my-document-playing * {
 					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The prefix URL for
 					referencing its properties is <code>http://idpf.org/epub/vocab/structure/#</code>.</p>
 
-				<p>Unprefixed terms that are not part of this vocabulary MAY be used, but the preferred method for
-					adding custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
+				<p>Unprefixed terms that are not part of this vocabulary MAY be used but the preferred method for adding
+					custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
 						href="#sec-vocab-assoc"></a> for more information.</p>
 
 				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
@@ -10422,10 +10423,9 @@ html.my-document-playing * {
 					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, they can cause interoperability
-							issues. [=EPUB conformance checkers=] will often reject new prefixes until their developers
-							update the tools to the latest version of the specification, for example. It is advised to
-							declare all prefixes to avoid any issues.</p>
+						<p>Although reserved prefixes are an authoring convenience, they can cause issues in the supply
+							chain. Vendors, for example, will often reject new prefixes until they update their [=EPUB
+							conformance checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
 					</div>
 
 					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -8546,7 +8546,7 @@ No Entry</pre>
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
 						sentence, or other segment of the EPUB content document by its URL [[url]] reference. The
 							<code>audio</code> element <code>src</code> attribute similarly references the location of
-						the corresponding audio clip and adds the optional <a href="#attrdef-smil-clipBegin"
+						the corresponding audio clip and adds the <a href="#attrdef-smil-clipBegin"
 								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
 						attributes to indicate a specific offset within the clip.</p>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -7255,7 +7255,7 @@ No Entry</pre>
 
 							<dt>auto</dt>
 							<dd>
-								<p>No synthetic spread behavior preference. Default value.</p>
+								<p>No synthetic spread behavior preference is defined. Default value.</p>
 							</dd>
 						</dl>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6456,7 +6456,7 @@ No Entry</pre>
 					restrictions on the structure or content of the EPUB navigation document outside of the specialized
 					navigation elements (i.e., the rest of the document can be marked up like any other XHTML content
 					document). As a result, it can also be part of the linear reading order, avoiding the need for
-					duplicate tables of contents. Navigation elements that are only for machine processing (e.g., the
+					duplicate tables of contents. Navigation elements that are only meant for machine processing (e.g., the
 					page list) can be hidden using the <a href="#sec-nav-doc-use-spine"><code>hidden</code>
 						attribute</a>.</p>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5870,7 +5870,7 @@ No Entry</pre>
 								that these attributes represent an extension of the HTML grammar. <a
 									data-cite="html#microdata">Microdata attributes</a> [[html]] and <a
 									data-cite="json-ld11#">linked data</a> [[json-ld11]] are natively supported in XHTML
-								content documents.</p>
+								content documents and can be used as well.</p>
 						</div>
 					</section>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -847,23 +847,21 @@
 						documents=] and [=SVG content documents=].</p>
 
 					<p>To use any other type of resource in the spine, called a [=foreign content document=], requires
-						including a fallback to an EPUB content document. This extensibility model allows
-						experimentation with formats while ensuring that reading systems are always able to render
-						something for the user to read, as there is no guarantee of support for foreign content
-						documents.</p>
-
-					<p>A mechanism called <a href="#sec-manifest-fallbacks">manifest fallbacks</a> allows EPUB creators
-						to provide fallbacks for foreign content documents. In this model, the [=EPUB manifest |
-						manifest=] entry for the foreign content document must include a <a
-							href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to the next
-						possible resource for reading systems to try when they do not support its format. Although not
-						common, a fallback resource can specify another fallback, thereby making chains many resources
-						deep. The one requirement is that there must be at least one EPUB content document in a
-						[=manifest fallback chain=].</p>
+						including a <a href="#sec-manifest-fallbacks">manifest fallback</a> to an EPUB content document.
+						In this model, the [=EPUB manifest | manifest=] entry for the foreign content document must
+						include a <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to
+						the next possible resource for reading systems to try when they do not support its format.
+						Although not common, a fallback resource can specify another fallback, thereby making chains
+						many resources deep. The one requirement is that there must be at least one EPUB content
+						document in a [=manifest fallback chain=].</p>
 
 					<p>Although they are not directly listed in the spine, all of the resources in the fallback chain
 						are considered part of the spine, and by extension part of the spine plane, since any may be
 						used by a reading system.</p>
+
+					<p>This extensibility model allows experimentation with formats while ensuring that reading systems
+						are always able to render something for the user to read, as there is no guarantee of support
+						for foreign content documents.</p>
 
 					<p>Refer to <a href="#sec-manifest-fallbacks"></a> for more information.</p>
 
@@ -907,8 +905,7 @@
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
 						for example, have intrinsic fallback capabilities. One example is the [^picture^]
-						element&#160;[[html]], which allows [=EPUB creators=] to specify multiple alternative image
-						formats.</p>
+						element&#160;[[html]], which allows multiple alternative image formats to be specified.</p>
 
 					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
 						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
@@ -928,16 +925,17 @@
 
 					<div class="note">
 						<p>A common point of confusion arising from core media type resources is the listing of XHTML
-							and SVG as core media type resources with the requirement the markup conform to their
-							respective EPUB content document definitions. This allows EPUB creators to embed both XHTML
-							and SVG documents in EPUB content documents while keeping consistent requirements for
-							authoring and reading system support.</p>
+							and SVG as core media type resources with the requirement that the markup conform to their
+							respective EPUB content document definitions. This common definition ensures that regardless
+							of whether XHTML and SVG documents are listed in the spine or embedded in other EPUB content
+							documents they the same requirements for authoring and reading system support.</p>
 
 						<p>In practice, it means that EPUB creators can put XHTML and SVG core media type resources in
-							the spine without any modification or fallback (they are also conforming XHTML and SVG
-							content documents), but this is a unique case. All other core media type resources become
-							foreign content documents when used in the spine (i.e., foreign content documents include
-							all foreign resources and all core media type resources except for XHTML and SVG).</p>
+							the spine without any modification or fallback as they are also conforming XHTML and SVG
+							content documents. But, this is a unique case &#8212; all other core media type resources
+							become foreign content documents when used in the spine (i.e., foreign content documents
+							include all foreign resources and all core media type resources except for XHTML and
+							SVG).</p>
 					</div>
 				</section>
 			</section>
@@ -945,13 +943,13 @@
 			<section id="sec-core-media-types">
 				<h3>Core media types</h3>
 
-				<p>[=EPUB creators=] MAY include [=publication resources=] that conform to the MIME media type
+				<p>[=EPUB publications=] MAY include [=publication resources=] that conform to the MIME media type
 					[[rfc2046]] specifications defined in the following table without fallbacks when they are used in
 					[=EPUB content documents=] and [=foreign content documents=]. These resources are classified as
 					[=core media type resources=].</p>
 
-				<p>With the exception of [=XHTML content documents=] and [=SVG content documents=], EPUB creators MUST
-					provide <a href="#sec-manifest-fallbacks">manifest fallbacks</a> for core media type resources
+				<p>With the exception of [=XHTML content documents=] and [=SVG content documents=], EPUB publications
+					MUST include <a href="#sec-manifest-fallbacks">manifest fallbacks</a> for core media type resources
 					referenced directly from the [=EPUB spine | spine=]. In this case, they are [=foreign content
 					documents=].</p>
 
@@ -961,11 +959,11 @@
 					<li>
 						<p><strong>Media Type</strong>—The MIME media type [[rfc2046]] used to represent the given
 							publication resource in the [=EPUB manifest | manifest=].</p>
-						<p>If the table lists more than one media type, the first one is the preferred media type. EPUB
-							creators should use the preferred media type for all new EPUB publications.</p>
+						<p>If the table lists more than one media type, the first one is the preferred media type. The
+							preferred media type SHOULD be used for all EPUB publications.</p>
 					</li>
 					<li><strong>Content Type Definition</strong>—The specification to which the given core media type
-						resource must conform.</li>
+						resource MUST conform.</li>
 					<li><strong>Applies to</strong>—The publication resource type(s) that the Media Type and Content
 						Type Definition applies to.</li>
 				</ul>
@@ -1163,8 +1161,7 @@
 
 					<p>The Working Group typically only includes formats as core media type resources when they have
 						broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
-						upon. They are an agreement between reading system developers and EPUB creators to ensure the
-						predictability of rendering of EPUB publications.</p>
+						upon — as at that stage they ensure predictable rendering in EPUB publications.</p>
 				</div>
 			</section>
 
@@ -1176,8 +1173,8 @@
 					which is not guaranteed [=reading system=] support when used in an [=EPUB content document=] or
 					[=foreign content document=].</p>
 
-				<p id="confreq-cmt">[=EPUB creators=] MUST provide fallbacks for foreign resources, where fallbacks take
-					one of the following forms:</p>
+				<p id="confreq-cmt">[=EPUB publications=] MUST include fallbacks for foreign resources, where fallbacks
+					take one of the following forms:</p>
 
 				<ul>
 					<li>
@@ -1218,19 +1215,18 @@
 
 				<p>There are only a small set of special cases for exempt resources. Video, for example, are exempt from
 					fallbacks because there is no consensus on a core media type video format at this time (i.e., there
-					is no format to fallback to). Similarly, audio and video tracks are exempt to allow [=EPUB
-					creators=] to meet accessibility requirements using whatever format reading systems support
-					best.</p>
+					is no format to fallback to). Similarly, audio and video tracks are exempt to allow the use of
+					whatever format reading systems support best.</p>
 
 				<p>The following list details cases of content-specific exempt resources, including any restrictions on
-					where EPUB creators can use them.</p>
+					where they can be used.</p>
 
 				<dl>
 					<dt id="exempt-fonts">Fonts</dt>
 					<dd id="confreq-resources-cd-fonts">
 						<p>Font resources are exempt resources.</p>
-						<p>This exemption allows EPUB creators to use any font format without a fallback, regardless of
-							reading system support expectations, as CSS rules will ensure a fallback font in case of no
+						<p>This exemption allows the use of any font format without a fallback, regardless of reading
+							system support expectations, as CSS rules will ensure a fallback font in case of no
 							support.</p>
 						<p>Refer to the <a data-cite="epub-rs-34#confreq-css-rs-fonts">reading system support
 								requirements for fonts</a> [[epub-rs-34]] for more information.</p>
@@ -1260,8 +1256,8 @@
 						<div class="note">
 							<p>Although reading systems are encouraged to support at least one of the H.264 [[?h264]]
 								and VP8 [[?rfc6386]] video codecs, support for video codecs is not a conformance
-								requirement. EPUB creators must consider factors such as breadth of adoption, playback
-								quality, and technology royalties when deciding which video formats to include.</p>
+								requirement. When deciding which video formats to include, consider factors such as
+								breadth of adoption, playback quality, and technology royalties.</p>
 						</div>
 					</dd>
 				</dl>
@@ -1285,8 +1281,8 @@
 					</li>
 				</ul>
 
-				<p>This exemption allows EPUB creators to include resources in the [=EPUB container=] that are not for
-					use by EPUB reading systems. Resources that benefit from this exemption include:</p>
+				<p>This exemption allows the inclusion of resources in the [=EPUB container=] that are not for use by
+					EPUB reading systems, such as:</p>
 
 				<ul>
 					<li>script code modules, such as WebAssembly [[?wasm-core-2]];</li>
@@ -1297,15 +1293,13 @@
 						with instructions on how to extract it from the EPUB container).</li>
 				</ul>
 
-				<div class="note">
-					<p>An example of a resource not exempted by this rule would be a foreign image resource referenced
-						by a <a data-cite="css-values#urls"><code>url</code> function</a> [[css-values]] in a CSS style
-						sheet, as this would result in the non-core media type format being displayed.</p>
-				</div>
+				<p>A foreign image resource referenced from a <a data-cite="css-values#urls"><code>url</code>
+						function</a> [[css-values]] in a CSS style sheet is an example of a resource not exempted by
+					this rule as it would result in the non-core media type format being displayed.</p>
 
-				<p>The exemption also allows EPUB creators to use foreign resources in foreign content documents without
-					reading systems or [=EPUB conformance checkers=] having to understand the fallback capabilities of
-					those resources (i.e., the requirement for a fallback for the foreign content document covers any
+				<p>The exemption also allows the use of foreign resources in foreign content documents without reading
+					systems or [=EPUB conformance checkers=] having to understand the fallback capabilities of those
+					resources (i.e., the requirement for a fallback for the foreign content document covers any
 					rendering issues within it). As the resource is not referenced from an EPUB content document, it
 					automatically becomes exempt from fallbacks.</p>
 			</section>
@@ -1326,38 +1320,36 @@
 						the <a data-cite="xml#id">ID</a> [[xml]] of another manifest <code>item</code> that is a
 						fallback for the current <code>item</code>. The ordered list of all the references that a
 						reading system can reach, starting from a given <code>item</code>'s <code>fallback</code>
-						attribute, represents the full fallback chain for that <code>item</code>. This chain also
-						represents the [=EPUB creator | EPUB creator's=] preferred fallback order.</p>
+						attribute, represents both the full and preferred fallback chain for that <code>item</code>.</p>
 
 					<p>There are two cases for manifest fallbacks:</p>
 
 					<dl>
 						<dt id="spine-fallbacks">Spine fallbacks</dt>
 						<dd>
-							<p>EPUB creators MUST specify a fallback chain for a [=foreign content document=] to ensure
-								that reading systems can always render the [=EPUB spine | spine=] item. In this case,
-								the chain MUST contain at least one [=EPUB content document=].</p>
-							<p>EPUB creators MAY provide fallbacks for EPUB content documents (e.g., to provide a <a
-									href="#confreq-cd-scripted-flbk">fallback for scripted content</a>).</p>
-							<p>When a fallback chain includes more than one EPUB content document, EPUB creators can use
-								the <a href="#attrdef-properties"><code>properties</code> attribute</a> to differentiate
+							<p>[=foreign content document=] MUST specify a fallback chain that MUST include at least one
+								[=EPUB content document=] to ensure that reading systems can always render the [=EPUB
+								spine | spine=] item.</p>
+							<p>EPUB content documents MAY specify a fallback. For example, to provide a <a
+									href="#confreq-cd-scripted-flbk">fallback for scripted content</a>.</p>
+							<p>When a fallback chain includes more than one EPUB content document, use the <a
+									href="#attrdef-properties"><code>properties</code> attribute</a> to differentiate
 								the purpose of each.</p>
 						</dd>
 
 						<dt id="content-fallbacks">Content fallbacks</dt>
 						<dd>
 							<div class="note">
-								<p>The original purpose for content fallbacks was to specify fallback images for the
-									[[html]] [^img^] element. As HTML now has intrinsic fallback mechanism for images,
-									the use of content fallbacks is strongly discouraged. EPUB creators should always
-									use the intrinsic fallback capabilities of [[html]] and [[svg]] to provide fallback
-									content.</p>
+								<p>The original reason for defining a content fallback mechanism was to handle foreign
+									resource images in the [[html]] [^img^] element. As HTML now has intrinsic fallback
+									mechanisms for images, such as the [^img/src^] attribute and [^source^] element, the
+									use of content fallbacks is strongly discouraged.</p>
 							</div>
-							<p>EPUB creators MUST provide a content fallback for [=foreign resources=] when the elements
-								that reference them do not have intrinsic fallback capabilities. In this case, the
-								fallback chain MUST contain at least one [=core media type resource=].</p>
-							<p>EPUB creators MAY also provide manifest fallbacks for core media type resources (e.g., to
-								allow reading systems to select from more than one image format).</p>
+							<p>When elements that reference [=foreign resources=] do not have intrinsic fallback
+								capabilities, a content fallback MUST be provided. In this case, the fallback chain MUST
+								contain at least one [=core media type resource=].</p>
+							<p>Manifest fallbacks MAY also be provided for core media type resources. For example, to
+								allow reading systems to select from more than one image format.</p>
 						</dd>
 					</dl>
 
@@ -1366,8 +1358,8 @@
 
 					<div class="note">
 						<p>As it is not possible to use manifest fallbacks for resources represented in <a
-								href="#sec-data-urls">data URLs</a>, EPUB creators can only represent foreign resources
-							as data URLs where an intrinsic fallback mechanism is available.</p>
+								href="#sec-data-urls">data URLs</a>, foreign resources can only be represented as data
+							URLs where an intrinsic fallback mechanism is available.</p>
 					</div>
 				</section>
 
@@ -1381,12 +1373,11 @@
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L256,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L262,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L272">
 						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
-							[[html]]&#160;[=flow content=] within a <a data-cite="html#media-elements">media element</a>
-							(i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
-								data-cite="html#the-video-element"><code>video</code></a>) as an intrinsic fallback for
-							audio [=foreign resources=]. Only child [^source^] elements&#160;[[html]] provide intrinsic
-							fallback capabilities.</p>
+						<p id="confreq-resources-cd-fallback-media">[=XHTML content documents=] MUST NOT include
+							embedded [[html]]&#160;[=flow content=] within <a data-cite="html#the-audio-element"
+									><code>audio</code></a> or <a data-cite="html#the-video-element"
+								><code>video</code></a> elements as an intrinsic fallback for [=foreign resources=].
+							Only child [^source^] elements&#160;[[html]] provide intrinsic fallback capabilities.</p>
 
 						<p>Only older [=reading systems=] that do not recognize the <code>audio</code> or the
 								<code>video</code> elements (e.g., EPUB 2 reading systems) will render the embedded
@@ -1404,16 +1395,14 @@
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L280,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L285,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L290,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L296,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L302,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L308,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L313">
 						<h5>HTML <code>img</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that [=EPUB creators=]
-							can specify in the [[html]] [^img^] element, the following fallback conditions apply to its
-							use:</p>
+						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that can be referenced
+							from the [[html]] [^img^] element, the following fallback conditions apply to its use:</p>
 						<ul>
 							<li>
 								<p>If it is the child of a [^picture^] element:</p>
 								<ul>
 									<li>it MUST reference core media type resources from its <code>src</code> and
-											<code>srcset</code> attributes, when EPUB creators specify those attributes;
-										and</li>
+											<code>srcset</code> attributes when those attributes are set; and</li>
 									<li>each sibling [^source^] element MUST reference a [=core media type resource=]
 										from its <code>[^source/src^]</code> and <code>[^source/srcset^]</code>
 										attributes unless it specifies the MIME media type [[rfc2046]] of a [=foreign
@@ -1422,8 +1411,8 @@
 							</li>
 
 							<li>Otherwise, it MAY reference foreign resources in its <code>[^img/src^]</code> and
-									<code>[^img/srcset^]</code> attributes provided EPUB creators define a <a
-									href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
+									<code>[^img/srcset^]</code> attributes provided there is also a <a
+									href="#sec-manifest-fallbacks">manifest fallback</a> to a core media type.</li>
 						</ul>
 					</section>
 
@@ -1442,8 +1431,8 @@
 								media type requirements</a> — requiring fallbacks for the raw data does not serve a
 							useful purpose.</p>
 
-						<p>Consequently, to ensure that [=EPUB creators=] can include data blocks for scripting
-							purposes, they are exempt from fallback requirements.</p>
+						<p>Consequently, data blocks are exempt from fallback requirements to allow their use by
+							scripts.</p>
 
 						<div class="note">
 							<p>This exemption aligns data blocks with the <a href="#confreq-foreign-no-fallback"
@@ -1462,8 +1451,7 @@
 				data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L267,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L341,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L346,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L351,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L357,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L362,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L367,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L373,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L379,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L385,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L391,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L397,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L403,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L408,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L413,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L418,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L423,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L429,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L435,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L441,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L449,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L457,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L463,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L469,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L475,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L481,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L487">
 				<h4>Resource locations</h4>
 
-				<p>[=EPUB creators=] MAY host the following types of [=publication resources=] outside the [=EPUB
-					container=]:</p>
+				<p>The following types of [=publication resources=] MAY be hosted outside the [=EPUB container=]:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -1481,15 +1469,15 @@
 					</li>
 				</ul>
 
-				<p>EPUB creators MUST store all other resources within the EPUB container.</p>
+				<p>All other resources MUST be stored within the EPUB container.</p>
 
 				<p>Storing all resources inside the EPUB container is strongly encouraged whenever possible as it allows
 					users access to the entire presentation regardless of connectivity status.</p>
 
-				<p>When resources have to be located outside the EPUB container, EPUB creators are RECOMMENDED to
-					reference them via the secure <code>https</code> URI scheme [[rfc9110]] to limit the threat of
-					exposing their publications, and users, to network attacks. [=Reading systems=] might not load
-					[=remote resources=] referenced using insecure schemes such as <code>http</code>.</p>
+				<p>When resources have to be located outside the EPUB container, it is RECOMMENDED to reference them via
+					the secure <code>https</code> URI scheme [[rfc9110]] to limit the threat of exposing their
+					publications, and users, to network attacks. [=Reading systems=] might not load [=remote resources=]
+					referenced using insecure schemes such as <code>http</code>.</p>
 
 				<p>These rules for locating publication resource apply regardless of whether the given resource is a
 					[=core media type resource=] or a [=foreign resource=].</p>
@@ -1537,11 +1525,11 @@
 				<h3>Data URLs</h3>
 
 				<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[rfc2397]] is used to encode resources
-					directly into a URL string. The advantage of this scheme is that it allows [=EPUB creators=] to
-					embed a resource within another, avoiding the need for an external file.</p>
+					directly into a URL string. The advantage of this scheme is that it allows a resource to be embedded
+					within another, avoiding the need for an external file.</p>
 
-				<p>EPUB creators MUST NOT use data URLs in the following scenarios where they can result in a
-					[=top-level content document=] or [=top-level browsing context=] [[html]]:</p>
+				<p>Data URLs MUST NOT be used in the following scenarios as they will result in a [=top-level content
+					document=] or [=top-level browsing context=] [[html]]:</p>
 
 				<ul>
 					<li>
@@ -1573,9 +1561,9 @@
 				<p>A consequence of embedding is that the data in a data URL is not considered its own unique
 					[=publication resource=] for manifest reporting purposes (i.e., only its containing publication
 					resource gets listed). As this data has its own media type, however, it is still subject to <a
-						href="#sec-foreign-resources">foreign resource restrictions</a>. EPUB creators MUST therefore
-					encode data URLs as [=core media type resources=] or provide a fallback using the intrinsic fallback
-					mechanisms of the host format.</p>
+						href="#sec-foreign-resources">foreign resource restrictions</a>. Therefore, data URLs MUST be
+					encoded as [=core media type resources=] or have a fallback using the intrinsic fallback mechanisms
+					of the host format.</p>
 			</section>
 
 			<section id="sec-file-urls" data-epubcheck="true"
@@ -1588,8 +1576,8 @@
 					system.</p>
 
 				<p>Using a file URL in an [=EPUB publication=], which can be transferred among different hosts,
-					represents a security risk and is also non-interoperable. As a consequence, [=EPUB creators=] MUST
-					NOT use file URLs in EPUB publications.</p>
+					represents a security risk and is also non-interoperable. Consequently, EPUB publications MUST NOT
+					include file URLs.</p>
 			</section>
 
 			<section id="sec-xml-constraints" data-epubcheck="true"
@@ -1626,8 +1614,8 @@
 					type resource=] or a [=foreign resource=].</p>
 
 				<div class="note">
-					<p>[[html]] and [[svg]] are removing support for the XML <code>base</code> attribute [[xmlbase]].
-						EPUB creators should avoid using this feature.</p>
+					<p>It is advised to avoid the XML <code>base</code> attribute [[xmlbase]] as [[html]] and [[svg]]
+						are removing support for it.</p>
 				</div>
 			</section>
 		</section>
@@ -1696,8 +1684,7 @@
 						</dt>
 						<dd>
 							<p>Contains information about the encryption of [=publication resources=]. This file is
-								mandatory when [=EPUB creators=] use <a href="#sec-font-obfuscation">font
-									obfuscation</a>.</p>
+								mandatory when using <a href="#sec-font-obfuscation">font obfuscation</a>.</p>
 						</dd>
 
 						<dt>
@@ -1747,15 +1734,15 @@
 					<p>Files in the <code>META-INF</code> directory and the <code>mimetype</code> file are not
 						[=publication resources=] so MUST NOT be listed in the [=EPUB manifest|manifest=].</p>
 
-					<p>[=EPUB creators=] MAY locate all other files within the OCF abstract container in any location
-						descendant from the root directory, provided they are not within the <code>META-INF</code>
-						directory. EPUB creators MUST NOT reference files in the <code>META-INF</code> directory from an
-						[=EPUB publication=].</p>
+					<p>All other files within the OCF abstract container MAY be stored in any location descendant from
+						the root directory provided they are not within the <code>META-INF</code> directory. [=EPUB
+						publications=] MUST NOT contain references to files in the <code>META-INF</code> directory.</p>
 
 					<div class="note">
 						<p>Some [=reading systems=] do not provide access to resources outside the directory where the
-							[=package document=] is stored. EPUB creators should therefore place all resources at or
-							below the directory containing the package document to avoid interoperability issues.</p>
+							[=package document=] is stored even though this is not a restriction defined in
+							[[epub-rs-34]]. To avoid interoperability issues with these reading systems, place all
+							resources at or below the directory containing the package document.</p>
 
 						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
 								>creating multiple renditions</a> [[epub-multi-rend-11]] of the publication.</p>
@@ -1854,11 +1841,10 @@
 								</li>
 							</ul>
 							<div class="note">
-								<p>The Unicode Character Database [[uax44]] also includes a <a
+								<p>The Unicode Character Database [[uax44]] includes a <a
 										href="https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt">list of
-										deprecated characters</a>. EPUB creators are advised to avoid these characters,
-									as well, as it is expected that [=EPUB conformance checkers=] will flag their
-									use.</p>
+										deprecated characters</a>. It is also advised to avoid these characters as it is
+									expected that [=EPUB conformance checkers=] will flag their use.</p>
 							</div>
 						</li>
 						<li>
@@ -1873,22 +1859,22 @@
 						</li>
 					</ul>
 					<div class="note">
-						<p>If [=EPUB creators=] dynamically integrate resources (i.e., where the naming is beyond their
-							control), they should be aware that automatic truncation of file names to keep them within
-							the 255 bytes limit can lead to corruption. This is due to the difference between bytes and
-							characters in multibyte encodings such as UTF-8; it is, therefore, important to avoid
-							mid-character truncation. See the section on <a
+						<p>If [=EPUB publications=] are created by dynamically integrating resources (i.e., where the
+							naming is not known in advance), be aware that automatic truncation of file names to keep
+							them within the 255 bytes limit can lead to corruption. This is due to the difference
+							between bytes and characters in multibyte encodings such as UTF-8. Therefore, it is
+							important to avoid mid-character truncation. See the section on <a
 								data-cite="international-specs/#char_truncation">"Truncating or limiting the length of
 								strings"</a> in [[international-specs]] for more information.</p>
 					</div>
 
 					<div class="note">
-						<p>EPUB creators should use an abundance of caution in their file naming when interoperability
-							of content is key. The <a href="#ocf-fn-chars">list of restricted characters</a> is intended
-							to help avoid some known problem areas, but it does not ensure that all other Unicode
-							characters are supported. Although Unicode support is much better now than in earlier
-							iterations of EPUB, older tools and toolchains may still be encountered (e.g., ZIP tools
-							that only support [[us-ascii]]).</p>
+						<p>Use an abundance of caution naming files when interoperability of content is key. The <a
+								href="#ocf-fn-chars">list of restricted characters</a> is intended to help avoid some
+							known problem areas, but it does not ensure that all other Unicode characters are supported.
+							Although Unicode support is much better now than in earlier iterations of EPUB, older tools
+							and toolchains can still be encountered (e.g., ZIP tools that only support
+							[[us-ascii]]).</p>
 					</div>
 				</section>
 
@@ -1918,8 +1904,8 @@
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The [=container root
-						URL=] is the [=URL=]&#160;[[url]] of the [=root directory=]. It is implementation-specific, but
-						[=EPUB creators=] MUST assume it has the following properties:</p>
+						URL=] is the [=URL=]&#160;[[url]] of the [=root directory=]. Although the container root URL is
+						implementation-specific, it MUST have the following properties:</p>
 
 					<ul id="sec-root-url-properties">
 						<li id="sec-container-iri-root-parse"
@@ -2309,9 +2295,9 @@
 									</dd>
 								</dl>
 
-								<p>If an [=EPUB creator=] defines more than one <code>rootfile</code> element, each MUST
-									reference a package document that conforms to the same version of EPUB. Each package
-									document represents one rendering of the [=EPUB publication=].</p>
+								<p>If more than one <code>rootfile</code> element is specified, each MUST reference a
+									package document that conforms to the same version of EPUB. Each package document
+									represents one rendering of the [=EPUB publication=].</p>
 
 								<div class="note">
 									<p>Although the EPUB container provides the ability to reference more than one
@@ -2438,10 +2424,9 @@
 							<h6>Encryption file (<code>encryption.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>encryption.xml</code> file in the <code>META-INF</code> directory
-								holds all encryption information on the contents of the container. If an [=EPUB
-								creator=] encrypts any resources within the container, they MUST include an
-									<code>encryption.xml</code> file to provide information about the encryption
-								used.</p>
+								holds all encryption information on the contents of the container. If an any resources
+								within the container are encrypted, there MUST be an <code>encryption.xml</code> file to
+								provide information about the encryption used.</p>
 
 							<section id="sec-encryption.xml-encryption" data-epubcheck="true"
 								data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L209,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L225">
@@ -2503,18 +2488,18 @@
 
 								<p>OCF uses XML Encryption [[xmlenc-core1]] to provide a framework for encryption,
 									allowing a variety of algorithms to be used. XML Encryption specifies a process for
-									encrypting arbitrary data and representing the result in XML. Even though an [=OCF
-									abstract container=] may contain non-XML data, [=EPUB creators=] can use XML
-									Encryption to encrypt all data in an [=OCF abstract container=]. OCF encryption
-									supports only the encryption of entire files within the container, not parts of
-									files. EPUB creators MUST NOT encrypt the <code>encryption.xml</code> file when
-									present.</p>
+									encrypting arbitrary data and representing the result in XML. Even if an [=OCF
+									abstract container=] contains non-XML data, XML Encryption can be used to encrypt
+									that data. OCF encryption supports only the encryption of entire files within the
+									container, not parts of files.</p>
+
+								<p>When present, the <code>encryption.xml</code> file MUST NOT be encrypted.</p>
 
 								<p>Encrypted data replaces unencrypted data in an OCF abstract container. For example,
-									if an EPUB creator encrypts an image named <code>photo.jpeg</code>, they should
-									replace the contents of the <code>photo.jpeg</code> resource with its encrypted
-									contents. Within the ZIP directory, EPUB creators SHOULD store encrypted files
-									rather than Deflate-compress them.</p>
+									if an image named <code>photo.jpeg</code> is encrypted, the contents of the
+										<code>photo.jpeg</code> resource is replaced with its encrypted contents.
+									Encrypted files within the ZIP directory SHOULD be stored rather than
+									Deflate-compressed.</p>
 
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
 									of embedded fonts referenced by an [=EPUB publication=] to make them more difficult
@@ -2523,7 +2508,7 @@
 										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
 									deobfuscate.</p>
 
-								<p id="encryption-restrictions">EPUB creators MUST NOT encrypt the following files:</p>
+								<p id="encryption-restrictions">The following files MUST NOT be encrypted:</p>
 
 								<ul class="nomark">
 									<li>
@@ -2550,10 +2535,9 @@
 									<li> [= <code>package document</code> =] </li>
 								</ul>
 
-								<p>EPUB creators MAY subsequently encrypt signed resources using the Decryption
-									Transform for XML Signature&#160;[[xmlenc-decrypt]]. This feature enables a
-									[=reading system=] to distinguish data encrypted before signing from data encrypted
-									after signing.</p>
+								<p>The Decryption Transform for XML Signature&#160;[[xmlenc-decrypt]] MAY subsequently
+									be used to encrypt signed resources. This feature enables a [=reading system=] to
+									distinguish data encrypted before signing from data encrypted after signing.</p>
 
 								<aside class="example" title="An encrypted image">
 									<p>In this example, adapted from <a data-cite="xmlenc-core1#sec-eg-Symmetric-Key"
@@ -2601,12 +2585,12 @@
 								data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L234">
 								<h6>Order of compression and encryption</h6>
 
-								<p>When stored in an [=OCF ZIP container=], [=EPUB creators=] SHOULD compress streams of
-									data with [=non-codec=] content types before encrypting them. EPUB creators MUST use
-									Deflate compression. This practice ensures that file entries stored in the ZIP
-									container have a smaller size.</p>
+								<p>When stored in an [=OCF ZIP container=], streams of data with [=non-codec=] content
+									types SHOULD be compressed before encrypting them. Deflate compression MUST be used.
+									This practice ensures that file entries stored in the ZIP container have a smaller
+									size.</p>
 
-								<p>EPUB creators SHOULD NOT compress streams of data with [=codec=] content types before
+								<p>Streams of data with [=codec=] content types SHOULD NOT be compressed before
 									encrypting them. In such cases, additional compression introduces unnecessary
 									processing overhead at production time (especially with large resource files) and
 									impacts audio/video playback performance at consumption time. In some cases, the
@@ -2615,13 +2599,13 @@
 									ranges), due to the technical impossibility to determine the length of the full
 									resource ahead of media playback (e.g. HTTP Content-Length header).</p>
 
-								<p>When EPUB creators compress streams of data before encrypting, they SHOULD provide
-									additional <code>EncryptionProperties</code> metadata to specify the size of the
-									initial resource (i.e., before compression and encryption), as per the
-										<code>Compression</code> XML element defined below. When EPUB creators do not
-									compress streams of data before encrypting, they MAY provide the additional
-										<code>EncryptionProperties</code> metadata to specify the size of the initial
-									resource (i.e., before encryption).</p>
+								<p>When streams of data are compressed before encrypting, additional
+										<code>EncryptionProperties</code> metadata SHOULD be provided to specify the
+									size of the initial resource (i.e., before compression and encryption), as per the
+										<code>Compression</code> XML element defined below. When streams of data are not
+									compresed before encrypting, additional <code>EncryptionProperties</code> metadata
+									MAY be provided to specify the size of the initial resource (i.e., before
+									encryption).</p>
 
 								<dl class="elemdef" id="elemdef-enc-Compression">
 									<dt>Element Name:</dt>
@@ -2669,8 +2653,8 @@
 								</dl>
 
 								<aside class="example" title="A compressed video">
-									<p>In this example, the EPUB creator has Deflate compressed the MP4 file. Its
-										original size was 3500000 bytes.</p>
+									<p>In this example, the MP4 file has been Deflate compressed. Its original size was
+										3500000 bytes.</p>
 
 									<pre>&lt;encryption
     xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
@@ -2716,8 +2700,8 @@
 							<p>The OPTIONAL <code>metadata.xml</code> file in the <code>META-INF</code> directory is
 								only for container-level metadata.</p>
 
-							<p>If [=EPUB creators=] include a <code>metadata.xml</code> file, they SHOULD use only
-								namespace-qualified elements [[xml-names]] in it. The file SHOULD contain the <a
+							<p>If a <code>metadata.xml</code> file is included, it SHOULD include only
+								namespace-qualified elements [[xml-names]]. The file SHOULD contain the <a
 									data-cite="xml#dt-root">root element</a> [[xml]] <code>metadata</code> in the
 								namespace <code>http://www.idpf.org/2013/metadata</code>, but this specification allows
 								other root elements for backwards compatibility.</p>
@@ -2734,9 +2718,9 @@
 									<code>META-INF</code> directory for the trusted exchange of [=EPUB publications=]
 								among rights holders, intermediaries, and users.</p>
 
-							<p>When [=EPUB creators=] do not include a <code>rights.xml</code> file, no part of the
-								[=OCF abstract container=] is rights governed at the container level. Rights expressions
-								might exist within the EPUB publications.</p>
+							<p>When a <code>rights.xml</code> file is not included, no part of the [=OCF abstract
+								container=] is rights governed at the container level. Rights expressions might exist
+								within the EPUB publication.</p>
 						</section>
 
 						<section id="sec-container-metainf-signatures.xml">
@@ -2789,44 +2773,45 @@
 								</dl>
 
 								<p>The <code>signature</code> element contains child elements of type
-										<code>Signature</code>, as defined by [[xmldsig-core1]]. [=EPUB creators=] can
-									apply signatures to an EPUB publication as a whole or to its parts, and can specify
-									the signing of any kind of data (i.e., not just XML).</p>
+										<code>Signature</code>, as defined by [[xmldsig-core1]]. Signatures can be
+									applied to an EPUB publication as a whole or to its parts, and can specify the
+									signing of any kind of data (i.e., not just XML).</p>
 
 								<p class="note">An <a href="#app-schema-signatures">XML Schema</a> also informally
 									defines the content of the <code>signatures.xml</code> file.</p>
 
-								<p>When an EPUB creator does not include a <code>signatures.xml</code> file, they are
-									not signing any part of the [=OCF abstract container=] at the container level.
-									Digital signing might exist within the EPUB publication.</p>
+								<p>When a <code>signatures.xml</code> file is not included, no part of the [=OCF
+									abstract container=] is being signed at the container level. Digital signing might
+									exist within the EPUB publication.</p>
 
-								<p id="sig-container">When an EPUB creator creates a data signature for the OCF abstract
-									container, they SHOULD add the signature as the last child <code>Signature</code>
-									element of the <code>signatures</code> element.</p>
+								<p id="sig-container">When a data signature is created for the OCF abstract container,
+									the signature SHOULD be stored in the last child <code>Signature</code> element of
+									the <code>signatures</code> element.</p>
 
 								<div class="note">
 									<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by
 										URL [[url]] the data to which the signature applies, using the [[xmldsig-core1]]
 											<code>Manifest</code> element and its <code>Reference</code> sub-elements.
-										EPUB creator may sign individual container files separately or together.
-										Separately signing each file creates a digest value for the resource that
-										reading systems can validate independently. This approach might make a Signature
-										element larger. If EPUB creators sign files together, they can list the set of
-										signed files in a single XML Signature <code>Manifest</code> element and
-										reference them by one or more <code>Signature</code> elements.</p>
+										Individual container files can be signed separately or together. Separately
+										signing each file creates a digest value for the resource that reading systems
+										can validate independently. This approach might make a Signature element larger.
+										If the files are signed together, list the set of signed files in a single XML
+										Signature <code>Manifest</code> element and reference them from one or more
+											<code>Signature</code> elements.</p>
 								</div>
 
-								<p id="sig-restrictions">EPUB creators can sign any or all files in the OCF abstract
-									container in their entirety, except for the <code>signatures.xml</code> file since
-									that file will contain the computed signature information. Whether and how EPUB
-									creators sign the <code>signatures.xml</code> file depends on their objective.</p>
+								<p id="sig-restrictions">Any or all files in the OCF abstract container can be signed in
+									their entirety, except for the <code>signatures.xml</code> file since that file will
+									contain the computed signature information. Whether and how the
+										<code>signatures.xml</code> file is signed depends on the objective of the
+									signer.</p>
 
-								<p>If the EPUB creator wants to allow signatures to be added or removed from the OCF
-									abstract container without invalidating their signature, they SHOULD NOT sign the
+								<p>To allow signatures to be added or removed from the OCF abstract container without
+									invalidating their signature, the signer SHOULD NOT sign the
 										<code>signatures.xml</code> file.</p>
 
-								<p>If the EPUB creator wants any addition or removal of a signature to invalidate their
-									signature, they can use the Enveloped Signature transform defined in <a
+								<p>To have any addition or removal of a signature invalidate their signature, the signer
+									can use the Enveloped Signature transform defined in <a
 										data-cite="xmldsig-core#sec-EnvelopedSignature">Section 6.6.4</a> of
 									[[xmldsig-core1]] to sign the entire pre-existing signature file excluding the
 										<code>Signature</code> being created. This transform would sign all previous
@@ -2834,10 +2819,10 @@
 									package.</p>
 
 								<div class="note">
-									<p>If the EPUB creator wants the removal of an existing signature to invalidate
-										their signature, but also wants to allow the addition of signatures, they could
-										use an XPath transform to sign just the existing signatures. The details of such
-										a transform are outside the scope of this specification, however.</p>
+									<p>If the signer wants the removal of an existing signature to invalidate their
+										signature, but also wants to allow the addition of signatures, they could use an
+										XPath transform to sign just the existing signatures. The details of such a
+										transform are outside the scope of this specification, however.</p>
 								</div>
 
 								<p>The [[xmldsig-core1]] specification does not associate any semantics with a
@@ -2980,15 +2965,14 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-zip-fld-version">In the local file header table, [=EPUB creators=] MUST set
-								the <code>version needed to extract</code> fields to the values <code>10</code>,
-									<code>20</code> or <code>45</code> to match the maximum version level needed by the
-								given file (e.g., <code>20</code> for Deflate, <code>45</code> for ZIP64).</p>
+							<p id="confreq-zip-fld-version">In the local file header table, the <code>version needed to
+									extract</code> fields MUST be set to <code>10</code>, <code>20</code> or
+									<code>45</code> to match the maximum version level needed by the given file (e.g.,
+									<code>20</code> for Deflate, <code>45</code> for ZIP64).</p>
 						</li>
 						<li>
-							<p id="confreq-zip-fld-comp">In the local file header table, EPUB creators MUST set the
-									<code>compression</code> method field to the values <code>0</code> or
-								<code>8</code>.</p>
+							<p id="confreq-zip-fld-comp">In the local file header table, the <code>compression</code>
+								method field MUST be set to <code>0</code> or <code>8</code>.</p>
 						</li>
 					</ul>
 				</section>
@@ -2997,8 +2981,8 @@
 					data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L317,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L323,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L329,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L335,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L341,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L347">
 					<h4>OCF ZIP container media type identification</h4>
 
-					<p>[=EPUB creators=] MUST include the <code>mimetype</code> file as the first file in the [=OCF ZIP
-						container=]. In addition:</p>
+					<p>The <code>mimetype</code> file MUST be the first file in the [=OCF ZIP container=]. In
+						addition:</p>
 
 					<ul>
 						<li>The contents of the <code>mimetype</code> file MUST be the MIME media type [[rfc2046]]
@@ -3006,8 +2990,8 @@
 						<li>The <code>mimetype</code> file MUST NOT contain any leading or trailing padding or
 							whitespace.</li>
 						<li>The <code>mimetype</code> file MUST NOT begin with the Unicode byte order mark U+FEFF.</li>
-						<li>EPUB creators MUST NOT compress or encrypt the <code>mimetype</code> file.</li>
-						<li>EPUB creators MUST NOT include an extra field in its ZIP header.</li>
+						<li>The <code>mimetype</code> file MUST NOT be compressed or encrypted.</li>
+						<li>The <code>mimetype</code> file MUST NOT include an extra field in its ZIP header.</li>
 					</ul>
 
 					<div class="note">
@@ -3023,10 +3007,9 @@
 				<div class="caution">
 					<p>Better methods of protecting fonts exist. Both [[woff]] and [[woff2]] fonts, for example, allow
 						the embedding of licensing information and provide some protection through font table
-						compression. The use of remotely hosted fonts also allows for font subsetting. [=EPUB creators=]
-						are advised to use font obfuscation as defined in this section only when no other options are
-						available to them. See also the <a href="#fobfus-limitations">limitations of
-						obfuscation</a>.</p>
+						compression. The use of remotely hosted fonts also allows for font subsetting. It is advised to
+						use font obfuscation as defined in this section only when no other options are available. See
+						also the <a href="#fobfus-limitations">limitations of obfuscation</a>.</p>
 				</div>
 
 				<section id="fobfus-intro" class="informative">
@@ -3038,11 +3021,11 @@
 						(e.g., a folder).</p>
 
 					<p>While this simplicity of ZIP files is quite useful, it also poses a problem when ease of
-						extraction of fonts is not a desired side-effect of not encrypting them. An [=EPUB creator=] who
-						wishes to include a third-party font, for example, typically does not want that font extracted
-						and re-used by others. More critically, many commercial fonts allow embedding, but embedding a
-						font implies making it an integral part of the [=EPUB publication=], not just providing the
-						original font file along with the content.</p>
+						extraction of fonts is not a desired side-effect of not encrypting them. When a publisher wishes
+						to include a third-party font, for example, they typically do not want that font extracted and
+						re-used by others. More critically, many commercial fonts allow embedding, but embedding a font
+						implies making it an integral part of the [=EPUB publication=], not just providing the original
+						font file along with the content.</p>
 
 					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
 						in the [=OCF ZIP container=] is insufficient to signify that the font cannot be reused in other
@@ -3083,12 +3066,12 @@
 					</ul>
 
 					<p>As a result, whether this method of obfuscation satisfies the requirements of individual font
-						licenses remains a question for the licensor and licensee. [=EPUB creators=] are responsible for
+						licenses remains a question for the licensor and licensee. Publishers are responsible for
 						ensuring their use of obfuscation meets font licensing requirements.</p>
 
-					<p>EPUB creators should also be aware that obfuscation may lead to interoperability issues in
-						reading systems as reading systems are not required to deobfuscate fonts. As a result, the
-						visual presentation of their publications may differ from reading system to reading system.</p>
+					<p>It is also worth noting that obfuscation can lead to interoperability issues in reading systems
+						as they are not required to deobfuscate fonts. As a result, the visual presentation of a
+						publication could differ from reading system to reading system.</p>
 
 					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a
 						general-purpose mechanism for obfuscating any resource in the EPUB container.</p>
@@ -3097,17 +3080,16 @@
 				<section id="obfus-keygen">
 					<h4>Obfuscation key</h4>
 
-					<p id="obfus-key-unique-id" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">[=EPUB
-						creators=] MUST derive the key used in the obfuscation algorithm from the [=unique
-						identifier=].</p>
+					<p id="obfus-key-unique-id" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">The key
+						used in the obfuscation algorithm MUST be derived the from the [=unique identifier=].</p>
 
 					<p>All whitespace characters, as defined in <a data-cite="xml#sec-common-syn">section 2.3 of the XML
 							1.0 specification</a> [[xml]], MUST be removed from this identifier — specifically, the
 						Unicode code points <code>U+0020</code>, <code>U+0009</code>, <code>U+000D</code> and
 							<code>U+000A</code>.</p>
 
-					<p>EPUB creators MUST generate a SHA-1 digest of the UTF-8 representation of the resulting string as
-						specified by the Secure Hash Standard [[fips-180-4]]. They can then use this digest as the key
+					<p>A SHA-1 digest of the UTF-8 representation of the resulting string, as specified by the Secure
+						Hash Standard [[fips-180-4]], MUST then be generated. This digest can then be used as the key
 						for the algorithm.</p>
 				</section>
 
@@ -3127,10 +3109,10 @@
 						the source. Once 1040 bytes are encoded in this way (or the end of the source is reached),
 						directly copy any remaining data in the source to the destination.</p>
 
-					<p>[=EPUB creators=] MUST obfuscate fonts before compressing and adding them to the [=OCF ZIP
-						container=]. Note that as obfuscation is not encryption, this requirement is not a violation of
-						the one in <a href="#sec-container-metainf-encryption.xml"></a> to compress fonts before
-						encrypting them.</p>
+					<p>Fonts MUST be obfuscated before compressing and adding them to the [=OCF ZIP container=]. Note
+						that as obfuscation is not encryption, this requirement is not a violation of the one in <a
+							href="#sec-container-metainf-encryption.xml"></a> to compress fonts before encrypting
+						them.</p>
 
 					<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
 
@@ -3183,14 +3165,14 @@
 							class="filename">encryption.xml</code> file accompanying the [=EPUB publication=] (see <a
 							href="#sec-container-metainf-encryption.xml"></a>).</p>
 
-					<p>[=EPUB creators=] MUST specify an <code>EncryptedData</code> element for each obfuscated font.
-						Each <code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
+					<p>An <code>EncryptedData</code> element MUST be specified for each obfuscated font. Each
+							<code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
 						element whose <code>Algorithm</code> attribute has the value
 							<code>http://www.idpf.org/2008/embedding</code>. The presence of this attribute signals the
 						use of the algorithm described in this specification.</p>
 
-					<p>EPUB creators MUST list the path to the obfuscated font in the <code>CipherReference</code> child
-						of the <code>CipherData</code> element. As the obfuscation algorithm is restricted to fonts, the
+					<p>The <code>CipherReference</code> child of the <code>CipherData</code> element MUST list the path
+						to the obfuscated font. As the obfuscation algorithm is restricted to fonts, the
 							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a
 							href="#cmt-grp-font">Font core media type resource</a>.</p>
 
@@ -3209,9 +3191,9 @@
 &lt;/encryption&gt;</pre>
 					</aside>
 
-					<p>To prevent trivial copying of the embedded font to other EPUB publications, EPUB creators MUST
-						NOT provide the <a href="#obfus-keygen">obfuscation key</a> in the <code>encryption.xml</code>
-						file.</p>
+					<p>To prevent trivial copying of the embedded font to other EPUB publications, the <a
+							href="#obfus-keygen">obfuscation key</a> MUST NOT be provided in the
+							<code>encryption.xml</code> file.</p>
 				</section>
 			</section>
 		</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -200,9 +200,9 @@
 				<div class="caution">
 					<p>The technologies EPUB 3 builds on are constantly evolving. Some, typically referred to as
 						"living" or "evergreen" standards, are subject to change daily and their impact on the validity
-						of EPUB publications is immediate. Others are updated less frequently and the changes may not
+						of EPUB publications is immediate. Others are updated less frequently and the changes might not
 						affect [=EPUB publications=] until EPUB 3 undergoes a new revision.</p>
-					<p>In all cases, it is possible that previously valid features may become obsolete (e.g., due to a
+					<p>In all cases, it is possible that previously valid features might become obsolete (e.g., due to a
 						lack of support or because of security issues). Consequently, it is advised to only use features
 						without broad support sparingly and keep [=EPUB conformance checkers=] up to date.</p>
 				</div>
@@ -227,7 +227,7 @@
 							syntax</a>. The Working Group recognizes that XML remains an integral technology in the
 						publishing ecosystem and will not remove support for the XML syntax from EPUB 3. Regardless,
 						publishers that prefer to keep using the XML syntax will need to monitor future support for it,
-						and may have to adapt to the HTML syntax to gain access to some features of [[html]].</p>
+						and might have to adapt to the HTML syntax to gain access to some features of [[html]].</p>
 
 					<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
 						<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. The above paragraph
@@ -283,10 +283,10 @@
 
 					<p>This specification refers to the [[url]] standard for terminology and processing related to URLs
 						expressed in [=EPUB publications=]. It is anticipated that new and revised web formats will
-						adopt this standard, but until then this may put this specification in conflict with the
+						adopt this standard, but until then this could put this specification in conflict with the
 						internal requirements for some formats (e.g., valid relative paths), specifically with respect
 						to the use of internationalized URLs. If a format does not allow internationalized URLs (i.e.,
-						URLs must conform to [[rfc3986]] or earlier), that requirement takes precedence within those
+						URLs have to conform to [[rfc3986]] or earlier), that requirement takes precedence within those
 						resources.</p>
 				</section>
 			</section>
@@ -526,7 +526,7 @@
 					<dd>
 						<p>A resource that is only referenced from a [=package document=] [^link^] element (i.e., not
 							also used in the rendering of an [=EPUB publication=].</p>
-						<p>Linked resources are not [=publication resources=] but may be stored in the [=EPUB
+						<p>Linked resources are not [=publication resources=] but can be stored in the [=EPUB
 							container=]. They do not require fallbacks.</p>
 					</dd>
 
@@ -571,13 +571,13 @@
 					</dt>
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
-							of an [=EPUB publication=]. In the absence of this resource, [=reading systems=] may not
+							of an [=EPUB publication=]. In the absence of this resource, [=reading systems=] might not
 							render the EPUB publication as intended. Examples of publication resources include the
 							[=package document=], [=EPUB content documents=], CSS Style Sheets, audio, video, images,
 							embedded fonts, and scripts.</p>
 						<p>The package document [=EPUB manifest | manifest=] has to include a list of all publication
 							resources and they typically have to be bundled in the [=EPUB container=] (the exception
-							being they may locate resources listed in <a href="#sec-resource-locations"></a> outside the
+							being they can locate resources listed in <a href="#sec-resource-locations"></a> outside the
 							EPUB container).</p>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
@@ -671,8 +671,8 @@
 				<p>In [=package document=] metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
 						prefixes</a> are used without declaration.</p>
 
-				<p>References to Dublin Core elements [[dcterms]] use the <code>dc:</code> prefix. This prefix must be
-					declared in the [=package document=] for their use to be valid
+				<p>References to Dublin Core elements [[dcterms]] use the <code>dc:</code> prefix. This prefix have to
+					be declared in the [=package document=] for their use to be valid
 						(<code>xmlns:dc="http://purl.org/dc/elements/1.1/"</code>)</p>
 
 				<p>The <code>epub</code> namespace prefix [[xml-names]] is also used on elements and attributes without
@@ -775,9 +775,9 @@
 						[=exempt resources=]).</li>
 				</ul>
 
-				<p>The same resource may exist on more than one plane and will be referred to differently in this
+				<p>The same resource can exist on more than one plane and will be referred to differently in this
 					specification depending on which plane is being discussed. For example, a core media type resource
-					used in the rendering of an EPUB content document (on the content plane) may also be a foreign
+					used in the rendering of an EPUB content document (on the content plane) can also be a foreign
 					content document if it is also listed in the spine (the spine plane).</p>
 
 				<p>The following sections describe these planes in more detail.</p>
@@ -823,7 +823,7 @@
 
 					<p>Since linked resources are not essential to the rendering of an EPUB publication, there are no
 						requirements on where they are located and consequently no special naming of them based on their
-						location. They may be located within the EPUB container or outside it.</p>
+						location. They can be located within the EPUB container or outside it.</p>
 
 					<div class="note">
 						<p>Hyperlinked content outside the EPUB container (e.g., web pages) are not publication
@@ -839,7 +839,7 @@
 						default reading order established by the [=EPUB spine | spine=], which includes both <a
 							href="#attrdef-itemref-linear">linear and non-linear content</a>. The spine instructs
 						[=reading systems=] on how to load these resources as the user progresses through the [=EPUB
-						publication=]. Although many resources may be bundled in an [=EPUB container=], they are not all
+						publication=]. Although many resources can be bundled in an [=EPUB container=], they are not all
 						allowed by default in the spine.</p>
 
 					<p>EPUB 3 defines a special class of resources called [=EPUB content documents=] that can be used in
@@ -848,15 +848,15 @@
 
 					<p>To use any other type of resource in the spine, called a [=foreign content document=], requires
 						including a <a href="#sec-manifest-fallbacks">manifest fallback</a> to an EPUB content document.
-						In this model, the [=EPUB manifest | manifest=] entry for the foreign content document must
+						In this model, the [=EPUB manifest | manifest=] entry for the foreign content document has to
 						include a <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to
 						the next possible resource for reading systems to try when they do not support its format.
 						Although not common, a fallback resource can specify another fallback, thereby making chains
-						many resources deep. The one requirement is that there must be at least one EPUB content
+						many resources deep. The one requirement is that there has to be at least one EPUB content
 						document in a [=manifest fallback chain=].</p>
 
 					<p>Although they are not directly listed in the spine, all of the resources in the fallback chain
-						are considered part of the spine, and by extension part of the spine plane, since any may be
+						are considered part of the spine, and by extension part of the spine plane, since any can be
 						used by a reading system.</p>
 
 					<p>This extensibility model allows experimentation with formats while ensuring that reading systems
@@ -1152,7 +1152,7 @@
 				<div class="note">
 					<p>Inclusion as a core media type resource does not mean that all reading systems will support the
 						rendering of a resource. Reading system support also depends on the capabilities of the
-						application (e.g., a reading system with a [=viewport=] must support image core media type
+						application (e.g., a reading system with a [=viewport=] has to support image core media type
 						resources, but a reading system without a viewport does not). Refer to <a
 							data-cite="epub-rs-34#sec-epub-rs-conf-cmt">Core media types</a> [[epub-rs-34]] for more
 						information about which reading systems rendering capabilities require support for which core
@@ -1625,11 +1625,11 @@
 			<section id="sec-ocf-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>OCF is the required container technology for [=EPUB publications=]. OCF may play a role in the
+				<p>OCF is the required container technology for [=EPUB publications=]. OCF can play a role in the
 					following workflows:</p>
 
 				<ul>
-					<li>During the preparation steps in producing an EPUB publication, OCF may be used as the container
+					<li>During the preparation steps in producing an EPUB publication, OCF can be used as the container
 						format when exchanging in-progress publications between different individuals and/or different
 						organizations.</li>
 					<li>When providing an EPUB publication from publisher or conversion house to the distribution or
@@ -1769,7 +1769,7 @@
 						</li>
 						<li>
 							<p id="ocf-fn-chars">File names MUST NOT use the following [[unicode]] characters, as
-								commonly used operating systems may not support these characters consistently:</p>
+								commonly used operating systems might not support these characters consistently:</p>
 							<ul>
 								<li>
 									<p>SOLIDUS: <code>/</code> (<code>U+002F</code>)</p>
@@ -1929,9 +1929,9 @@
 
 						<p>However, a reading system cannot arbitrarily use any URL, but one that honors the constraints
 							defined above. These constraints ensure that any relative URL string found in the EPUB will
-							always be parsed to a URL of a resource within the container (which may or may not exist).
-							The primary reason for these constraints is to avoid potential run-time security issues that
-							would be caused by parsed URLs "leaking" outside the container files.</p>
+							always be parsed to a URL of a resource within the container (which might or might not
+							exist). The primary reason for these constraints is to avoid potential run-time security
+							issues that would be caused by parsed URLs "leaking" outside the container files.</p>
 
 						<p>For example, URLs like <code>https://localhost:12345/</code> or
 								<code>https://www.example.org:12345/</code> honor these properties. But URLs like
@@ -1944,7 +1944,7 @@
 					</div>
 
 					<div class="note">
-						<p>Parsing may replace some characters in the file path by their <a
+						<p>Parsing might replace some characters in the file path by their <a
 								data-cite="url#percent-encode">percent encoded</a> alternative. For example,
 								<code>A/B/C/file&#160;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>.
 						</p>
@@ -1972,7 +1972,7 @@
 						</li>
 
 						<li>
-							<p>Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that must be
+							<p>Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that MUST be
 								used to parse <var>url</var> as defined by the context (document or environment) where
 									<var>url</var> is used, and according to the content URL of the [=package document=]
 								(see <a href="#sec-parse-package-urls"></a>).</p>
@@ -2001,13 +2001,13 @@
 							<details class="explanation">
 								<summary>Explanation</summary>
 								<p>The reasons to repeat the same steps twice with different, and artificial, settings
-									of the container root URL is to avoid collision which may occur if the
+									of the container root URL is to avoid collision which can occur if the
 										<var>url</var> string also includes <code>/A/</code>. Consider, for example, the
 									case where <var>url</var> is <code>../../A/doc.xhtml</code>.</p>
 							</details>
 						</li>
 
-						<li>Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that must be
+						<li>Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that MUST be
 							used to parse <var>url</var> as defined by the context (document or environment) where
 								<var>url</var> is used, and according to the content URL of the package document (see <a
 								href="#sec-parse-package-urls"></a>).</li>
@@ -3058,7 +3058,7 @@
 
 					<ul>
 						<li>applying the deobfuscation algorithm to extract the raw font file;</li>
-						<li>accessing the deobfuscated font through a [=reading system=] that must deobfuscate it to
+						<li>accessing the deobfuscated font through a [=reading system=] that has to deobfuscate it to
 							render the content (e.g., by accessing the resources through a browser-based reading
 							system); or</li>
 						<li>accessing the deobfuscated font through authoring tools that provide the visual rendering of
@@ -3751,7 +3751,7 @@
 
 					<p>These elements MUST have non-empty values after <a
 							data-lt="strip leading and trailing ascii whitespace">leading and trailing ASCII
-							whitespace</a>&#160;[[infra]] is stripped (i.e., they must consist of at least one
+							whitespace</a>&#160;[[infra]] is stripped (i.e., they have to consist of at least one
 						non-whitespace character).</p>
 
 					<p>Whitespace within these element values is not significant. Sequences of one or more whitespace
@@ -3958,7 +3958,7 @@
 							<div class="note">
 								<p>Although it is possible to include more than one <code>dc:title</code> element for
 									multipart titles, reading system support for additional <code>dc:title</code>
-									elements is inconsistent. Reading systems may ignore the additional segments or
+									elements is inconsistent. Reading systems might ignore the additional segments or
 									combine them in unexpected ways.</p>
 
 								<p>For example, the following example shows a basic multipart title:</p>
@@ -4740,7 +4740,7 @@ XHTML:
 					<aside class="example" title="Declaring a new link relationship">
 						<p>In this example, the <code>link</code> element is used to associate an author's home page
 							using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
-								href="#sec-metadata-reserved-prefixes">reserved prefix</a>, it must be declared in the
+								href="#sec-metadata-reserved-prefixes">reserved prefix</a>, it has to be declared in the
 								<a href="#attrdef-package-prefix">prefix attribute</a>.</p>
 
 						<pre>&lt;package
@@ -4860,7 +4860,7 @@ XHTML:
 								Container</a> (i.e., files in the <code>META-INF</code> directory, and the
 								<code>mimetype</code> file) are restricted from inclusion.</p>
 
-						<p>Failure to provide a complete manifest of publication resources may lead to rendering issues.
+						<p>Failure to provide a complete manifest of publication resources can lead to rendering issues.
 							[=Reading systems=] might not unzip such resources or could prevent access to them for
 							security reasons.</p>
 					</div>
@@ -5411,7 +5411,7 @@ No Entry</pre>
 
 					<p>Although the <code>page-progression-direction</code> attribute sets the global flow direction,
 						individual EPUB content documents and parts of EPUB content documents MAY override this setting
-						(e.g., via the <code>writing-mode</code> CSS property). Reading systems may also provide
+						(e.g., via the <code>writing-mode</code> CSS property). Reading systems might also provide
 						mechanisms to override the default direction (e.g., buttons or settings that allow the
 						application of alternate style sheets).</p>
 
@@ -5501,8 +5501,8 @@ No Entry</pre>
 
 					<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the referenced
 							<code>item</code> contains content that contributes to the primary reading order and that
-						[=reading systems=] must read sequentially ("<code>yes</code>"), or auxiliary content that
-						enhances or augments the primary content that reading systems can access out of sequence
+						[=reading systems=] are expected to read sequentially ("<code>yes</code>"), or auxiliary content
+						that enhances or augments the primary content that reading systems can access out of sequence
 							("<code>no</code>"). Examples of auxiliary content include notes, descriptions, and answer
 						keys.</p>
 
@@ -5511,9 +5511,9 @@ No Entry</pre>
 						might, for example, present in a popup window or omit from an aural rendering.</p>
 
 					<p>Specifying that content is non-linear does not require reading systems to present it in a
-						specific way, however; it is only a hint to the purpose. Reading systems may present non-linear
-						content where it occurs in the spine, for example, or may skip it until users reach the end of
-						the spine.</p>
+						specific way, however; it is only a hint to the purpose. Reading systems might present
+						non-linear content where it occurs in the spine, for example, or might skip it until users reach
+						the end of the spine.</p>
 
 					<div class="note">
 						<p>It is advised to list non-linear content at the end of the spine except when it makes sense
@@ -5696,9 +5696,9 @@ No Entry</pre>
 					<p>EPUB 3 reading systems will not use these features when presenting publications to users.</p>
 
 					<div class="note">
-						<p>[=EPUB conformance checkers=] should not issue alerts about the presence of legacy features
-							in an [=EPUB publication=], as their inclusion is valid for backwards compatibility. EPUB
-							conformance checkers must issue alerts if a legacy feature does not conform to its
+						<p>The Working Group advises that [=EPUB conformance checkers=] not issue alerts about the
+							presence of legacy features in [=EPUB publications=], as their inclusion is valid for
+							backwards compatibility. Only issue alerts if a legacy feature does not conform to its
 							definition or otherwise breaks a usage requirement.</p>
 					</div>
 				</section>
@@ -5991,8 +5991,8 @@ No Entry</pre>
 							<p id="confreq-html-vocab-base"> The [[html]] <a data-lt="base"><code>base</code>
 								</a> element can be used to specify the [=document base URL=] for the purposes of
 								parsing URLs. When using it in an [=EPUB publication=], the interpretation of the
-									<code>base</code> element may inadvertently result in references to [=remote
-								resources=]. It may also cause [=reading systems=] to misinterpret the location of
+									<code>base</code> element could inadvertently result in references to [=remote
+								resources=]. It could also cause [=reading systems=] to misinterpret the location of
 								hyperlinks (e.g., relative links to other documents in the publication might appear as
 								links to a web site if the <code>base</code> element specifies an absolute URL). To
 								avoid significant interoperability issues, use of the <code>base</code> element is
@@ -6025,7 +6025,7 @@ No Entry</pre>
 				<h3>SVG content documents</h3>
 
 				<div class="caution">
-					<p>[=Reading systems=] may not support all the features of [[svg]] or support them across all
+					<p>[=Reading systems=] might not support all the features of [[svg]] or support them across all
 						platforms that reading systems run on. When utilizing such features, consider the risks to
 						interoperability and document longevity.</p>
 				</div>
@@ -6221,7 +6221,7 @@ No Entry</pre>
 						<ul>
 							<li>
 								<p>Reading system-induced pagination can interact poorly with style sheets as reading
-									systems sometimes paginate using columns. This may result in incorrect values for
+									systems sometimes paginate using columns. This could result in incorrect values for
 									viewport sizes. Fixed and absolute positioning are particularly problematic.</p>
 							</li>
 							<li>
@@ -6256,9 +6256,9 @@ No Entry</pre>
 								href="#css-prefixes"></a>.</p>
 
 						<div class="caution">
-							<p>The Working Group recommends anyone still using <code>-epub-</code> prefixed properties
-								move to the unprefixed versions as soon as support allows, as the Working Group does not
-								anticipate supporting them in the next major version of EPUB.</p>
+							<p>The Working Group recommends switching to the unprefixed versions as soon as CSS support
+								allows as these prefixed properties are not expected to be maintained in the next major
+								version of EPUB.</p>
 
 							<p>This specification retains the widely used prefixed properties from
 								[[epubcontentdocs-301]] but removes support for the less-used ones. It is strongly
@@ -6302,7 +6302,7 @@ No Entry</pre>
 							information).</p>
 
 						<div class="note">
-							<p>Reading systems may render scripted content documents in a manner that disables other
+							<p>Reading systems might render scripted content documents in a manner that disables other
 								EPUB capabilities and/or provides a different rendering and user experience (e.g., by
 								disabling pagination).</p>
 						</div>
@@ -6321,8 +6321,8 @@ No Entry</pre>
 						</ul>
 
 						<div class="note">
-							<p>Scripts may execute in other contexts, but [=reading system=] support for these contexts
-								is optional. For example, a scripted SVG document may be referenced from an [[html]]
+							<p>Scripts can execute in other contexts, but [=reading system=] support for these contexts
+								is optional. For example, a scripted SVG document might be referenced from an [[html]]
 								[^object^] element.</p>
 							<p>Refer to the <a data-cite="epub-rs-34#sec-scripted-content">processing of scripts</a>
 								[[epub-rs-34]] for more information.</p>
@@ -6445,7 +6445,7 @@ No Entry</pre>
 					thereby ensuring increased usability and accessibility for the user.</p>
 
 				<p>The EPUB navigation document is a special type of [=XHTML content document=] that defines the <a
-						href="#sec-nav-toc">table of contents</a> for [=reading systems=]. It may also include other
+						href="#sec-nav-toc">table of contents</a> for [=reading systems=]. It can also include other
 					specialized navigation elements, such as a <a href="#sec-nav-pagelist">page list</a> and a list of
 					key <a href="#sec-nav-landmarks">landmarks</a>. These navigation elements have <a
 						href="#sec-nav-def-model">additional restrictions</a> on their content to facilitate their
@@ -6459,8 +6459,8 @@ No Entry</pre>
 					page list) can be hidden using the <a href="#sec-nav-doc-use-spine"><code>hidden</code>
 						attribute</a>.</p>
 
-				<p>Note that reading systems may strip scripting, styling, and HTML formatting as they generate
-					navigational interfaces from information found in the EPUB navigation document, and this may make
+				<p>Note that reading systems might strip scripting, styling, and HTML formatting as they generate
+					navigational interfaces from information found in the EPUB navigation document, and this could make
 					the result difficult to read. If such formatting and functionality is necessary, then the EPUB
 					navigation document can also be included in the [=EPUB spine | spine=]. The use of progressive
 					enhancement techniques for scripting and styling of the navigation document will help ensure the
@@ -6707,10 +6707,9 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p>An EPUB navigation document may contain at most one navigation aid for each of these types.</p>
-
-					<p>The EPUB navigation document may include additional navigation types. See <a
-							href="#sec-nav-def-types-other"></a> for more information.</p>
+					<p>An EPUB navigation document can contain at most one navigation aid for each of these types. It
+						can also include additional navigation types. See <a href="#sec-nav-def-types-other"></a> for
+						more information.</p>
 				</section>
 
 				<section id="sec-nav-toc">
@@ -6741,8 +6740,8 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L162,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L168">
 					<h4>The <code>page-list nav</code> element </h4>
 
-					<p>The page list provides navigation to static page boundaries in the content. These boundaries may
-						correspond to a statically paginated source such as print or may be defined exclusively for the
+					<p>The page list provides navigation to static page boundaries in the content. These boundaries
+						either correspond to a statically paginated source such as print or are exclusively for the
 						[=EPUB publication=].</p>
 
 					<p>The page list is defined in a [^nav^] element [[html]] whose [^/epub:type^] attribute is set to
@@ -6825,7 +6824,7 @@ No Entry</pre>
 							systems often use this landmark to automatically jump users past the front matter when they
 							begin reading.</li>
 						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a>&#160;[[?epub-ssv-11]] — If the table
-							of contents is available in the spine, reading systems may use this landmark to take users
+							of contents is available in the spine, reading systems can use this landmark to take users
 							to the document containing it.</li>
 					</ul>
 
@@ -6911,7 +6910,7 @@ No Entry</pre>
 				<div class="note">
 					<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
 							property</a> [[csssnapshot]] controls the visual rendering of EPUB navigation documents in
-						[=reading systems=] with [=viewports=], reading systems without viewports may not support CSS.
+						[=reading systems=] with [=viewports=], reading systems without viewports might not support CSS.
 						The <code>hidden</code> attribute can be used together with the <code>display</code> property to
 						maximize interoperability across all reading systems.</p>
 				</div>
@@ -7532,10 +7531,10 @@ No Entry</pre>
 							spreads.</p>
 
 						<p>Although it is common practice to specify to use a spread in certain device orientations, the
-							content itself does not represent a true spread &#8212; two consecutive pages that reading
-							systems must render side-by-side for readability, such as a two-page map. To indicate that
-							two consecutive pages represent a true spread, the <code>rendition:page-spread-left</code>
-							and <code>rendition:page-spread-right</code> properties SHOULD be set on the [=EPUB spine |
+							content itself does not represent a true spread &#8212; two consecutive pages that have to
+							be rendered side-by-side for readability, such as a two-page map. To indicate that two
+							consecutive pages represent a true spread, the <code>rendition:page-spread-left</code> and
+								<code>rendition:page-spread-right</code> properties SHOULD be set on the [=EPUB spine |
 							spine=] items for the two adjacent EPUB content documents and the properties omitted on
 							spine items where one-up or two-up presentation is equally acceptable.</p>
 
@@ -7726,7 +7725,7 @@ No Entry</pre>
 
 						<p class="note"> The initial containing block definition affects only the document where it is
 							defined. The dimensions of the containing blocks in the other content documents within the
-							same publication may be different. </p>
+							same publication can be different. </p>
 					</section>
 				</section>
 			</section>
@@ -8109,7 +8108,7 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>As this specification does not define any metadata properties that must occur in the media
+						<p>As this specification does not define any metadata properties that has to occur in the media
 							overlay document, the <code>head</code> element is OPTIONAL.</p>
 					</section>
 
@@ -8374,7 +8373,7 @@ No Entry</pre>
 						<p>The <code>text</code> element references an element in an [=EPUB content document=]. A
 								<code>text</code> element typically refers to a textual element but can also refer to
 							other [=EPUB content document=] media elements. In the absence of a sibling [^audio^]
-							element, textual content referred to by this element may be rendered via <a href="#sec-tts"
+							element, textual content referred to by this element can be rendered via <a href="#sec-tts"
 								>text-to-speech</a>.</p>
 
 						<dl class="elemdef" id="elemdef-smil-text">
@@ -8432,8 +8431,8 @@ No Entry</pre>
 
 						<p class="note">[[epub-rs-34]] no longer provides guidance for reading systems on the playback
 							of timed media (i.e., the automatic starting of the referenced media). Although the
-								<code>src</code> attribute of a <code>text</code> element may refer to embedded timed
-							media (e.g., via an [[html]]&#160;[^video^] element), referencing such media may have
+								<code>src</code> attribute of a <code>text</code> element can refer to embedded timed
+							media (e.g., via an [[html]]&#160;[^video^] element), referencing such media can have
 							unpredictable results.</p>
 					</section>
 
@@ -8800,7 +8799,7 @@ No Entry</pre>
 						<h5>Referencing document fragments</h5>
 
 						<p>Both the <code>epub:textref</code> attribute and the [^text^] element's <code>src</code>
-							attribute may contain a [=URL-fragment string=] that references a specific part (e.g., an
+							attribute can contain a [=URL-fragment string=] that references a specific part (e.g., an
 							element via its ID) of the associated [=EPUB content document=].</p>
 
 						<p>For [=XHTML content document | XHTML=] and [=SVG content documents=], the URL-fragment string
@@ -8835,9 +8834,9 @@ No Entry</pre>
 							content of an [=EPUB publication=] as artificial human speech using a synthesized voice — in
 							addition to pre-recorded audio clips.</p>
 
-						<p>When a media overlay [^par^] element omits its [^audio^] element, its [^text^] element may be
+						<p>When a media overlay [^par^] element omits its [^audio^] element, its [^text^] element can be
 							rendered in reading systems via TTS. If the text fragment is not appropriate for TTS
-							rendering (e.g., is not a text element and/or has no text fallback), this may produce
+							rendering (e.g., is not a text element and/or has no text fallback), this can produce
 							unexpected results.</p>
 
 						<div class="note">
@@ -9057,9 +9056,9 @@ html.my-document-playing * {
 								href="#total-duration">total duration</a> plus or minus one second.</p>
 
 						<div class="note">
-							<p>Although the sum of individual durations may not exactly match the total due to rounding
-								the times to nearest fraction of a second, a difference of greater than one second
-								indicates a mismatch arising from other issues.</p>
+							<p>Although the sum of individual durations might not exactly match the total due to
+								rounding the times to nearest fraction of a second, a difference of greater than one
+								second indicates a mismatch arising from other issues.</p>
 						</div>
 
 						<p><a href="#narrator"><code>narrator</code></a> information MAY also be specified in the
@@ -9126,7 +9125,7 @@ html.my-document-playing * {
 				<section id="sec-skippability">
 					<h4>Skippability</h4>
 
-					<p>While reading, users may want to turn on or off certain features of the content, such as
+					<p>While reading, users might want to turn on or off certain features of the content, such as
 						footnotes, page numbers, or other types of secondary content. This feature is called
 						skippability. [=Reading systems=] use the semantic information provided by media overlay
 						elements' <a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to
@@ -9249,8 +9248,8 @@ html.my-document-playing * {
 						option of escapability.</p>
 
 					<div class="note">
-						<p>Sometimes escapable structures may contain escapable structures. For example, tables are
-							composed of many rows and cells that users may want to separately escape from. Reading
+						<p>Sometimes escapable structures can contain escapable structures. For example, tables are
+							composed of many rows and cells that users might want to separately escape from. Reading
 							system support for escaping from such structures is complex and not well supported at this
 							time. It is advised to avoid identifying nested escapable structures until better support is
 							available.</p>
@@ -9394,7 +9393,7 @@ html.my-document-playing * {
 					</li>
 					<li>
 						<p>When exposed in a presentation context that allows users to access and activate the links,
-							reading systems may implement additional presentation behaviors to expose audio feedback
+							reading systems can implement additional presentation behaviors to expose audio feedback
 							when user access navigation links.</p>
 					</li>
 				</ul>
@@ -9509,7 +9508,7 @@ html.my-document-playing * {
 							publication.</p>
 						<p>This threat is not limited to accessing content created by a bad actor. If content from
 							untrustworthy sources (e.g., third party audio and video) is embedded in an EPUB
-							publication, there is always the possibility that users may receive compromised
+							publication, there is always the possibility that users could receive compromised
 							resources.</p>
 						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
 							malicious content can be swapped in any time after publication, unlike resources that come
@@ -9540,9 +9539,9 @@ html.my-document-playing * {
 					<dt>Including malicious content</dt>
 					<dd>
 						<p>Resources embedded in the EPUB container are not immune to malicious actors, especially when
-							EPUB publications are obtained from untrusted sources. Resources may contain exploits or
-							forms that may submit sensitive information to unintended parties. Such actors may also try
-							to gain access to [=remote resources=] using file indirection techniques, such as symbolic
+							EPUB publications are obtained from untrusted sources. Resources could contain exploits or
+							forms that submit sensitive information to unintended parties. Such actors might also try to
+							gain access to [=remote resources=] using file indirection techniques, such as symbolic
 							links or file aliases. </p>
 						<p>The use of third-party content, such as games and quizzes, can also lead to security and
 							privacy issues if the content cannot be fully vetted.</p>
@@ -9566,7 +9565,7 @@ html.my-document-playing * {
 					<dt>Securing content with digital rights management</dt>
 					<dd>
 						<p>The encryption and decryption of EPUB publications using digital rights management schemes
-							may allow personally identifiable information about the user, what vendors they use, and
+							could allow personally identifiable information about the user, what vendors they use, and
 							their reading choices to be relayed to third parties.</p>
 					</dd>
 				</dl>
@@ -9706,9 +9705,9 @@ html.my-document-playing * {
 				<p>This feature MAY be used as described.</p>
 
 				<div class="note">
-					<p>[=EPUB conformance checkers=] should alert about the presence of under-implemented features when
-						encountered in EPUB publications but must not treat their inclusion as a violation of the
-						standard (i.e., not emit errors or warnings).</p>
+					<p>The Working Group advises that [=EPUB conformance checkers=] alert about the presence of
+						under-implemented features when encountered in EPUB publications but as their inclusion is not a
+						violation of the standard to not emit as errors or warnings).</p>
 				</div>
 
 				<div class="note">
@@ -9867,8 +9866,8 @@ html.my-document-playing * {
 				</dl>
 
 				<div class="note">
-					<p>[=EPUB conformance checkers=] should alert about the presence of deprecated features when
-						encountered in EPUB publications.</p>
+					<p>The Working Group recommends that [=EPUB conformance checkers=] alert about the presence of
+						deprecated features when encountered in EPUB publications.</p>
 				</div>
 			</section>
 		</section>
@@ -10061,7 +10060,7 @@ html.my-document-playing * {
 						roles influence how assistive technologies understand such elements.</p>
 
 					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
-						[=reading system=] enhancements. Reading systems may use <code>epub:type</code> values to
+						[=reading system=] enhancements. Reading systems can use <code>epub:type</code> values to
 						provide accessibility enhancements like built-in read aloud or media overlays functionality
 						where interaction with assistive technologies is not essential.</p>
 
@@ -10577,7 +10576,7 @@ html.my-document-playing * {
 
 			<p class="note">The prefix definitions are no longer being synchronized with their CSS counterparts. In some
 				cases, the unprefixed versions of these properties now support additional values. [=Reading systems=]
-				may not support the new syntax with the prefixed properties, so it is advised to use the unprefixed
+				might not support the new syntax with the prefixed properties, so it is advised to use the unprefixed
 				versions for newer features.</p>
 
 			<section id="sec-css-prefixed-writing-modes">
@@ -11047,7 +11046,7 @@ html.my-document-playing * {
 					<p>Although the <code>viewport meta</code> tag allows the use of properties other than
 							<code>height</code> and <code>width</code>, as well as to omit values for the
 							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
-						properties may have unintended consequences on the rendering of fixed-layout documents.</p>
+						properties could have unintended consequences on the rendering of fixed-layout documents.</p>
 				</div>
 			</section>
 		</section>
@@ -11070,8 +11069,8 @@ html.my-document-playing * {
 				</div>
 
 				<div class="note">
-					<p>These schemas may be updated and corrected outside of formal revisions of this specification. As
-						a result, they are subject to change at any time. </p>
+					<p>Updates and corrections to these schemas can occur outside of formal revisions of this
+						specification. As a result, they are subject to change at any time. </p>
 				</div>
 			</section>
 
@@ -11303,11 +11302,11 @@ html.my-document-playing * {
 					<dt><code>image/image_2.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is referenced via an [[html]] [^a^] element. Because it
-							is referenced from a hyperlink, it <em>must</em> be listed in the spine. It is a publication
-							resource on the manifest plane, a container resource, a [=foreign content document=] on the
-							spine plane, and a core media type resource on the content plane. As a foreign content
-							document, a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks"
-								>manifest fallback</a>.</p>
+							is referenced from a hyperlink, it <em>has to</em> be listed in the spine. It is a
+							publication resource on the manifest plane, a container resource, a [=foreign content
+							document=] on the spine plane, and a core media type resource on the content plane. As a
+							foreign content document, a fallback is required, which is provided via a <a
+								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
@@ -11805,7 +11804,7 @@ EPUB/images/cover.png</pre>
 						<p>Clearly, it is possible to author malicious files which, for example, contain malformed data.
 							Most XML parsers protect themselves from such attacks by rigorously enforcing
 							conformance.</p>
-						<p>All processors that read package documents should rigorously check the size and validity of
+						<p>All processors that read package documents need to rigorously check the size and validity of
 							data retrieved.</p>
 						<p>There is no current provision in the EPUB 3 specification for encryption, signing, or
 							authentication within the package document format.</p>
@@ -12014,8 +12013,8 @@ EPUB/images/cover.png</pre>
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a> — those that may affect the conformance of [=EPUB
-				publications=].</p>
+					href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a> — those that could affect the conformance of
+				[=EPUB publications=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A2025-02-11..2027-02-11%20-label%3AErrata"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -214,10 +214,10 @@
 						That standard, in turn, references various technologies that also continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
-					<p>The benefit of this approach for EPUB is that [=EPUB publications=] always keep pace with changes
-						to the web without the need for new revisions. Anyone who creates EPUB publications, however,
-						will have to keep track of the various changes to HTML and the technologies it references to
-						ensure they keep their processes up to date.</p>
+					<p>The benefit of this approach is that EPUB 3 is always up to date with the web, but it also means
+						that this specification does not track changes to HTML and the technologies it references. Those
+						standards have to be monitored separately to ensure that authoring processes are kept up to
+						date.</p>
 
 					<p>The [[html]] standard defines a single content model with rules for expressing a tag set using
 						either the <a data-cite="html#syntax">HTML syntax</a> or the <a
@@ -249,9 +249,9 @@
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
 
-					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Anyone
-						who creates EPUB publications, however, will have to keep track of changes to the SVG standard
-						to ensure they keep their processes up to date.</p>
+					<p>The benefit of this approach is that EPUB 3 is always up to date with the SVG standard, but it
+						also means that this specification does not track changes to SVG. The SVG standards has to be
+						monitored separately to ensure that authoring processes are kept up to date.</p>
 				</section>
 
 				<section id="sec-overview-relations-css">
@@ -740,9 +740,9 @@
 					reported as warnings.</p>
 
 				<div class="note">
-					<p>Vendors, distributors, and other retailers of EPUB publications should consider the importance of
-						recommended practices before basing their acceptance or rejection on a zero-issue outcome from
-						an EPUB conformance checker. There will be legitimate reasons why EPUB publications cannot
+					<p>Vendors, distributors, and other retailers of EPUB publications need to consider the importance
+						of recommended practices before basing their acceptance or rejection on a zero-issue outcome
+						from an EPUB conformance checker. There will be legitimate reasons why EPUB publications cannot
 						adhere to recommended practices in all cases.</p>
 				</div>
 			</section>
@@ -3832,10 +3832,10 @@
 &lt;/package&gt;</pre>
 							</aside>
 
-							<p>Although not static, changes to the unique identifier should only be made as infrequently
-								as possible. Unique Identifiers should have maximal persistence both for referencing and
-								distribution purposes. Do not issue new identifiers when making minor revisions such as
-								updating metadata, fixing errata, or making similar minor changes.</p>
+							<p>Although not static, avoid changing the unique identifier too often. Unique Identifiers
+								are intended to have maximal persistence both for referencing and distribution purposes.
+								Do not issue new identifiers when making minor revisions such as updating metadata,
+								fixing errata, or making similar minor changes.</p>
 
 							<p>Additional identifiers MAY be specified.</p>
 
@@ -4169,8 +4169,8 @@
 &lt;/metadata&gt;</pre>
 							</aside>
 
-							<p>The <code>dc:creator</code> element should contain the name of the creator as [=reading
-								systems=] are expected to display it to users.</p>
+							<p>It is advised that the <code>dc:creator</code> element contain the name of the creator as
+								[=reading systems=] are expected to display it to users.</p>
 
 							<p>The <a href="#file-as"><code>file-as</code> property</a> MAY be used <a
 									href="#subexpression">to associate</a> a normalized form of the creator's name, and
@@ -5506,9 +5506,9 @@ No Entry</pre>
 							("<code>no</code>"). Examples of auxiliary content include notes, descriptions, and answer
 						keys.</p>
 
-					<p>The <code>linear</code> attribute allows reading systems to distinguish content that a user
-						should access as part of the default reading order from supplementary content which a reading
-						system might, for example, present in a popup window or omit from an aural rendering.</p>
+					<p>The <code>linear</code> attribute allows reading systems to distinguish content that a user needs
+						to access as part of the default reading order from supplementary content which a reading system
+						might, for example, present in a popup window or omit from an aural rendering.</p>
 
 					<p>Specifying that content is non-linear does not require reading systems to present it in a
 						specific way, however; it is only a hint to the purpose. Reading systems may present non-linear
@@ -5905,8 +5905,8 @@ No Entry</pre>
 
 						<div class="note">
 							<p>Custom attributes are usually defined in a reading system-specific manner and are not
-								intended for use by other reading systems. This specification should be extended to
-								provide extensions that multiple independent reading systems can use.</p>
+								intended for use by other reading systems. The preferred method to add extensions for
+								multiple indenpendent reading system to use is to extend this specification.</p>
 						</div>
 					</section>
 				</section>
@@ -7159,12 +7159,12 @@ No Entry</pre>
 						<dl class="variablelist">
 							<dt>landscape</dt>
 							<dd>
-								<p>[=Reading systems=] should render the content in landscape orientation.</p>
+								<p>Render the content in landscape orientation.</p>
 							</dd>
 
 							<dt>portrait</dt>
 							<dd>
-								<p>Reading systems should render the content in portrait orientation.</p>
+								<p>Render the content in portrait orientation.</p>
 							</dd>
 
 							<dt>auto</dt>
@@ -7209,16 +7209,13 @@ No Entry</pre>
 
 							<dl>
 								<dt id="orientation-auto">rendition:orientation-auto</dt>
-								<dd>Specifies that the [=reading system=] determines the orientation to render the spine
-									item in.</dd>
+								<dd>The [=reading system=] determines the orientation to render the spine item in.</dd>
 
 								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
-								<dd>Specifies that reading systems should render the given spine item in landscape
-									orientation.</dd>
+								<dd>Render the given spine item in landscape orientation.</dd>
 
 								<dt id="orientation-portrait">rendition:orientation-portrait</dt>
-								<dd>Specifies that reading systems should render the given spine item in portrait
-									orientation.</dd>
+								<dd>Render the given spine item in portrait orientation.</dd>
 							</dl>
 
 							<p>A spine item MUST NOT declare more than one of these overrides.</p>
@@ -7241,8 +7238,8 @@ No Entry</pre>
 						<dl class="variablelist">
 							<dt>none</dt>
 							<dd>
-								<p>Do not incorporate spine items in a synthetic spread. Reading systems should display
-									the items in a single [=viewport=] positioned at the center of the screen.</p>
+								<p>Do not incorporate spine items in a synthetic spread. Render the items in a single
+									[=viewport=] positioned at the center of the screen.</p>
 							</dd>
 
 							<dt>landscape</dt>
@@ -7476,20 +7473,19 @@ No Entry</pre>
 
 							<dl>
 								<dt id="spread-auto">rendition:spread-auto</dt>
-								<dd>Specifies the [=reading system=] determines when to render a synthetic spread for
-									the spine item. </dd>
+								<dd>The [=reading system=] determines when to render a synthetic spread for the spine
+									item. </dd>
 
 								<dt id="spread-both">rendition:spread-both</dt>
-								<dd>Specifies the reading system should render a synthetic spread for the spine item in
-									both portrait and landscape orientations. </dd>
+								<dd>Render a synthetic spread for the spine item in both portrait and landscape
+									orientations. </dd>
 
 								<dt id="spread-landscape">rendition:spread-landscape</dt>
-								<dd>Specifies the reading system should render a synthetic spread for the spine item
-									only when in landscape orientation.</dd>
+								<dd>Render a synthetic spread for the spine item only when in landscape
+									orientation.</dd>
 
 								<dt id="spread-none">rendition:spread-none</dt>
-								<dd>Specifies the reading system should not render a synthetic spread for the spine
-									item.</dd>
+								<dd>Do not render a synthetic spread for the spine item.</dd>
 							</dl>
 
 							<p>A spine item MUST NOT declare more than one of these overrides.</p>
@@ -7749,7 +7745,7 @@ No Entry</pre>
 					<h4>The <code>rendition:flow</code> property</h4>
 
 					<p>The <code>rendition:flow</code> property specifies the preference for how [=reading systems=]
-						should handle content overflow. </p>
+						handle content overflow. </p>
 
 					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
 						specified on a <code>meta</code> element, it indicates the preference for overflow content
@@ -7928,8 +7924,8 @@ No Entry</pre>
 				<section id="align-x-center">
 					<h4>The <code>rendition:align-x-center</code> property</h4>
 
-					<p>The <code>rendition:align-x-center</code> property specifies that the given [=EPUB spine |
-						spine=] item should be centered horizontally in the [=viewport=] or spread.</p>
+					<p>The <code>rendition:align-x-center</code> property specifies to center the given [=EPUB spine |
+						spine=] horizontally in the [=viewport=] or spread.</p>
 
 					<p>The property MUST NOT be set globally for all [=EPUB content documents=] (i.e., in a [^meta^]
 						element without a <a href="#attrdef-refines"><code>refines</code> attribute</a>). It is only

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -10419,8 +10419,7 @@ html.my-document-playing * {
 					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, they can cause issues in the supply
-							chain. Vendors, for example, will often reject new prefixes until they update their [=EPUB
+						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for example, will often reject new prefixes until they update their [=EPUB
 							conformance checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
 					</div>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -2602,7 +2602,7 @@
 										<code>EncryptionProperties</code> metadata SHOULD be provided to specify the
 									size of the initial resource (i.e., before compression and encryption), as per the
 										<code>Compression</code> XML element defined below. When streams of data are not
-									compresed before encrypting, additional <code>EncryptionProperties</code> metadata
+									compressed before encrypting, additional <code>EncryptionProperties</code> metadata
 									MAY be provided to specify the size of the initial resource (i.e., before
 									encryption).</p>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -576,7 +576,7 @@
 							[=package document=], [=EPUB content documents=], CSS Style Sheets, audio, video, images,
 							embedded fonts, and scripts.</p>
 						<p>The package document [=EPUB manifest | manifest=] has to include a list of all publication
-							resources and the resources typically have to be bundled in the [=EPUB container=] (the
+							resources that typically have to be bundled in the [=EPUB container=] (the
 							exception being that resources listed in <a href="#sec-resource-locations"></a> can be
 							located outside the EPUB container).</p>
 						<div class="note">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -2784,7 +2784,7 @@
 									exist within the EPUB publication.</p>
 
 								<p id="sig-container">When a data signature is created for the OCF abstract container,
-									the signature SHOULD be stored in the last child <code>Signature</code> element of
+									the signature SHOULD be stored as the last child <code>Signature</code> element of
 									the <code>signatures</code> element.</p>
 
 								<div class="note">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6440,8 +6440,8 @@ No Entry</pre>
 				<h3>Introduction</h3>
 
 				<p>The [=EPUB navigation document=] is a <a href="#confreq-nav">mandatory component</a> of an [=EPUB
-					publication=]. It allows [=EPUB creators=] to include a human- and machine-readable global
-					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
+					publication=]. It allows the inclusion of a human- and machine-readable global navigation layer,
+					thereby ensuring increased usability and accessibility for the user.</p>
 
 				<p>The EPUB navigation document is a special type of [=XHTML content document=] that defines the <a
 						href="#sec-nav-toc">table of contents</a> for [=reading systems=]. It may also include other
@@ -6452,18 +6452,18 @@ No Entry</pre>
 
 				<p>The EPUB navigation document is not exclusively for machine processing, however. There are no
 					restrictions on the structure or content of the EPUB navigation document outside of the specialized
-					navigation elements (i.e., EPUB creators can mark the rest of the document up like any other XHTML
-					content document). As a result, it can also be part of the linear reading order, avoiding the need
-					for duplicate tables of contents. EPUB creators can hide navigation elements that are only for
-					machine processing (e.g., the page list) with the <a href="#sec-nav-doc-use-spine"
-							><code>hidden</code> attribute</a>.</p>
+					navigation elements (i.e., the rest of the document can be marked up like any other XHTML content
+					document). As a result, it can also be part of the linear reading order, avoiding the need for
+					duplicate tables of contents. Navigation elements that are only for machine processing (e.g., the
+					page list) can be hidden using the <a href="#sec-nav-doc-use-spine"><code>hidden</code>
+						attribute</a>.</p>
 
 				<p>Note that reading systems may strip scripting, styling, and HTML formatting as they generate
 					navigational interfaces from information found in the EPUB navigation document, and this may make
-					the result difficult to read. If EPUB creators require such formatting and functionality, then they
-					should also include the EPUB navigation document in the [=EPUB spine | spine=]. The use of
-					progressive enhancement techniques for scripting and styling of the navigation document will help
-					ensure the content will retain its integrity when rendered in a non-browser context.</p>
+					the result difficult to read. If such formatting and functionality is necessary, then the EPUB
+					navigation document can also be included in the [=EPUB spine | spine=]. The use of progressive
+					enhancement techniques for scripting and styling of the navigation document will help ensure the
+					content will retain its integrity when rendered in a non-browser context.</p>
 			</section>
 
 			<section id="sec-nav-content-req" data-epubcheck="true"
@@ -6572,8 +6572,8 @@ No Entry</pre>
 						<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
 							other item of interest. A child <code>a</code> element describes the target that the link
 							points to, while a <code>span</code> element serves as a heading for breaking down lists
-							into distinct groups (for example, an EPUB creator could segment a large list of
-							illustrations into several lists, one for each chapter).</p>
+							into distinct groups. For example, a large list of illustrations could be split into several
+							lists, one for each chapter.</p>
 					</li>
 					<li>
 						<p id="confreq-nav-a-cnt">The child <code>a</code> or <code>span</code> element MUST provide a
@@ -6658,8 +6658,8 @@ No Entry</pre>
 						content=], app-based reading systems often only support simple text labels. Because these apps
 						create their own navigation widgets that are not based on HTML rendering, they often cannot
 						retain embedded images and multimedia, MathML, inline styling and other element- and
-						attribute-based rendering instructions. EPUB creators should avoid using these types of elements
-						where their absence may lead to usability issues.</p>
+						attribute-based rendering instructions. It is advised to avoid using this type of content where
+						its absence will lead to usability issues.</p>
 				</div>
 			</section>
 
@@ -6682,8 +6682,8 @@ No Entry</pre>
 						</dt>
 						<dd>
 							<p>Identifies the <code>nav</code> element that contains the table of contents. The
-									<code>toc nav</code> is the only navigation aid that [=EPUB creators=] must include
-								in the EPUB navigation document.</p>
+									<code>toc nav</code> is the only navigation aid that has to be included in the EPUB
+								navigation document.</p>
 						</dd>
 
 						<dt>
@@ -6721,8 +6721,8 @@ No Entry</pre>
 						conceptually corresponds to a table of contents in a printed work &#8212; it provides navigation
 						to the major structural sections of the publication.</p>
 
-					<p>[=EPUB creators=] SHOULD order the references in the <code>toc nav</code> element such that they
-						reflect both:</p>
+					<p>The references in the <code>toc nav</code> element SHOULD be ordered such that they reflect
+						both:</p>
 
 					<ul>
 						<li>
@@ -6754,8 +6754,8 @@ No Entry</pre>
 					<p>The <code>page-list nav</code> element SHOULD contain only a single <code>ol</code> descendant
 						(i.e., no nested sublists).</p>
 
-					<p>[=EPUB creators=] MAY identify the destinations of the <code>page-list</code> references in their
-						respective [=EPUB content documents=] using the <a data-cite="epub-ssv-11/#pagebreak"
+					<p>The destinations of the <code>page-list</code> references MAY be identified in their respective
+						[=EPUB content documents=] using the <a data-cite="epub-ssv-11/#pagebreak"
 								><code>pagebreak</code> term</a> [[epub-ssv-11]].</p>
 				</section>
 
@@ -6813,9 +6813,9 @@ No Entry</pre>
 					<p>The <code>landmarks nav</code> MUST NOT include multiple entries with the same
 							<code>epub:type</code> value that reference the same resource, or fragment thereof.</p>
 
-					<p>[=EPUB creators=] should limit the number of items they define in the <code>landmarks nav</code>
-						to only items that a reading system is likely to use in its user interface. The element is not
-						meant to repeat the table of contents.</p>
+					<p>It is advised to limit the number of items defined in the <code>landmarks nav</code> to only
+						items that a reading system is likely to use in its user interface. The element is not meant to
+						repeat the table of contents.</p>
 
 					<p>The following landmarks are recommended to include when available:</p>
 
@@ -6831,9 +6831,9 @@ No Entry</pre>
 					<p>Other possibilities for inclusion in the <code>landmarks nav</code> are key reference sections
 						such as indexes and glossaries.</p>
 
-					<p>Although the <code>landmarks nav</code> is intended for reading system use, EPUB creators should
-						still ensure that the labels for the <code>landmarks nav</code> are human readable. Reading
-						systems may expose the links directly to users.</p>
+					<p>Although the <code>landmarks nav</code> is intended for reading system use, it is still advised
+						to ensure that the labels for the <code>landmarks nav</code> are human readable. Reading systems
+						might expose the links directly to users.</p>
 				</section>
 
 				<section id="sec-nav-def-types-other" data-epubcheck="true"
@@ -6851,8 +6851,8 @@ No Entry</pre>
 						contain link targets with homogeneous or heterogeneous semantics.</p>
 
 					<aside class="example" title="Adding a custom navigation element">
-						<p>In this example, the <code>lot</code> semantic indicates that the EPUB creator is adding a
-							"list of tables" navigation element.</p>
+						<p>In this example, the <code>lot</code> semantic indicates that <code>nav</code> element
+							contains a list of tables.</p>
 
 						<pre>&lt;nav
     epub:type="lot"
@@ -6884,28 +6884,28 @@ No Entry</pre>
 			<section id="sec-nav-doc-use-spine" class="informative">
 				<h3>Using in the spine</h3>
 
-				<p id="confreq-cd-nav-docprops-spine">As a conforming [=XHTML content document=], [=EPUB creators=] can
-					include the EPUB navigation document in the [=EPUB spine | spine=].</p>
+				<p id="confreq-cd-nav-docprops-spine">As a conforming [=XHTML content document=], the EPUB navigation
+					document can be included in the [=EPUB spine | spine=].</p>
 
-				<p id="confreq-nav-ol-style">When adding the navigation document to the spine, EPUB creators have to
-					consider that any [=reading system=] processing of the document will not apply. In particular,
-					although [=EPUB reading systems=] are <a data-cite="epub-rs-34#confreq-nav-ol-style">required to
-						suppress list item numbering</a> [[epub-rs-34]] when presenting the EPUB navigation document
-					outside of the spine (such as in dedicated navigation user interfaces provided by reading systems),
-					this requirement does not apply to in-spine use. Consequently, if EPUB creators do not want HTML's
-					default list item numbering when presenting the navigation document in the spine, they have to
-					specify the alternative list styling using CSS.</p>
+				<p id="confreq-nav-ol-style">When adding the navigation document to the spine, consider that any
+					[=reading system=] processing of the document will not apply. In particular, although [=EPUB reading
+					systems=] are <a data-cite="epub-rs-34#confreq-nav-ol-style">required to suppress list item
+						numbering</a> [[epub-rs-34]] when presenting the EPUB navigation document outside of the spine
+					(such as in dedicated navigation user interfaces provided by reading systems), this requirement does
+					not apply to in-spine use. Consequently, if HTML's default list item numbering is not wanted when
+					presenting the navigation document in the spine, alternative list styling has to be provided using
+					CSS.</p>
 
 				<p>Similarly, it is often the case that not all of the navigation structures, or branches within them,
-					are needed when the EPUB navigation document is presented in the spine. EPUB creators will often
-					want to hide the <a href="#sec-nav-pagelist">page list</a> and <a href="#sec-nav-landmarks"
-						>landmarks</a> navigation elements, for example, or trim the branches of the table of contents
-					for books that have many levels of subsections.</p>
+					are needed when the EPUB navigation document is presented in the spine. It is often preferred to
+					hide the <a href="#sec-nav-pagelist">page list</a> and <a href="#sec-nav-landmarks">landmarks</a>
+					navigation elements, for example, or to trim of the table of contents for books that have many
+					levels of subsections.</p>
 
-				<p>In these cases, EPUB creators are advised use the [[html]] [^html-global/hidden^] attribute to
-					indicate which (if any) portions of the navigation data are excluded from rendering in the content
-					flow. The <a data-cite="epub-rs-34#confreq-nav-hidden">the attribute has no effect</a>
-					[[epub-rs-34]] on how reading systems render the navigation document outside of the spine.</p>
+				<p>In these cases, it is advised to use the [[html]] [^html-global/hidden^] attribute to indicate which
+					(if any) portions of the navigation data are excluded from rendering in the content flow. The <a
+						data-cite="epub-rs-34#confreq-nav-hidden">the attribute has no effect</a> [[epub-rs-34]] on how
+					reading systems render the navigation document outside of the spine.</p>
 
 				<div class="note">
 					<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
@@ -6983,10 +6983,10 @@ No Entry</pre>
 					upon. For example, although HTML with CSS provides powerful layout capabilities, those capabilities
 					are limited to the scope of the document being rendered.</p>
 
-				<p>This section defines properties that allow [=EPUB creators=] to express package-level rendering
-					intentions (i.e., functionality that can only be implemented by the [=EPUB reading system=]). If a
-					reading system supports the desired rendering, these properties enable the user to be presented the
-					content as the EPUB creator optimally designed it.</p>
+				<p>This section defines properties that allow the expression of package-level rendering intentions
+					(i.e., functionality that can only be implemented by the [=EPUB reading system=]). If a reading
+					system supports the desired rendering, these properties enable the user to be presented the content
+					as it was optimally designed.</p>
 			</section>
 
 			<section id="sec-fixed-layouts">
@@ -7003,19 +7003,19 @@ No Entry</pre>
 
 					<p>But this principle does not work for all types of documents. Sometimes content and design are so
 						intertwined it is not possible to separate them. Any change in appearance risks changing the
-						meaning or losing all meaning. [=Fixed-layout documents=] give [=EPUB creators=] greater control
-						over presentation when a reflowable EPUB is not suitable for the content.</p>
+						meaning or losing all meaning. [=Fixed-layout documents=] give greater control over presentation
+						when a reflowable EPUB is not suitable for the content.</p>
 
-					<p>EPUB creators define fixed layouts using a <a href="#sec-fxl-package">set of package document
-							properties</a> to control the rendering in [=reading systems=]. In addition, they set <a
-							href="#sec-fxl-package">the dimensions of each fixed-layout document</a> in its respective
-						[=EPUB content document=].</p>
+					<p>Fixed layouts are defined using a <a href="#sec-fxl-package">set of package document
+							properties</a> to control the rendering in [=reading systems=]. In addition, <a
+							href="#sec-fxl-package">the dimensions of each fixed-layout document</a> is set in its
+						respective [=EPUB content document=].</p>
 
 					<div class="note" id="note-mechanisms">
 						<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
-							content is necessary, the EPUB creator's choice of mechanism will depend on many factors
-							including desired degree of precision, file size, accessibility, etc. This section does not
-							attempt to dictate the EPUB creator's choice of mechanism.</p>
+							content is necessary, the choice of mechanism will depend on many factors including desired
+							degree of precision, file size, accessibility, etc. This section does not attempt to dictate
+							the choice of mechanism.</p>
 					</div>
 				</section>
 
@@ -7033,8 +7033,7 @@ No Entry</pre>
 								property</a> is specified on a <code>meta</code> element, it indicates that the
 							paginated or reflowable layout style applies globally (i.e., for all spine items).</p>
 
-						<p>[=EPUB creators=] MUST use one of the following values with the <code>rendition:layout</code>
-							property:</p>
+						<p>The <code>rendition:layout</code> property MUST specify one of the following properties:</p>
 
 						<dl class="variablelist">
 							<dt id="def-layout-reflowable">reflowable</dt>
@@ -7053,22 +7052,21 @@ No Entry</pre>
 						<div class="note" id="uaag">
 							<p>Reading systems typically restrict or deny the application of user or user agent style
 								sheets to pre-paginated documents because dynamic style changes are likely to have
-								unintended consequence on the intrinsic properties of such documents. EPUB creators
-								should consider the negative impact on usability and accessibility that these
-								restrictions have when choosing to use pre-paginated instead of reflowable content.
-								Refer to <a data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text
-									configuration</a> [[uaag20]] for related information.</p>
+								unintended consequence on the intrinsic properties of such documents. When choosing to
+								use pre-paginated instead of reflowable content, it is advised to consider the negative
+								impact on usability and accessibility that these restrictions have. Refer to <a
+									data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text configuration</a>
+								[[uaag20]] for related information.</p>
 						</div>
 
 						<p id="fxl-layout-duplication" data-tests="#lay-fxl-layout-duplication">When the property is set
 							to <code>pre-paginated</code> for a spine item, its content dimensions MUST be set as
 							defined in <a href="#sec-fxl-content-dimensions"></a>.</p>
 
-						<p>EPUB creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
-
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#layout-overrides"></a> for
-							setting the property for individual [=EPUB content documents=].</p>
+						<p>The <code>rendition:layout</code> property MUST NOT be declared more than once. In addition,
+							the property MUST NOT be declared using the <a href="#attrdef-refines"><code>refines</code>
+								attribute</a>. Refer to <a href="#layout-overrides"></a> for setting the property for
+							individual [=EPUB content documents=].</p>
 
 						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
 							<p>In this example, the document's layout is set to <code>pre-paginated</code> (i.e., it is
@@ -7126,9 +7124,9 @@ No Entry</pre>
 							data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L59,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L64">
 							<h6>Layout overrides</h6>
 
-							<p id="property-layout-local">[=EPUB creators=] MAY specify the following properties locally
-								on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-									href="#property-layout-global">global value</a> for the given spine item:</p>
+							<p id="property-layout-local">The following properties MAY be declared on [=EPUB spine |
+								spine=] [^itemref^] elements to override the <a href="#property-layout-global">global
+									value</a>:</p>
 
 							<dl>
 								<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
@@ -7138,7 +7136,7 @@ No Entry</pre>
 								<dd>Specifies that the given spine item is reflowable.</dd>
 							</dl>
 
-							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
+							<p>A spine item MUST NOT declare more than one of these overrides.</p>
 						</section>
 					</section>
 
@@ -7147,15 +7145,15 @@ No Entry</pre>
 						<h5>Orientation</h5>
 
 						<p>The <code>rendition:orientation</code> property specifies which orientation the [=EPUB
-							creator=] intends the content to be rendered in. </p>
+							publication=] is intended to be rendered in. </p>
 
 						<p id="property-orientation-global">When the <a href="#orientation"
 									><code>rendition:orientation</code> property</a> is specified on a [^meta^] element,
 							it indicates that the intended orientation applies globally (i.e., for all [=EPUB spine |
 							spine=] items).</p>
 
-						<p>[=EPUB creators=] MUST use one of the following values with the
-								<code>rendition:orientation</code> property:</p>
+						<p>One of the following values MUST be used with the <code>rendition:orientation</code>
+							property:</p>
 
 						<dl class="variablelist">
 							<dt>landscape</dt>
@@ -7174,12 +7172,11 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p id="fxl-orientation-duplication">EPUB creators MUST NOT declare the
-								<code>rendition:orientation</code> property more than once.</p>
-
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#orientation-overrides"></a>
-							for setting the property for individual [=EPUB content documents=].</p>
+						<p id="fxl-orientation-duplication">The <code>rendition:orientation</code> property MUST NOT be
+							declared more than once. In addition, it MUST NOT be declared using the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a>. Refer to <a
+								href="#orientation-overrides"></a> for setting the property for individual [=EPUB
+							content documents=].</p>
 
 						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
 							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
@@ -7205,9 +7202,9 @@ No Entry</pre>
 							data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L102,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L107">
 							<h6>Orientation overrides</h6>
 
-							<p id="property-orientation-local">[=EPUB creators=] MAY specify the following properties
-								locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-									href="#property-orientation-global">global value</a> for the given spine item:</p>
+							<p id="property-orientation-local">The following properties MAY be specified on [=EPUB spine
+								| spine=] [^itemref^] elements to override the <a href="#property-orientation-global"
+									>global value</a>:</p>
 
 							<dl>
 								<dt id="orientation-auto">rendition:orientation-auto</dt>
@@ -7223,7 +7220,7 @@ No Entry</pre>
 									orientation.</dd>
 							</dl>
 
-							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
+							<p>A spine item MUST NOT declare more than one of these overrides.</p>
 						</section>
 					</section>
 
@@ -7238,8 +7235,7 @@ No Entry</pre>
 								<code>meta</code> element, it indicates that the intended [=synthetic spread=] behavior
 							applies globally (i.e., for all spine items).</p>
 
-						<p>[=EPUB creators=] MUST use one of the following values with the <code>rendition:spread</code>
-							property:</p>
+						<p>One of the following values MUST be used with the <code>rendition:spread</code> property:</p>
 
 						<dl class="variablelist">
 							<dt>none</dt>
@@ -7261,16 +7257,14 @@ No Entry</pre>
 
 							<dt>auto</dt>
 							<dd>
-								<p>The EPUB creator is not defining an explicit synthetic spread behavior. Default
-									value.</p>
+								<p>No synthetic spread behavior preference. Default value.</p>
 							</dd>
 						</dl>
 
-						<p>EPUB creators MUST NOT declare the <code>rendition:spread</code> property more than once.</p>
-
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#spread-overrides"></a> for
-							setting the property for individual [=EPUB content documents=].</p>
+						<p>The <code>rendition:spread</code> property MUST NOT be declare more than once. In addition,
+							it MUST NOT be declared using the <a href="#attrdef-refines"><code>refines</code>
+								attribute</a>. Refer to <a href="#spread-overrides"></a> for setting the property for
+							individual [=EPUB content documents=].</p>
 
 						<div class="note">
 							<p>When synthetic spreads are used in the context of [=XHTML content document | XHTML=] and
@@ -7418,9 +7412,9 @@ No Entry</pre>
 
 						<aside class="example" id="spread-both-with-intro-example"
 							title="Overriding the global spread behavior">
-							<p>In this example, the EPUB creator overrides the global reflowable setting in the spine
-								for the introductory page. The intention is for reading systems to render it as a
-								reflowable document.</p>
+							<p>In this example, the global reflowable setting in the spine is overridden for the
+								introductory page. The intention is for reading systems to render it as a reflowable
+								document.</p>
 
 							<pre>&lt;package …&gt;
    &lt;metadata …&gt;
@@ -7475,9 +7469,9 @@ No Entry</pre>
 							data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L151,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L156">
 							<h6>Synthetic spread overrides</h6>
 
-							<p id="property-spread-local">[=EPUB creators=] MAY specify the following properties locally
-								on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-									href="#property-spread-global">global value</a> for the given spine item:</p>
+							<p id="property-spread-local">The following properties MAY be specified on [=EPUB spine |
+								spine=] [^itemref^] elements to override the <a href="#property-spread-global">global
+									value</a>:</p>
 
 							<dl>
 								<dt id="spread-auto">rendition:spread-auto</dt>
@@ -7497,7 +7491,7 @@ No Entry</pre>
 									item.</dd>
 							</dl>
 
-							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
+							<p>A spine item MUST NOT declare more than one of these overrides.</p>
 						</section>
 					</section>
 
@@ -7509,10 +7503,9 @@ No Entry</pre>
 							the spread by rendering the next [=EPUB content document=] in the next available unpopulated
 							[=viewport=], where the next available viewport is determined by the given <a
 								href="#attrdef-spine-page-progression-direction">page progression direction</a> or by
-							local declarations within [=EPUB content documents=]. An [=EPUB creator=] MAY override this
-							automatic population behavior and force reading systems to place a document in a particular
-							viewport by specifying one of the following properties on its spine <code>itemref</code>
-							element:</p>
+							local declarations within [=EPUB content documents=]. To force reading systems to place a
+							document in a particular viewport, this automatic population behavior MAY be overridden by
+							specifying one of the following properties on its spine <code>itemref</code> element:</p>
 
 						<dl>
 							<dt id="page-spread-center">
@@ -7541,30 +7534,29 @@ No Entry</pre>
 							reflowable content. They only apply when the reading system is creating synthetic
 							spreads.</p>
 
-						<p>Although EPUB creators often indicate to use a spread in certain device orientations, the
-							content itself does not represent true spreads (i.e., two consecutive pages that reading
-							systems must render side-by-side for readability, such as a two-page map). To indicate that
-							two consecutive pages represent a true spread, EPUB creators SHOULD use the
-								<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-							properties on the [=EPUB spine | spine=] items for the two adjacent EPUB content documents,
-							and omit the properties on spine items where one-up or two-up presentation is equally
-							acceptable.</p>
+						<p>Although it is common practice to specify to use a spread in certain device orientations, the
+							content itself does not represent a true spread &#8212; two consecutive pages that reading
+							systems must render side-by-side for readability, such as a two-page map. To indicate that
+							two consecutive pages represent a true spread, the <code>rendition:page-spread-left</code>
+							and <code>rendition:page-spread-right</code> properties SHOULD be set on the [=EPUB spine |
+							spine=] items for the two adjacent EPUB content documents and the properties omitted on
+							spine items where one-up or two-up presentation is equally acceptable.</p>
 
-						<p>EPUB creators MUST NOT declare more than one <code>rendition:page-spread-*</code> property,
-							and/or their unprefixed equivalents, on any given spine item (e.g., it is valid to specify
-							both "<code>rendition:page-spread-left page-spread-left</code>" in case reading systems only
+						<p>A spine item MUST NOT declare more than one <code>rendition:page-spread-*</code> property,
+							and/or their unprefixed equivalents (e.g., it is valid to specify both
+								"<code>rendition:page-spread-left page-spread-left</code>" in case reading systems only
 							support one of properties).</p>
 
 						<div class="note" id="note-page-spread-aliases">
 							<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 								properties were created to allow the use of a single vocabulary for all fixed-layout
-								properties. EPUB creators can use either property set, but older reading systems might
-								only recognize the unprefixed versions.</p>
+								properties. Either property set can be used, but older reading systems might only
+								recognize the unprefixed versions.</p>
 
-							<p>The <code>rendition:page-spread-center</code> was created to make it easier for EPUB
-								creators to understand the process of switching between two-page spreads and single
-								centered pages. EPUB creators can use either <code>rendition:page-spread-center</code>
-								or <code>spread-none</code> to disable spread behavior in reading systems.</p>
+							<p>The <code>rendition:page-spread-center</code> was created to make it easier to understand
+								the process of switching between two-page spreads and single centered pages. Either
+									<code>rendition:page-spread-center</code> or <code>spread-none</code> can be used to
+								disable spread behavior in reading systems.</p>
 						</div>
 
 						<aside class="example" id="spread-page-spread-right-example"
@@ -7617,11 +7609,10 @@ No Entry</pre>
 						</aside>
 
 						<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
-							<p>In this example, the EPUB creator intends the reading system to create a two-page
-								fixed-layout center plate using synthetic spreads in any device orientation. Note that
-								the EPUB creator has left spread behavior for the other (reflowable) parts undefined,
-								since the global value of <code>rendition:spread</code> initializes to <code>auto</code>
-								by default.</p>
+							<p>In this example, the intent is for the reading system to create a two-page fixed-layout
+								center plate using synthetic spreads in any device orientation. Note that the spread
+								behavior for the other (reflowable) parts has been left undefined, since the global
+								value of <code>rendition:spread</code> initializes to <code>auto</code> by default.</p>
 
 							<pre>&lt;package …&gt;
    …
@@ -7699,8 +7690,8 @@ No Entry</pre>
 									first <code>viewport meta</code> tag in document order in the [[html]] <a
 										data-cite="html#the-head-element"><code>head</code></a> element. Reading systems
 									will ignore subsequent <code>viewport meta</code> tags.</p>
-								<p>EPUB creators MUST NOT specify more than one <code>height</code> or
-										<code>width</code> definition within a <code>viewport meta</code> tag.</p>
+								<p>A <code>viewport meta</code> tag MUST NOT specify more than one <code>height</code>
+									or <code>width</code> definition.</p>
 								<aside class="example"
 									title="Specifying the initial containing block in a viewport meta tag">
 									<pre>&lt;html …&gt;
@@ -7750,25 +7741,23 @@ No Entry</pre>
 						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
 					technologies, there are also considerations for reflowable content that are unique to [=EPUB
 					publications=] (e.g., how to handle the flow of content in the [=viewport=]). This section defines
-					properties that allow [=EPUB creators=] to control presentation aspects of reflowable content.</p>
+					properties that provide control over presentation aspects of reflowable content.</p>
 
 				<section id="flow" data-epubcheck="true"
 					data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L320,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L325,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L332,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L339">
 					<h4>The <code>rendition:flow</code> property</h4>
 
-					<p>The <code>rendition:flow</code> property specifies the [=EPUB creator=] preference for how
-						[=reading systems=] should handle content overflow. </p>
+					<p>The <code>rendition:flow</code> property specifies the preference for how [=reading systems=]
+						should handle content overflow. </p>
 
 					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
-						specified on a <code>meta</code> element, it indicates the EPUB creator's global preference for
-						overflow content handling (i.e., for all [=EPUB spine | spine=] items). EPUB creators MAY
-						indicate a preference for dynamic pagination or scrolling. For scrolled content, it is also
-						possible to specify whether consecutive [=EPUB content documents=] are to be rendered as a
-						continuous scrolling view or whether each is to be rendered separately (i.e., with a dynamic
-						page break between each).</p>
+						specified on a <code>meta</code> element, it indicates the preference for overflow content
+						handling (i.e., for all [=EPUB spine | spine=] items). Either dynamic pagination or scrolling
+						MAY be specified. For scrolled content, it is also possible to specify whether consecutive
+						[=EPUB content documents=] are to be rendered as a continuous scrolling view or whether each is
+						to be rendered separately (i.e., with a dynamic page break between each).</p>
 
-					<p>EPUB creators MUST use one of the following values with the <code>rendition:flow</code>
-						property:</p>
+					<p>One of the following values MUST be used with the <code>rendition:flow</code> property:</p>
 
 					<dl class="variablelist">
 						<dt id="paginated">paginated</dt>
@@ -7781,9 +7770,8 @@ No Entry</pre>
 							<p>Render all EPUB content documents such that overflow content is scrollable, and the
 								[=EPUB publication=] is presented as one continuous scroll from spine item to spine item
 								(except where <a href="#flow-overrides">locally overridden</a>).</p>
-							<p>Note that EPUB creators SHOULD NOT create publications in which different resources have
-								different block flow directions, as continuous scrolled rendition in EPUB reading
-								systems would be problematic.</p>
+							<p>Resources SHOULD NOT have different block flow directions as it makes continuous scrolled
+								rendition in EPUB reading systems problematic.</p>
 						</dd>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
@@ -7804,15 +7792,14 @@ No Entry</pre>
 							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
 							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 								><code>page-break-before</code> property</a> [[!csssnapshot]] having been set to
-							<code>always</code>. In addition to using the <code>rendition:flow</code> property, EPUB
-						creators MAY override this behavior through an appropriate style sheet declaration, if the
-						reading system supports such overrides.</p>
+							<code>always</code>. In addition to using the <code>rendition:flow</code> property, this
+						behavior MAY be overridden through an appropriate style sheet declaration if the reading system
+						supports such overrides.</p>
 
-					<p>EPUB creators MUST NOT declare the <code>rendition:flow</code> property more than once.</p>
-
-					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
-							attribute</a>. Refer to <a href="#flow-overrides"></a> for setting the property for
-						individual EPUB content documents.</p>
+					<p>The <code>rendition:flow</code> property MUST NOT be declared more than once. In addition, it
+						MUST NOT be declared using the <a href="#attrdef-refines"><code>refines</code> attribute</a>.
+						Refer to <a href="#flow-overrides"></a> for setting the property for individual EPUB content
+						documents.</p>
 
 					<figure id="fig-flow-paginated-single">
 						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
@@ -7886,34 +7873,33 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L348,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L353">
 						<h5>Spine overrides</h5>
 
-						<p id="layout-property-flow-local">[=EPUB creators=] MAY specify the following properties
-							locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-								href="#property-flow-global">global value</a> for the given spine item:</p>
+						<p id="layout-property-flow-local">The following properties MAY be specified on [=EPUB spine |
+							spine=] [^itemref^] elements to override the <a href="#property-flow-global">global
+								value</a>:</p>
 
 						<dl>
 							<dt id="flow-auto">rendition:flow-auto</dt>
-							<dd>Indicates no preference for overflow content handling by the EPUB creator.</dd>
+							<dd>Indicates no preference for overflow content handling.</dd>
 
 							<dt id="flow-paginated">rendition:flow-paginated</dt>
-							<dd>Indicates the EPUB creator preference is to dynamically paginate content overflow.</dd>
+							<dd>Indicates the preference is to dynamically paginate content overflow.</dd>
 
 							<dt id="flow-scrolled-continuous">rendition:flow-scrolled-continuous</dt>
-							<dd>Indicates the EPUB creator preference is to provide a scrolled view for overflow
-								content, and that consecutive spine items with this property are to be rendered as a
-								continuous scroll.</dd>
+							<dd>Indicates the preference is to provide a scrolled view for overflow content, and that
+								consecutive spine items with this property are to be rendered as a continuous
+								scroll.</dd>
 
 							<dt id="flow-scrolled-doc">rendition:flow-scrolled-doc</dt>
-							<dd>Indicates the EPUB creator preference is to provide a scrolled view for overflow
-								content, and each spine item with this property is to be rendered as a separate
-								scrollable document.</dd>
+							<dd>Indicates the preference is to provide a scrolled view for overflow content, and each
+								spine item with this property is to be rendered as a separate scrollable document.</dd>
 						</dl>
 
-						<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
+						<p>A spine item MUST NOT declare more than one of these overrides.</p>
 
 						<aside class="example" id="property-flow-ex1"
 							title="Overriding a global paginated flow declaration">
-							<p>In this example, the EPUB creator's intent is to have a paginated [=EPUB publication=]
-								with a scrollable table of contents.</p>
+							<p>In this example, the intent is to have a paginated [=EPUB publication=] with a scrollable
+								table of contents.</p>
 							<pre>&lt;package …&gt;
 &lt;metadata …&gt;
 	…
@@ -7952,8 +7938,8 @@ No Entry</pre>
 					<div class="note">
 						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
 							in the absence of reliable centering control within the content rendering. As support for
-							paged media evolves in CSS, however, this property is expected to be deprecated. [=EPUB
-							creators=] are encouraged to use CSS solutions when effective.</p>
+							paged media evolves in CSS, this property is expected to be deprecated. The use of CSS
+							solutions is encouraged when effective.</p>
 					</div>
 				</section>
 			</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -7536,7 +7536,7 @@ No Entry</pre>
 							be rendered side-by-side for readability, such as a two-page map. To indicate that two
 							consecutive pages represent a true spread, the <code>rendition:page-spread-left</code> and
 								<code>rendition:page-spread-right</code> properties SHOULD be set on the [=EPUB spine |
-							spine=] items for the two adjacent EPUB content documents and the properties omitted on
+							spine=] items for the two adjacent EPUB content documents, and the properties omitted on
 							spine items where one-up or two-up presentation is equally acceptable.</p>
 
 						<p>A spine item MUST NOT declare more than one <code>rendition:page-spread-*</code> property,

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5907,7 +5907,7 @@ No Entry</pre>
 						<div class="note">
 							<p>Custom attributes are usually defined in a reading system-specific manner and are not
 								intended for use by other reading systems. The preferred method to add extensions for
-								multiple indenpendent reading system to use is to extend this specification.</p>
+								multiple independent reading systems to use is to extend this specification.</p>
 						</div>
 					</section>
 				</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1317,9 +1317,10 @@
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
 							attribute</a> on [=EPUB Manifest | manifest=] [^item^] elements. This attribute references
 						the <a data-cite="xml#id">ID</a> [[xml]] of another manifest <code>item</code> that is a
-						fallback for the current <code>item</code>. The ordered list of all the references that a
-						reading system can reach, starting from a given <code>item</code>'s <code>fallback</code>
-						attribute, represents both the full and preferred fallback chain for that <code>item</code>.</p>
+						fallback for the current <code>item</code>. <span id="preferred-fallback-chain">The ordered list
+							of all the references that a reading system can reach, starting from a given
+								<code>item</code>'s <code>fallback</code> attribute, represents both the full and
+							preferred fallback chain for that <code>item</code>.</span></p>
 
 					<p>There are two cases for manifest fallbacks:</p>
 
@@ -11049,9 +11050,8 @@ html.my-document-playing * {
 
 					<p>Although the <code>viewport meta</code> tag allows the use of properties other than
 							<code>height</code> and <code>width</code>, as well as to omit values for the
-							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting
-						other properties may have unintended consequences on the rendering of fixed-layout
-						documents.</p>
+							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
+						properties may have unintended consequences on the rendering of fixed-layout documents.</p>
 				</div>
 			</section>
 		</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1741,7 +1741,7 @@
 					<div class="note">
 						<p>Some [=reading systems=] do not provide access to resources outside the directory where the
 							[=package document=] is stored even though this is not a restriction defined in
-							[[epub-rs-34]]. To avoid interoperability issues with these reading systems, place all
+							[[epub-rs-34]]. To avoid interoperability issues with these reading systems, it is advised to place all
 							resources at or below the directory containing the package document.</p>
 
 						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5880,7 +5880,7 @@ No Entry</pre>
 						<p>The [[its20]] specification defines a set of attributes that MAY be used in [=XHTML content
 							documents=] to add support for internationalization, translation, and localization.</p>
 
-						<p>ITS attributes MUST only be used as they are defined in <a data-cite="its20#html5-markup"
+						<p>ITS attributes MUST only be used as defined in <a data-cite="its20#html5-markup"
 								>Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does not support the namespaced
 							attributes).</p>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -7531,7 +7531,7 @@ No Entry</pre>
 							reflowable content. They only apply when the reading system is creating synthetic
 							spreads.</p>
 
-						<p>Although it is common practice to specify to use a spread in certain device orientations, the
+						<p>Although it is common practice to specify the use of a spread in certain device orientations, the
 							content itself does not represent a true spread &#8212; two consecutive pages that have to
 							be rendered side-by-side for readability, such as a two-page map. To indicate that two
 							consecutive pages represent a true spread, the <code>rendition:page-spread-left</code> and

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
@@ -160,8 +160,8 @@
 
 				<p>The actual content of an EPUB publication — what users are presented with when they begin reading —
 					is built on the Open Web Platform and comes in two flavors: XHTML and SVG. Called [=EPUB content
-					documents=], these documents typically reference many additional resources required for their proper
-					rendering, such as images, audio and video clips, scripts, and style sheets.</p>
+					documents=], these documents typically reference many additional resources necessary for their
+					proper rendering, such as images, audio and video clips, scripts, and style sheets.</p>
 
 				<p>Refer to <a href="#sec-contentdocs"></a> for detailed information about the rules and requirements to
 					produce EPUB content documents, and [[epub-a11y-111]] for accessibility requirements.</p>
@@ -246,8 +246,8 @@
 					<h4>Relationship to SVG</h4>
 
 					<p>This specification does not reference a specific version of [[svg]], but instead uses an undated
-						reference. Whenever there is any ambiguity in this reference, the latest recommended
-						specification is the authoritative reference.</p>
+						reference. Whenever there is any ambiguity in this reference, the latest recommended version is
+						the authoritative reference.</p>
 
 					<p>The benefit of this approach is that EPUB 3 is always up to date with the SVG standard, but it
 						also means that this specification does not track changes to SVG. The SVG standards has to be
@@ -430,7 +430,7 @@
 					</dt>
 					<dd>
 						<p>Exempt resources are a special class of [=publication resources=] that do not require <a
-								href="#sec-foreign-resources">fallbacks</a> but that reading systems are not required to
+								href="#sec-foreign-resources">fallbacks</a> and that reading systems do not have to
 							support the rendering of.</p>
 						<p>Refer to <a href="#sec-exempt-resources"></a> for more information.</p>
 					</dd>
@@ -576,9 +576,9 @@
 							[=package document=], [=EPUB content documents=], CSS Style Sheets, audio, video, images,
 							embedded fonts, and scripts.</p>
 						<p>The package document [=EPUB manifest | manifest=] has to include a list of all publication
-							resources that typically have to be bundled in the [=EPUB container=] (the
-							exception being that resources listed in <a href="#sec-resource-locations"></a> can be
-							located outside the EPUB container).</p>
+							resources that typically have to be bundled in the [=EPUB container=] (the exception being
+							that resources listed in <a href="#sec-resource-locations"></a> can be located outside the
+							EPUB container).</p>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
 									<code>href</code> attribute of an [[html]] [^a^] element) are not publication
@@ -873,8 +873,8 @@
 
 					<div class="note">
 						<p>It is possible to provide manifest fallbacks for EPUB content documents, but this is not
-							required or common. For example, a [=scripted content document=] could have a fallback to an
-							unscripted alternative for reading systems that do not support scripting.</p>
+							common or a requirement. For example, a [=scripted content document=] could have a fallback
+							to an unscripted alternative for reading systems that do not support scripting.</p>
 					</div>
 				</section>
 
@@ -927,8 +927,9 @@
 						<p>A common point of confusion arising from core media type resources is the listing of XHTML
 							and SVG as core media type resources with the requirement that the markup conform to their
 							respective EPUB content document definitions. This common definition ensures that regardless
-							of whether XHTML and SVG documents are listed in the spine, or embedded in other EPUB content
-							documents, they have the same requirements for authoring and reading system support.</p>
+							of whether XHTML and SVG documents are listed in the spine, or embedded in other EPUB
+							content documents, they have the same requirements for authoring and reading system
+							support.</p>
 
 						<p>In practice, it means that XHTML and SVG core media type resources are allowed in the spine
 							without any modification or fallback as they are also conforming XHTML and SVG content
@@ -1386,7 +1387,7 @@
 
 						<div class="note">
 							<p>The requirement for fallbacks only applies to audio foreign resources referenced from
-									<code>audio</code> and <code>video</code> elements. Fallbacks are not required for
+									<code>audio</code> and <code>video</code> elements. Fallbacks are not necessary for
 								video resources; they are [=exempt resources=]. </p>
 						</div>
 					</section>
@@ -1625,17 +1626,17 @@
 			<section id="sec-ocf-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>OCF is the required container technology for [=EPUB publications=]. OCF can play a role in the
-					following workflows:</p>
+				<p>OCF is the container technology for [=EPUB publications=]. It can play a role in the following
+					workflows:</p>
 
 				<ul>
 					<li>During the preparation steps in producing an EPUB publication, OCF can be used as the container
 						format when exchanging in-progress publications between different individuals and/or different
 						organizations.</li>
 					<li>When providing an EPUB publication from publisher or conversion house to the distribution or
-						sales channel, OCF is the recommended container format to be used as the transport format.</li>
-					<li>When delivering the final EPUB publication to an [=EPUB reading system=] or user, OCF is the
-						required format for the container that holds all of the assets that make up the
+						sales channel, OCF is the preferred container format for transport.</li>
+					<li>When delivering the final EPUB publication to an [=EPUB reading system=] or user, OCF has to be
+						used as the format for the container that holds all of the assets that make up the
 						publication.</li>
 				</ul>
 
@@ -1741,8 +1742,8 @@
 					<div class="note">
 						<p>Some [=reading systems=] do not provide access to resources outside the directory where the
 							[=package document=] is stored even though this is not a restriction defined in
-							[[epub-rs-34]]. To avoid interoperability issues with these reading systems, it is advised to place all
-							resources at or below the directory containing the package document.</p>
+							[[epub-rs-34]]. To avoid interoperability issues with these reading systems, it is advised
+							to place all resources at or below the directory containing the package document.</p>
 
 						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
 								>creating multiple renditions</a> [[epub-multi-rend-11]] of the publication.</p>
@@ -3071,8 +3072,8 @@
 						ensuring the use of obfuscation meets their font licensing requirements.</p>
 
 					<p>It is also worth noting that obfuscation can lead to interoperability issues in reading systems
-						as they are not required to deobfuscate fonts. As a result, the visual presentation of a
-						publication could differ from reading system to reading system.</p>
+						as they do not have to deobfuscate fonts. As a result, the visual presentation of a publication
+						could differ from reading system to reading system.</p>
 
 					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a
 						general-purpose mechanism for obfuscating any resource in the EPUB container.</p>
@@ -3708,7 +3709,7 @@
 						[^dc:identifier^], and [^dc:language^] elements together with the [[dcterms]]
 						[^dcterms:modified^] property. All other metadata is OPTIONAL.</p>
 
-					<aside class="example" title="The minimal set of metadata required in the package document">
+					<aside class="example" title="The minimal set of metadata necessary in the package document">
 						<pre>&lt;package … unique-identifier="pub-id"&gt;
     …
     &lt;metadata …&gt;
@@ -3986,12 +3987,11 @@
 &lt;/metadata&gt;
 </pre>
 
-								<p>Previous versions of this specification recommended using the <a
-										href="#sec-title-type"><code>title-type</code></a> and <a
-										href="#sec-display-seq"><code>display-seq</code></a> properties to identify and
-									format the segments of multipart titles (see the <a href="#cookbook-ex">Great
-										Cookbooks example</a>). It is still possible to add these semantics, but they
-									are also not well supported.</p>
+								<p>Previous versions of this specification advised using the <a href="#sec-title-type"
+											><code>title-type</code></a> and <a href="#sec-display-seq"
+											><code>display-seq</code></a> properties to identify and format the segments
+									of multipart titles (see the <a href="#cookbook-ex">Great Cookbooks example</a>). It
+									is still possible to add these semantics, but they are also not well supported.</p>
 							</div>
 						</section>
 
@@ -4504,8 +4504,8 @@
 					<pre><code>YYYY-MM-DDThh:mm:ssZ</code></pre>
 
 					<div class="note">
-						<p>The required "Z" (Zulu) time indicator at the end of the pattern means the last modification
-							date is always expressed in Coordinated Universal Time (UTC).</p>
+						<p>The "Z" (Zulu) time indicator at the end of the pattern means the last modification date is
+							always expressed in Coordinated Universal Time (UTC).</p>
 					</div>
 
 					<aside class="example" title="Expressing a last modification date">
@@ -4684,8 +4684,8 @@ XHTML:
 					</aside>
 
 					<p id="linked-res-location">Although linked resources MAY be located outside the [=EPUB container=],
-						[=reading systems=] are not required to retrieve [=remote resources=]. It is advised to consider
-						what impact this might have on the user's reading experience before hosting them remotely.</p>
+						[=reading systems=] do not have to retrieve [=remote resources=]. It is advised to consider what
+						impact this might have on the user's reading experience before hosting them remotely.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
 							attribute</a> MUST be specified for all linked resources within the EPUB container. It is
@@ -5028,9 +5028,8 @@ XHTML:
     media-type="application/xhtml+xml" /&gt;</pre>
 						</aside>
 
-						<p>If an EPUB publication contains a cover image, it is recommended to set the <a
-								href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this property
-							is OPTIONAL.</p>
+						<p>If an EPUB publication contains a cover image, it is advised to set the OPTIONAL <a
+								href="#sec-cover-image"><code>cover-image</code> property</a>.</p>
 
 						<aside class="example" id="example-item-properties-cover-image"
 							title="Identifying the cover image">
@@ -5390,8 +5389,8 @@ No Entry</pre>
 						foreign content documents hyperlinked to from hyperlinked documents have to be listed, and so
 						on.).</p>
 
-					<p>All EPUB and foreign content documents hyperlinked to from the [=EPUB navigation document=] 
-						MUST also be listed in the <code>spine</code>, regardless of whether the EPUB navigation document is
+					<p>All EPUB and foreign content documents hyperlinked to from the [=EPUB navigation document=] MUST
+						also be listed in the <code>spine</code>, regardless of whether the EPUB navigation document is
 						included in the <code>spine</code>.</p>
 
 					<div class="note">
@@ -5880,8 +5879,8 @@ No Entry</pre>
 						<p>The [[its20]] specification defines a set of attributes that MAY be used in [=XHTML content
 							documents=] to add support for internationalization, translation, and localization.</p>
 
-						<p>ITS attributes MUST only be used as defined in <a data-cite="its20#html5-markup"
-								>Using ITS markup in HTML</a> [[its20]] (i.e., EPUB 3 does not support the namespaced
+						<p>ITS attributes MUST only be used as defined in <a data-cite="its20#html5-markup">Using ITS
+								markup in HTML</a> [[its20]] (i.e., EPUB 3 does not support the namespaced
 							attributes).</p>
 
 						<p>The use of these attributes MUST conform to the requirements defined in [[its20]].</p>
@@ -6292,10 +6291,9 @@ No Entry</pre>
 								if a future update adds the concept.</p>
 						</div>
 
-						<p>Note that [=reading systems=] are required to behave as though a unique <a
-								data-cite="html#origin">origin</a> [[html]] has been assigned to each [=EPUB
-							publication=]. In practice, this means that it is not possible for scripts to share data
-							between EPUB publications.</p>
+						<p>Note that [=reading systems=] have to behave as though a unique <a data-cite="html#origin"
+								>origin</a> [[html]] has been assigned to each [=EPUB publication=]. In practice, this
+							means that it is not possible for scripts to share data between EPUB publications.</p>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
 							rights and restrictions that a reading system places on it (refer to <a
@@ -6367,8 +6365,7 @@ No Entry</pre>
 
 							<p>Note that <a data-cite="epub-rs-34#sec-scripted-content">support for
 									container-constrained scripting in reading systems</a> is only recommended in
-								reflowable documents [[epub-rs-34]]. Furthermore, [=reading system=] support in
-								[=fixed-layout documents=] is optional.</p>
+								reflowable documents [[epub-rs-34]] and optional in [=fixed-layout documents=].</p>
 
 							<p>Ensure that container-constrained scripts degrade gracefully in reading systems without
 								scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
@@ -6456,8 +6453,8 @@ No Entry</pre>
 					restrictions on the structure or content of the EPUB navigation document outside of the specialized
 					navigation elements (i.e., the rest of the document can be marked up like any other XHTML content
 					document). As a result, it can also be part of the linear reading order, avoiding the need for
-					duplicate tables of contents. Navigation elements that are only meant for machine processing (e.g., the
-					page list) can be hidden using the <a href="#sec-nav-doc-use-spine"><code>hidden</code>
+					duplicate tables of contents. Navigation elements that are only meant for machine processing (e.g.,
+					the page list) can be hidden using the <a href="#sec-nav-doc-use-spine"><code>hidden</code>
 						attribute</a>.</p>
 
 				<p>Note that reading systems might strip scripting, styling, and HTML formatting as they generate
@@ -6818,7 +6815,7 @@ No Entry</pre>
 						items that a reading system is likely to use in its user interface. The element is not meant to
 						repeat the table of contents.</p>
 
-					<p>The following landmarks are recommended to include when available:</p>
+					<p>It is advised to include the following landmarks when available:</p>
 
 					<ul>
 						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?epub-ssv-11]] — Reading
@@ -6890,12 +6887,11 @@ No Entry</pre>
 
 				<p id="confreq-nav-ol-style">When adding the navigation document to the spine, consider that any
 					[=reading system=] processing of the document will not apply. In particular, although [=EPUB reading
-					systems=] are <a data-cite="epub-rs-34#confreq-nav-ol-style">required to suppress list item
-						numbering</a> [[epub-rs-34]] when presenting the EPUB navigation document outside of the spine
-					(such as in dedicated navigation user interfaces provided by reading systems), this requirement does
-					not apply to in-spine use. Consequently, if HTML's default list item numbering is not wanted when
-					presenting the navigation document in the spine, alternative list styling has to be provided using
-					CSS.</p>
+					systems=] <a data-cite="epub-rs-34#confreq-nav-ol-style">have to suppress list item numbering</a>
+					[[epub-rs-34]] when presenting the EPUB navigation document outside of the spine (such as in
+					dedicated navigation user interfaces provided by reading systems), this requirement does not apply
+					to in-spine use. Consequently, if HTML's default list item numbering is not wanted when presenting
+					the navigation document in the spine, alternative list styling has to be provided using CSS.</p>
 
 				<p>Similarly, it is often the case that not all of the navigation structures, or branches within them,
 					are needed when the EPUB navigation document is presented in the spine. It is often preferred to
@@ -7531,9 +7527,9 @@ No Entry</pre>
 							reflowable content. They only apply when the reading system is creating synthetic
 							spreads.</p>
 
-						<p>Although it is common practice to specify the use of a spread in certain device orientations, the
-							content itself does not represent a true spread &#8212; two consecutive pages that have to
-							be rendered side-by-side for readability, such as a two-page map. To indicate that two
+						<p>Although it is common practice to specify the use of a spread in certain device orientations,
+							the content itself does not represent a true spread &#8212; two consecutive pages that have
+							to be rendered side-by-side for readability, such as a two-page map. To indicate that two
 							consecutive pages represent a true spread, the <code>rendition:page-spread-left</code> and
 								<code>rendition:page-spread-right</code> properties SHOULD be set on the [=EPUB spine |
 							spine=] items for the two adjacent EPUB content documents, and the properties omitted on
@@ -7950,7 +7946,7 @@ No Entry</pre>
 					some examples of works that contain synchronized audio narration. In EPUB 3, these types of books
 					can be created using media overlay documents to describe the timing for the pre-recorded audio
 					narration and how it relates to the [=EPUB content document=] markup. The specification defines the
-					file format for media overlays as a subset of [[smil3]], a W3C recommendation for representing
+					file format for media overlays as a subset of [[smil3]], a W3C Recommendation for representing
 					synchronized multimedia information in XML.</p>
 
 				<p>The text and audio synchronization enabled by media overlays provides enhanced accessibility for any
@@ -9606,7 +9602,7 @@ html.my-document-playing * {
 									href="#sec-xhtml-epub-trigger">multimedia control elements</a> only allow hiding of
 								content and script-less control of playback in HTML. Moreover, these features,
 								introduced in the first release of EPUB 3.0, are <a href="#deprecated">deprecated</a>
-								and no longer recommended for use.</p>
+								and no longer advised for use.</p>
 						</li>
 						<li>
 							<p>The <a href="#sec-epub-type-attribute">expression of structural semantics</a> in HTML and
@@ -10168,7 +10164,7 @@ html.my-document-playing * {
 						terms and properties, it is only necessary to declare a <a href="#sec-prefix-attr">prefix</a>.
 						In another authoring convenience, this specification also <a
 							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
-						publishing vocabularies (i.e., their declaration is optional).</p>
+						publishing vocabularies (i.e., their declaration is not required).</p>
 
 					<p>The following sections provide additional details on the <var>property</var> data type and
 						vocabulary association mechanism.</p>
@@ -11040,8 +11036,8 @@ html.my-document-playing * {
 							><code>meta</code></a> element by the [[html]] grammar.</p>
 
 				<div class="note">
-					<p>For more information about specifying the required <code>height</code> and <code>width</code>
-						properties, and their required values, refer to <a href="#sec-fxl-content-dimensions"></a>.</p>
+					<p>For more information about specifying the <code>height</code> and <code>width</code> properties
+						and their expected values, refer to <a href="#sec-fxl-content-dimensions"></a>.</p>
 
 					<p>Although the <code>viewport meta</code> tag allows the use of properties other than
 							<code>height</code> and <code>width</code>, as well as to omit values for the
@@ -11305,7 +11301,7 @@ html.my-document-playing * {
 							is referenced from a hyperlink, it <em>has to</em> be listed in the spine. It is a
 							publication resource on the manifest plane, a container resource, a [=foreign content
 							document=] on the spine plane, and a core media type resource on the content plane. As a
-							foreign content document, a fallback is required, which is provided via a <a
+							foreign content document, a fallback is mandatory and is provided via a <a
 								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
@@ -11324,7 +11320,7 @@ html.my-document-playing * {
 							referenced from an [[html]] [^source^] element. Its media type is not listed as a <a
 								href="#sec-core-media-types">core media type</a>. It is a publication resource on the
 							manifest plane, a container resource, is not present on the spine plane, and is a foreign
-							resource on the content plane. As a foreign resource, a fallback is required, which is
+							resource on the content plane. As a foreign resource, a fallback is mandatory and is
 							provided via the sibling [[html]] [^img^] element in an [[html]] [^picture^] element.</p>
 					</dd>
 

--- a/epub34/authoring/vocab/item-properties.html
+++ b/epub34/authoring/vocab/item-properties.html
@@ -1,4 +1,4 @@
-<html><head></head><body><section id="app-item-properties-vocab" class="vocab">
+<section id="app-item-properties-vocab" class="vocab">
 	<h3>Manifest properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the manifest [^item^]
@@ -235,4 +235,3 @@
 		</table>
 	</section>
 </section>
-</body></html>

--- a/epub34/authoring/vocab/itemref-properties.html
+++ b/epub34/authoring/vocab/itemref-properties.html
@@ -1,4 +1,4 @@
-<html><head></head><body><section id="app-itemref-properties-vocab" class="vocab">
+<section id="app-itemref-properties-vocab" class="vocab">
 	<h3>Spine properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the spine [^itemref^] element's
@@ -79,4 +79,3 @@
 		</aside>
 	</section>
 </section>
-</body></html>

--- a/epub34/authoring/vocab/link.html
+++ b/epub34/authoring/vocab/link.html
@@ -1,4 +1,4 @@
-<html><head></head><body><section id="app-link-vocab" class="vocab">
+<section id="app-link-vocab" class="vocab">
 	<h3>Metadata link vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the metadata [^link^]
@@ -186,4 +186,3 @@
 		</section>
 	</section>
 </section>
-</body></html>

--- a/epub34/authoring/vocab/meta-property.html
+++ b/epub34/authoring/vocab/meta-property.html
@@ -145,11 +145,10 @@
 							collections.</p>
 						<p>It is also possible to chain these properties using the <a href="#attrdef-refines"><code>refines</code> attribute</a> to indicate that one collection is
 							itself a member of another collection.</p>
-						<p>To allow [=reading systems=] to organize collections and avoid naming collisions (e.g.,
-							unrelated collections might share a similar name, or different editions of a
-							collection could be released), an identifier that uniquely
-							identifies the instance of the collection SHOULD be provided using a 
-							<code>dcterms:identifier</code> property.</p>
+						<p>A unique identifier SHOULD be provided for each instance of a collection using a 
+							<code>dcterms:identifier</code> property. This will allow [=reading systems=] to organize 
+							collections and avoid naming collisions (e.g., unrelated collections might share a similar 
+							name, or different editions of a collection could be released).</p>
 						<p>The collection MAY more precisely define its nature by attaching a <a href="#collection-type"><code>collection-type</code></a> property.</p>
 						<p>The position of the EPUB publication within the collection MAY be provided by
 							attaching a <a href="#group-position"><code>group-position</code> property</a>.</p>
@@ -228,7 +227,7 @@
 							</dd>
 						</dl>
 						<div class="note">
-							<p>Although [=reading systems=] are not required to support these values, specifying
+							<p>Although [=reading systems=] do not have to support these values, specifying
 								them provides the option to group related [=EPUB publications=] in more meaningful
 								ways.</p>
 						</div>
@@ -681,7 +680,7 @@ Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 	</section>
 	<section id="sec-source-of" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L170,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L175,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L182,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L189,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L196">
 		<h5>source-of</h5>
-		<p>The <code>source-of</code> property is no longer recommended for use in EPUB publications. To indicate
+		<p>It is no longer advised to use the <code>source-of</code> property in EPUB publications. To indicate
 			the source of pagination for an EPUB publication, refer to the <a 
 				href="#sec-pageBreakSource"><code>pageBreakSource</code> property definition</a>.</p>
 		<div class="note">

--- a/epub34/authoring/vocab/meta-property.html
+++ b/epub34/authoring/vocab/meta-property.html
@@ -1,4 +1,4 @@
-<html><head></head><body><section id="app-meta-property-vocab" class="vocab">
+<section id="app-meta-property-vocab" class="vocab">
 	<h3>Meta properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the [^meta^]
@@ -979,4 +979,3 @@ Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 		</aside>
 	</section>
 </section>
-</body></html>

--- a/epub34/authoring/vocab/meta-property.html
+++ b/epub34/authoring/vocab/meta-property.html
@@ -148,8 +148,8 @@
 						<p>To allow [=reading systems=] to organize collections and avoid naming collisions (e.g.,
 							unrelated collections might share a similar name, or different editions of a
 							collection could be released), an identifier that uniquely
-							identifies the instance of the collection SHOULD be provided. The 
-							<code>dcterms:identifier</code> property must carry this identifier.</p>
+							identifies the instance of the collection SHOULD be provided using a 
+							<code>dcterms:identifier</code> property.</p>
 						<p>The collection MAY more precisely define its nature by attaching a <a href="#collection-type"><code>collection-type</code></a> property.</p>
 						<p>The position of the EPUB publication within the collection MAY be provided by
 							attaching a <a href="#group-position"><code>group-position</code> property</a>.</p>
@@ -520,7 +520,7 @@
 				<td>
 					<p>Provides a unique identifier for the source of the page break markers in an <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a>.</p>
-					<p>The identifier should be expressed as a URN when the value conforms to a recognized
+					<p>It is advised to use a URN as the value when the identifier conforms to a recognized
 						scheme such as an ISBN.</p>
 					<p>If a unique identifier does not exist for the source, it is advised to use a text description 
 						that identifies the source as clearly as possible (e.g., the title of a word
@@ -600,10 +600,10 @@ Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 						<p>When the <code>role</code> value is drawn from a code list or other formal
 							enumeration, a <a href="#attrdef-scheme"><code>scheme</code>
 								attribute</a> SHOULD be attached to identify its source.</p>
-						<p>When attaching multiple roles to an individual or organization, the importance of the
-							roles should match the document order of their containing <code>meta</code> elements
-							(i.e., the first <code>meta</code> element encountered should contain the most
-							important role).</p>
+						<p>When assigning multiple roles to an individual or organization, associate each role in a
+							separate <code>meta</code> element and ensure the document order of the elements reflects
+							the importance of the roles played (i.e., the first <code>meta</code> element encountered
+							contains the most important role).</p>
 					</td>
 				</tr>
 				<tr>

--- a/epub34/authoring/vocab/meta-property.html
+++ b/epub34/authoring/vocab/meta-property.html
@@ -147,9 +147,9 @@
 							itself a member of another collection.</p>
 						<p>To allow [=reading systems=] to organize collections and avoid naming collisions (e.g.,
 							unrelated collections might share a similar name, or different editions of a
-							collection could be released), [=EPUB creators=] SHOULD provide an identifier that uniquely
-							identifies the instance of the collection. The <code>dcterms:identifier</code>
-							property must carry this identifier.</p>
+							collection could be released), an identifier that uniquely
+							identifies the instance of the collection SHOULD be provided. The 
+							<code>dcterms:identifier</code> property must carry this identifier.</p>
 						<p>The collection MAY more precisely define its nature by attaching a <a href="#collection-type"><code>collection-type</code></a> property.</p>
 						<p>The position of the EPUB publication within the collection MAY be provided by
 							attaching a <a href="#group-position"><code>group-position</code> property</a>.</p>
@@ -207,8 +207,8 @@
 						<p>The <code>collection-type</code> property indicates the form or nature of a
 							collection.</p>
 						<p>When the <code>collection-type</code> value is drawn from a code list or other formal
-							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
-								attribute</a> to identify its source.</p>
+							enumeration, a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> SHOULD be attached to identify its source.</p>
 						<p>This specification also defines the following collection types when no scheme is
 							specified:</p>
 						<dl>
@@ -379,7 +379,7 @@
 						<p>The <code>group-position</code> property indicates the numeric position in which the
 							[=EPUB publication=] is ordered relative to other works belonging to the same group
 							(whether all EPUB publications or not).</p>
-						<p>[=EPUB creators=] can attach the <code>group-position</code> property to any metadata
+						<p>The <code>group-position</code> property can be attached to any metadata
 							property that establishes the group but it is typically associated with the <a href="#belongs-to-collection"><code>belongs-to-collection</code>
 							property</a>.</p>
 						<p>An EPUB publication can belong to more than one group.</p>
@@ -462,8 +462,8 @@
 						<p>The <code>identifier-type</code> property indicates the form or nature of an
 								<code>identifier</code>.</p>
 						<p>When the <code>identifier-type</code> value is drawn from a code list or other formal
-							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
-								attribute</a> to identify its source.</p>
+							enumeration, a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> SHOULD be attached to identify its source.</p>
 					</td>
 				</tr>
 				<tr>
@@ -522,11 +522,11 @@
 							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a>.</p>
 					<p>The identifier should be expressed as a URN when the value conforms to a recognized
 						scheme such as an ISBN.</p>
-					<p>If a unique identifier does not exist for the source, EPUB creators should use a text
-						description that identifies the source as clearly as possible (e.g., the title of a word
+					<p>If a unique identifier does not exist for the source, it is advised to use a text description 
+						that identifies the source as clearly as possible (e.g., the title of a word
 						processing document).</p>
 					<p>If the page break markers are unique to the EPUB publication (e.g., for a digital-only
-						edition), EPUB creators MUST specify the value "<code>none</code>".</p>
+						edition), the value "<code>none</code>" MUST be specified.</p>
 				</td>
 			</tr>
 			<tr>
@@ -598,8 +598,8 @@ Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 								<code>contributor</code> or <code>publisher</code> in the creation of an EPUB
 							publication.</p>
 						<p>When the <code>role</code> value is drawn from a code list or other formal
-							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
-								attribute</a> to identify its source.</p>
+							enumeration, a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> SHOULD be attached to identify its source.</p>
 						<p>When attaching multiple roles to an individual or organization, the importance of the
 							roles should match the document order of their containing <code>meta</code> elements
 							(i.e., the first <code>meta</code> element encountered should contain the most
@@ -686,7 +686,7 @@ Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 				href="#sec-pageBreakSource"><code>pageBreakSource</code> property definition</a>.</p>
 		<div class="note">
 			<p>The <code>source-of</code> property will not be officially deprecated due to the existing base of EPUB 
-				publications in which it is used, but it should be treated by EPUB creators as though it is deprecated.
+				publications in which it is used, but it is advised to treat it as though it is deprecated.
 				For information on its use, refer to <a data-cite="epub-33#source-of"><code>source-of</code> property 
 					definition</a> in [[epub-33]].</p>
 		</div>
@@ -765,8 +765,8 @@ Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 						<p>The <code>title-type</code> property indicates the form or nature of a
 								<code>title</code>.</p>
 						<p>When the <code>title-type</code> value is drawn from a code list or other formal
-							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
-								attribute</a> to identify its source. When a scheme is not specified, [=reading systems=]
+							enumeration, a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> SHOULD be attached to identify its source. When a scheme is not specified, [=reading systems=]
 								SHOULD recognize the following title type values:
 								<code>main</code>, <code>subtitle</code>, <code class="value">short</code>,
 								<code>collection</code>, <code class="value">edition</code> and

--- a/epub34/authoring/vocab/overlays.html
+++ b/epub34/authoring/vocab/overlays.html
@@ -18,7 +18,7 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>[=EPUB creator=]-defined CSS class name to apply to the currently playing [=EPUB content document=]
+					<td>The CSS class name to apply to the currently playing [=EPUB content document=]
 						element.</td>
 				</tr>
 				<tr>

--- a/epub34/authoring/vocab/overlays.html
+++ b/epub34/authoring/vocab/overlays.html
@@ -1,4 +1,5 @@
-<html><head></head><body><section id="app-overlays-vocab" class="vocab">
+
+<section id="app-overlays-vocab" class="vocab">
 	<h3>Media overlays vocabulary</h3>
 	<p>The properties in this vocabulary are usable in the [^meta^] element's
 			<code>property</code> attribute.</p>
@@ -152,4 +153,3 @@
 		</table>
 	</section>
 </section>
-</body></html>

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -97,17 +97,15 @@
 	<section id="sec-rendering-custom-properties" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_package-rendering-vocab.feature_L19">
 		<h4>Custom rendering properties</h4>
 		
-		<p>[=Reading system=] developers may introduce functionality not defined in this specification to address 
-			reading system-specific issues rendering [=EPUB content documents=].</p>
-		
-		<p>To facilitate this experimentation, custom properties and [=EPUB spine | spine=]
-			overrides MAY be included in the [=package document=] provided they do not use the <code>rendition:</code>
-			prefix.</p>
+		<p>To address reading system-specific issues rendering [=EPUB content documents=], 
+			[=reading system=] developers MAY define custom properties and [=EPUB spine | spine=]
+			overrides for use in the [=package document=]. These properties MUST NOT use the 
+			<code>rendition:</code> prefix.</p>
 		
 		<div class="note">
-			<p>Custom properties should only address rendering issues specific to a particular reading system. This
-				specification should be extended to provide extensions that multiple independent reading systems can
-				use.</p>
+			<p>Custom properties are only for addressing rendering issues specific to a particular reading system. If
+				extensions are needed that multiple independent reading systems can use, the preferred method is to
+				extend this specification.</p>
 		</div>
 	</section>
 </section>

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -100,8 +100,8 @@
 		<p>[=Reading system=] developers may introduce functionality not defined in this specification to address 
 			reading system-specific issues rendering [=EPUB content documents=].</p>
 		
-		<p>To facilitate this experimentation, [=EPUB creators=] MAY include custom properties and [=EPUB spine | spine=]
-			overrides for use in the [=package document=] provided they do not use the <code>rendition:</code>
+		<p>To facilitate this experimentation, custom properties and [=EPUB spine | spine=]
+			overrides MAY be included in the [=package document=] provided they do not use the <code>rendition:</code>
 			prefix.</p>
 		
 		<div class="note">

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -1,4 +1,4 @@
-<html><head></head><body><section id="app-rendering-vocab">
+<section id="app-rendering-vocab">
 	<h3>Package rendering vocabulary</h3>
 	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
@@ -97,16 +97,16 @@
 	<section id="sec-rendering-custom-properties" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_package-rendering-vocab.feature_L19">
 		<h4>Custom rendering properties</h4>
 		
-		<p>To address reading system-specific issues rendering [=EPUB content documents=], 
-			[=reading system=] developers MAY define custom properties and [=EPUB spine | spine=]
-			overrides for use in the [=package document=]. These properties MUST NOT use the 
-			<code>rendition:</code> prefix.</p>
+		<p>Custom properties and [=EPUB spine | spine=] overrides can be included in the 
+			[=package document=] to address rendering issues specific to particular 
+			[=reading systems=], as defined by the developers of those reading systems.</p>
 		
-		<div class="note">
-			<p>Custom properties are only for addressing rendering issues specific to a particular reading system. If
-				extensions are needed that multiple independent reading systems can use, the preferred method is to
-				extend this specification.</p>
-		</div>
+		<p>The only restrictions are that such properties MUST NOT be defined with a 
+			<code>rendition:</code> prefix and MUST NOT conflict behaviorally with properties 
+			in the <a href="app-rendering-vocab">package rendering vocabulary</a>.</p>
+			
+		<p>If extensions are needed for use by multiple independent reading systems, the 
+			preferred method is to extend the package rendering vocabulary through a revision 
+			to this standard.</p>
 	</section>
 </section>
-</body></html>

--- a/epub34/overview/index.html
+++ b/epub34/overview/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Overview</title>
@@ -651,9 +651,9 @@
 						EPUB Accessibility 1.1.1 [[epub-a11y-111]] discovery and accessibility requirements for EPUB
 						publications. </li>
 					<li>
-						[[[epub-a11y-exemption]]] [[epub-a11y-exemption]]: the <code>exemption</code> property allows EPUB creators to indicate that an EPUB publication that does
-						not meet accessibility conformance requirements has an exemption under the applicable jurisdiction's
-						laws.
+						[[[epub-a11y-exemption]]] [[epub-a11y-exemption]]: the <code>exemption</code> property is used
+						to indicate that an EPUB publication that does not meet accessibility conformance requirements
+						has an exemption under the applicable jurisdiction's laws.
 					</li>
 					<li>
 						[[[epub-fxl-a11y]]] [[epub-fxl-a11y]]: provides guidance on how to make fixed-layout EPUB publications accessible.	

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -163,7 +163,7 @@
 					allow for such flexibility.</p>
 
 				<p>So, although this specification identifies the formal requirements for reading systems, it is not
-					possible to understand this document in isolation. Developers should also familiarize themselves
+					possible to understand this document in isolation. Developers also need to familiarize themselves
 					with the full content structure of an EPUB publication in order to understand the complete range of
 					information that is available.</p>
 
@@ -212,7 +212,7 @@
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
-					<p>[=Reading system=] developers must keep track of the changes to HTML, and the technologies it
+					<p>[=Reading system=] developers need to keep track of the changes to HTML, and the technologies it
 						references, to ensure they keep their systems up to date.</p>
 
 					<p>This specification does not require EPUB reading systems to support <a
@@ -232,7 +232,7 @@
 						specification is the authoritative reference.</p>
 
 					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. [=Reading
-						system=] developers must keep track of changes to the SVG standard to ensure that they keep
+						system=] developers need to keep track of changes to the SVG standard to ensure that they keep
 						their systems up to date.</p>
 				</section>
 			</section>
@@ -248,7 +248,7 @@
 					as all applicable conditionally-required features (e.g., to support image rendering if the reading
 					system has a [=viewport=]) as defined in their respective sections.</p>
 
-				<p class="note"> As a reading system is not necessarily a single application, but may exist as a
+				<p class="note"> As a reading system is not necessarily a single application, but can exist as a
 					distributed system, it is not always the case that reading system requirements will be met in the
 					application that renders EPUB publications to users. An example is a reading system that solely
 					interacts with a controlled content repository (e.g., a bookstore or library system). In this case,
@@ -260,14 +260,14 @@
 					requirements as defined in their respective sections.</p>
 
 				<p>When reading system developers opt not to support a recommended or optional feature, it does not
-					always mean none of the normative requirements of the section apply. In some cases, there may be
+					always mean none of the normative requirements of the section apply. In some cases, there might be
 					alternative requirements when not implementing a feature (e.g., to <a
 						href="#confreq-rs-scripted-flbk">process fallbacks</a> when scripting is not supported). Reading
 					systems MUST meet these alternative requirements when not supporting a feature.</p>
 
 				<div class="note">
 					<p>EPUB publications frequently contain information not required by this specification (e.g.,
-						[=package document=] metadata). Reading systems may use this additional information for any
+						[=package document=] metadata). Reading systems can use this additional information for any
 						purposes (e.g., to improve the user interface).</p>
 				</div>
 			</section>
@@ -318,8 +318,8 @@
 
 				<p class="note" id="note-video-codecs">It is recommended that reading systems support at least one of
 					the H.264 [[h264]] and VP8 [[rfc6386]] video codecs, but this is not a conformance requirement
-					&#8212; a reading system may support any video codec, or none at all. Reading system developers
-					should take into consideration factors such as breadth of adoption, playback quality, and technology
+					&#8212; a reading system can support any video codec, or none at all. Reading system developers have
+					to take into consideration factors such as breadth of adoption, playback quality, and technology
 					royalties when deciding which video formats to support.</p>
 			</section>
 
@@ -622,8 +622,8 @@
 					</div>
 
 					<div class="note">
-						<p>Unlike most language specifications, reading systems must use the [=container root URL=] as
-							the <a data-cite="url#concept-base-url">base URL</a> [[url]] for all files within the
+						<p>Unlike most language specifications, reading systems have to use the [=container root URL=]
+							as the <a data-cite="url#concept-base-url">base URL</a> [[url]] for all files within the
 								<code>META-INF</code> directory. See also the section on <a
 								data-cite="epub-34#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code>
 								directory</a> in [[!epub-34]].</p>
@@ -636,7 +636,7 @@
 					<p>Although [[epub-34]] defines <a data-cite="epub-34#sec-container-filenames">file name and file
 							path restrictions</a> for maximum interoperability, reading systems SHOULD attempt to
 						process file names and paths that do not adhere to these requirements. Invalid file names and
-						paths may only be problematic on some operating systems.</p>
+						paths might only be problematic on some operating systems.</p>
 
 					<p>This specification does not specify how a reading system that is unable to represent OCF file
 						names and paths would handle this incompatibility.</p>
@@ -755,15 +755,15 @@
 					SHOULD support deobfuscation of fonts as defined in <a data-cite="epub-34#sec-font-obfuscation">Font
 						obfuscation</a> [[epub-34]].</p>
 
-				<p>To restore the original data, reading systems should simply reverse the process: the source file
-					becomes the obfuscated data, and the destination file contains the raw data.</p>
+				<p>To restore the original data, reading systems can simply reverse the process: the source file becomes
+					the obfuscated data, and the destination file contains the raw data.</p>
 
 				<div class="note">
 					<p>EPUB 3 allowed font obfuscation prior to EPUB 3.0.1, but did not specify the order of obfuscation
 						and compression. As a result, reading systems might encounter invalid fonts after decompression
-						and deobfuscation. In such instances, deobfuscating the data before inflating it may return a
-						valid font. Reading systems do not have to support this method of retrieval, but developers
-						should consider it when supporting EPUB 3 content generally.</p>
+						and deobfuscation. In such instances, deobfuscating the data before inflating it might return a
+						valid font. Reading systems do not have to support this method of retrieval, but developers need
+						to consider that it will likely be encountered if they support EPUB 3 content generally.</p>
 				</div>
 			</section>
 		</section>
@@ -802,7 +802,7 @@
 				<p id="confreq-rs-pkg-unique-id" data-tests="#pkg-unique-id">Reading systems SHOULD NOT depend on the
 					[=unique identifier=] being unique to one and only one [=EPUB publication=]. Determining whether two
 					EPUB publications with the same unique identifier represent different versions of the same
-					publication, or different publications, may require inspecting other metadata, such as their last
+					publication, or different publications, could require inspecting other metadata, such as their last
 					modification dates, titles, and authors.</p>
 			</section>
 
@@ -1088,7 +1088,7 @@
 							</li>
 						</ul>
 
-						<p class="note">Reading systems may choose to use third-party libraries such as <a
+						<p class="note">Reading systems can use third-party libraries such as <a
 								href="https://www.mathjax.org/">MathJax</a> to provide MathML rendering.</p>
 					</section>
 
@@ -1266,7 +1266,7 @@
 					<li>
 						<p id="confreq-rs-scripted-optional-support">Reading systems MAY support scripting in other
 							contexts, but this specification does not address such scripting. As a result, the use of
-							scripting in these contexts may not be consistent across reading systems.</p>
+							scripting in these contexts might not be consistent across reading systems.</p>
 					</li>
 				</ul>
 
@@ -1342,25 +1342,24 @@
 					<p>Reading systems SHOULD follow the DOM Event model as per [[html]] and pass UI events to the
 						scripting environment before performing any default action associated with these events.</p>
 
-					<p>Reading system developers must ensure that scripts cannot disable critical functionality (such as
-						navigation) to constrain the extent to which a <a href="#sec-scripted-content-security"
+					<p>Reading system developers have to ensure that scripts cannot disable critical functionality (such
+						as navigation) to constrain the extent to which a <a href="#sec-scripted-content-security"
 							>potentially malicious</a> script could impact their reading systems. As a result, although
-						the scripting environment should be able to cancel the default action of any event, some events
-						either might not be passed through or might not be cancelable.</p>
+						the scripting environment ought to be able to cancel the default action of any event, some
+						events either might not be passed through or might not be cancelable.</p>
 				</section>
 
 				<section id="sec-scripted-content-security" class="informative">
 					<h3>Security considerations</h3>
 
-					<p>Reading system developers who also support scripting must be aware of the security issues that
+					<p>Reading system developers who also support scripting need to be aware of the security issues that
 						arise when reading systems execute scripted content. As the underlying scripting model employed
-						by reading systems and browsers is the same, developers must take into consideration the same
+						by reading systems and browsers is the same, developers have to take into consideration the same
 						kinds of issues encountered in web contexts.</p>
 
-					<p>Each reading system must establish if it can trust the scripts in a particular document. Reading
-						systems should treat all scripts as untrusted (and potentially malicious), and developers should
-						examine all vectors of attack and protect against them. In particular, developers should
-						consider the following:</p>
+					<p>Each reading system has to establish if it can trust the scripts in a particular document. It is
+						advised to treat all scripts as untrusted (and potentially malicious) and to examine and protect
+						against all vectors of attack, in particular:</p>
 
 					<ul>
 						<li>
@@ -1395,9 +1394,9 @@
 					<p>Examples of web APIs that are tied to the concept of "origin" include web storage [[html]] and
 						IndexedDB [[indexeddb]], which EPUB content documents can interact with via scripting. Reading
 						systems that allow users to add/remove publications from a managed library (their "bookshelf")
-						may maintain the publication's unique origin when the publication is removed and subsequently
-						re-imported into the content library. Conversely, reading systems may create a new unique origin
-						for every newly added publication.</p>
+						might maintain the publication's unique origin when the publication is removed and subsequently
+						re-imported into the content library. Conversely, reading systems might create a new unique
+						origin for every newly added publication.</p>
 
 					<p>This specification also recommends that <a data-cite="epub-34#sec-scripted-container-constrained"
 							>container-constrained scripts</a> [[epub-34]] not be allowed to modify the DOM of the host
@@ -1405,8 +1404,8 @@
 							href="#sec-scripted-content"></a>).</p>
 
 					<p>Note that compliance with these recommendations does not guarantee protection from the possible
-						attacks listed above; developers must examine each potential vulnerability within the context of
-						their reading system.</p>
+						attacks listed above; developers have to examine each potential vulnerability within the context
+						of their reading system.</p>
 				</section>
 			</section>
 		</section>
@@ -1668,7 +1667,7 @@
 									meta</code> tag (i.e., ignore repeated declarations). </p>
 							<p> If the <code>viewport meta</code> does not contain a width or a height value, or if
 								these values are invalid, reading systems MAY supply the values. For example, a reading
-								system may: </p>
+								system might:</p>
 							<ul>
 								<li>consider these as having the values <code>device-width</code> and
 										<code>device-height</code>, respectively; or</li>
@@ -1694,10 +1693,9 @@
 									data-cite="epub-34#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[epub-34]] to
 								render [=SVG content documents=]. </p>
 							<p id="confreq-fxl-rs-svg-icb-ratio" class="note"> When the ICB aspect ratio does not match
-								the aspect ratio of the reading system [=content display area=], reading systems should
-								follow the rules for the <a
-									href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
-									><code>viewBox</code></a> and the <a
+								the aspect ratio of the reading system [=content display area=], it is advised to follow
+								the rules for the <a href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
+										><code>viewBox</code></a> and the <a
 									href="https://www.w3.org/TR/SVG/coords.html#PreserveAspectRatioAttribute"
 										><code>preserveAspectRatio</code></a> attributes, as defined in [[SVG]]. </p>
 						</dd>
@@ -1783,13 +1781,13 @@
 						processing <a data-cite="epub-34#def-layout-pre-paginated">pre-paginated spine items</a>
 						[[epub-34]].</p>
 
-					<p class="note"> Reading system developers may decide to disregard this restriction, and accept the
+					<p class="note">Reading system developers could decide to disregard this restriction and accept the
 							<code>scrolled-continuous</code> value of <code>rendition:flow</code> as a switch to display
 						each pre-paginated spine item on a long, vertical strip (making it is easier to read on a
 						smartphone or computer). This type of presentation is often referred to as <a
 							href="https://medium.com/mrcomics/what-is-webtoon-4926929b20d8">"webtoons"</a>. Some
 						publishers already use this possibility. After some further experimentation and incubation, a
-						future version of this specification may introduce this approach as a standard feature for
+						future version of this specification could introduce this approach as a standard feature for
 						fixed-layout documents. See also the (deferred) github <a
 							href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>. </p>
 				</section>
@@ -1980,7 +1978,7 @@
 
 					<div class="note" id="note-table-reading-mode">
 						<p>Media overlay document elements can be associated with EPUB content document structures such
-							as tables. Reading systems should ensure that media overlay playback remains synchronized
+							as tables. Reading systems need to ensure that media overlay playback remains synchronized
 							with user navigation of table rows and cells. The reading system might also play the
 							corresponding table header preceding the contents of the cell.</p>
 					</div>
@@ -2007,7 +2005,7 @@
 						inference, of the parent <code>par</code> element) is therefore determined by the execution of
 						the Text-to-Speech engine, and cannot be known at authoring time (factors like speech rate,
 						pauses and other prosody parameters influence the audio output). This also means that reading
-						systems should treat the <a data-cite="epub-34#duration"><code>duration</code></a> property
+						systems need to treat the <a data-cite="epub-34#duration"><code>duration</code></a> property
 						values set in the package document as approximative when making use of them.</p>
 				</section>
 			</section>
@@ -2161,10 +2159,10 @@
 						<summary>Explanation</summary>
 						<p>The path-relative-scheme-less-URL string definition has a number of restrictions that apply
 							to the reference whether it has a prefix or not.</p>
-						<p>For example, the reference must not begin with a [=URL-scheme string=] followed by a colon.
+						<p>For example, the reference cannot begin with a [=URL-scheme string=] followed by a colon.
 							This restriction means that the following is not a valid <code>property</code> value as the
 							second colon could represent a scheme: <code>foo:bar:baz/qux</code>.</p>
-						<p>There are also restrictions on what characters must be percent encoded.</p>
+						<p>There are also restrictions on what characters have to be percent encoded.</p>
 					</details>
 				</li>
 				<li>
@@ -2250,8 +2248,9 @@
 					<p>Otherwise, return <var>expandedURL</var>.</p>
 					<details class="explanation">
 						<summary>Explanation</summary>
-						<p>Although an expanded value may be obtained, it is not necessarily the case that it is a valid
-							URL. This is only likely to occur when an invalid base URL is assigned to a prefix.</p>
+						<p>Although an expanded value might be obtained, it is not necessarily the case that it is a
+							valid URL. This is only likely to occur when an invalid base URL is assigned to a
+							prefix.</p>
 					</details>
 				</li>
 			</ol>
@@ -2260,7 +2259,7 @@
 				<p>Reading systems do not have to [=url parser | parse the resulting URL=] [[url]] or attempt to
 					dereference the resulting expanded URL. Expanding a <code>property</code> data type value to a full
 					URL only ensures a reading system has encountered the value it expects (i.e., because different EPUB
-					publications might assign the same prefix to different URLs, two values may appear the same until
+					publications might assign the same prefix to different URLs, two values might appear the same until
 					expanded).</p>
 			</div>
 		</section>
@@ -2287,11 +2286,11 @@
 			<h2>Accessibility</h2>
 
 			<p>Although the primary focus of this specification is on how to process and render [=EPUB publications=],
-				it does not mandate specific user interfaces that all [=reading systems=] must offer. This does not mean
-				that there are not common accessibility issues that all reading systems developers should be aware of,
-				or seek to avoid in their applications.</p>
+				it does not mandate specific user interfaces that all [=reading systems=] have to offer. This does not
+				mean that there are not common accessibility issues that all reading systems developers need to be aware
+				of, or seek to avoid in their applications.</p>
 
-			<p>The W3C's User Agent Accessibility Guidelines [[uaag20]] provides many useful practices developers should
+			<p>The W3C's User Agent Accessibility Guidelines [[uaag20]] provides many useful practices developers can
 				apply to improve their reading systems as many browser accessibility issues have parallels in
 				EPUB-specific user agents.</p>
 
@@ -2323,8 +2322,8 @@
 				<li>Document Object Model (DOM) &#8212; Provide access to the [[dom]] of EPUB content documents so that
 					users can investigate the semantics and structure expressed in the source.</li>
 				<li>Table of Contents &#8212; Ensure that users can access the link text, including <a
-						data-cite="epub-34#confreq-nav-a-title">text alternatives for visual content</a>. Activating the
-					table of contents links should be possible using different inputs.</li>
+						data-cite="epub-34#confreq-nav-a-title">text alternatives for visual content</a>. Ensure users
+					can activate the table of contents links using different inputs.</li>
 			</ul>
 
 			<p>The DAISY Consortium maintains an <a href="https://epubtest.org/test-books">accessibility test suite</a>
@@ -2369,7 +2368,7 @@
 					optimize experiences is a common need, for example, but done without user permission and reading
 					systems can run afoul of legal privacy requirements.</p>
 
-				<p>This section outlines some of the key threats that reading system developers must take into
+				<p>This section outlines some of the key threats that reading system developers need to take into
 					consideration, with further details and recommendations in the following sections.</p>
 
 				<dl>
@@ -2377,15 +2376,15 @@
 					<dd>
 						<p>Malicious scripts present several attack vectors against reading systems. If local storage is
 							not secure, for example, they can attempt to compromise the user's data. Provided with
-							network access, they may attempt unauthorized collection of user data.</p>
+							network access, they could attempt unauthorized collection of user data.</p>
 						<p>More detailed discussion of these issues and how to mitigate them is provided in <a
 								href="#sec-scripted-content-security"></a>.</p>
 					</dd>
 
 					<dt>Malicious content</dt>
 					<dd>
-						<p> EPUB publications may contain resources designed to exploit security flaws in reading
-							systems or the operating systems they run on. Attackers may also try to gain access to
+						<p>EPUB publications could contain resources designed to exploit security flaws in reading
+							systems or the operating systems they run on. Attackers could also try to gain access to
 							[=remote resources=] using file indirection techniques, such as symbolic links or file
 							aliases. </p>
 						<p>The lack of a standard method of signing EPUB publications means that reading systems cannot
@@ -2396,11 +2395,11 @@
 					<dt>Remote resources</dt>
 					<dd>
 						<p>[=Remote resources=] present the same risks as any EPUB publication loaded from an untrusted
-							source. Even if the publisher of the EPUB publication is trusted, remote resources may be
+							source. Even if the publisher of the EPUB publication is trusted, remote resources could be
 							compromised.</p>
 						<p>Calls to remote resources can also be used to track information about users (e.g., through
-							server logs). Reading systems should limit the information they expose through HTTP requests
-							to only what is essential to obtain the resource.</p>
+							server logs). It is advised to limit the information exposed through HTTP requests to only
+							what is essential to obtain the resource.</p>
 						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both specific to each reading
 							system implementation and not known outside that implementation. Consequently, even when
 							remote resources are hosted on a trusted web server, the server effectively cannot use
@@ -2413,11 +2412,11 @@
 
 					<dt>External links</dt>
 					<dd>
-						<p>Like remote resources, external links may be used to trick unwitting users into opening
+						<p>Like remote resources, external links could be used to trick unwitting users into opening
 							malicious resources on the web designed to exploit the reading system or operating
 							system.</p>
-						<p>Likewise, reading systems should also avoid exposing potentially identifying information
-							about users through the traversal of links (e.g., not using tracking identifiers or exposing
+						<p>Likewise, it is advised to also avoid exposing potentially identifying information about
+							users through the traversal of links (e.g., not using tracking identifiers or exposing
 							unnecessary information about the user's environment).</p>
 					</dd>
 
@@ -2458,17 +2457,17 @@
 				<p>If a reading system allows users to store persistent data, especially personally identifiable
 					information, it SHOULD treat that data as sensitive and not allow access to it by third parties.</p>
 
-				<p>It is understood that the collection of some user data may be required for the sale, delivery, and
+				<p>It is understood that the collection of some user data is often required for the sale, delivery, and
 					operation of an [=EPUB publication=], particularly on platforms where the sale of an EPUB
 					publication and the method of reading it are connected. In these cases, the reading system SHOULD
-					identify the data being collected, how it is used, and allow for user opt-outs (retailers may choose
-					to inform users by other means, however, such as when a user creates an account on their web site).
+					identify the data being collected, how it is used, and allow for user opt-outs (retailers could
+					choose to inform users by other means, such as when a user creates an account on their web site).
 					Anonymization of any collected data is RECOMMENDED for the privacy and the security of the user and
 					reading system.</p>
 
-				<p>It is also understood that user data may be required or helpful for some reading system affordances.
-					In these cases, anonymization is also RECOMMENDED. Reading systems also SHOULD inform users of what
-					data is needed, what it is to be used for, and to provide methods to opt-out.</p>
+				<p>It is also understood that user data could be required or helpful for some reading system
+					affordances. In these cases, anonymization is also RECOMMENDED. Reading systems also SHOULD inform
+					users of what data is needed, what it is to be used for, and to provide methods to opt-out.</p>
 
 				<p>Content processors &#8212; defined as entities that handle the ingestion of EPUB content for
 					distribution, display, or sale &#8212; also need to be aware of the potential risks in ingestion. It
@@ -2534,7 +2533,7 @@
 			</dl>
 
 			<div class="note">
-				<p>Developers should consider the unlikelihood of encountering content with deprecated features before
+				<p>Developers need to consider the unlikelihood of encountering content with deprecated features before
 					adding new support for them.</p>
 			</div>
 		</section>
@@ -2586,10 +2585,10 @@ partial interface Navigator {
 						event is triggered</a> [[html]].</p>
 
 				<div class="note">
-					<p>Reading systems implementations may create cloned instances of the <code>epubReadingSystem</code>
+					<p>Reading system implementations can create cloned instances of the <code>epubReadingSystem</code>
 						object in scripted content documents for technical feasibility reasons. In such cases, the
-						reading system must ensure they consistently maintain the object's state — as reflected by the
-						values of its properties and methods — across all copied instances.</p>
+						reading system has to consistently maintain the object's state — as reflected by the values of
+						its properties and methods — across all copied instances.</p>
 				</div>
 			</section>
 
@@ -2646,7 +2645,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									<td id="feature-dom-manipulation">
 										<code>dom-manipulation</code>
 									</td>
-									<td>Scripts may make structural changes to the document’s DOM (applies to <a
+									<td>Scripts can make structural changes to the document’s DOM (applies to <a
 											data-cite="epub-34#sec-scripted-spine">spine-level scripting</a> [[epub-34]]
 										only).</td>
 								</tr>
@@ -2654,7 +2653,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									<td id="feature-layout-changes">
 										<code>layout-changes</code>
 									</td>
-									<td>Scripts may modify attributes and CSS styles that affect content layout (applies
+									<td>Scripts can modify attributes and CSS styles that affect content layout (applies
 										to <a data-cite="epub-34#sec-scripted-spine">spine-level scripting</a>
 										[[epub-34]] only).</td>
 								</tr>
@@ -2705,7 +2704,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3</a> — those that may affect the conformance of
+					href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3</a> — those that can affect the conformance of
 				[=EPUB reading systems=].</p>
 
 			<p>For a list of all issues addressed, refer to the <a

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Reading Systems 3.4</title>
@@ -287,12 +287,11 @@
 					they are strongly encouraged to provide a means of accessing this information. A comparable example
 					are the developer tools that web browsers provide for debugging HTML pages and applications.</p>
 
-				<p>[=EPUB creators=], for example, can greatly benefit from having access to such processing information
-					(e.g., to efficiently debug their EPUB publications). For maximum use in debugging, it is
-					recommended that reading systems not only report issues they directly encounter but also issues
-					reported by any applications they use (e.g., HTML, CSS, and JavaScript errors reported from a
-					browser core used to render the content, or validation issues reported by <a
-						href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>).</p>
+				<p>Access to such processing information allows, for example, more efficient debugging of EPUB
+					publications. For maximum use in debugging, it is recommended that reading systems not only report
+					issues they directly encounter but also issues reported by any applications they use (e.g., HTML,
+					CSS, and JavaScript errors reported from a browser core used to render the content, or validation
+					issues reported by <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>).</p>
 
 				<p>It is not expected that error reporting will be an intrusive experience that affects the general
 					reading experience for users. Rather, reporting information could, for example, be selectively
@@ -634,11 +633,10 @@
 				<section id="sec-container-filenames">
 					<h4>File names</h4>
 
-					<p>Although [=EPUB creators=] are required to follow various <a
-							data-cite="epub-34#sec-container-filenames">file name and file path restrictions</a>
-						[[epub-34]] for maximum interoperability, reading systems SHOULD attempt to process file names
-						and paths that do not adhere to these requirements. Invalid file names and paths may only be
-						problematic on some operating systems.</p>
+					<p>Although [[epub-34]] defines <a data-cite="epub-34#sec-container-filenames">file name and file
+							path restrictions</a> for maximum interoperability, reading systems SHOULD attempt to
+						process file names and paths that do not adhere to these requirements. Invalid file names and
+						paths may only be problematic on some operating systems.</p>
 
 					<p>This specification does not specify how a reading system that is unable to represent OCF file
 						names and paths would handle this incompatibility.</p>
@@ -905,8 +903,9 @@
 					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple
 						publication resources in the fallback chain, it MAY select the resource to use based on the
 						resource's <a data-cite="epub-34#attrdef-item-properties"><code>properties</code> attribute</a>
-						[[epub-34]] values, otherwise it SHOULD honor the [=EPUB creator|EPUB creator's=] preferred
-						fallback order.</span>
+						[[epub-34]] values, otherwise it SHOULD honor the <a
+							data-cite="epub-34#preferred-fallback-chain">preferred fallback order</a>
+						[[epub-34]].</span>
 					<span id="confreq-rs-pkg-manifest-fallback-fail">If a reading system does not support any resource
 						in the fallback chain, it MUST alert the user that it could not display the content. </span>
 				</p>
@@ -942,11 +941,11 @@
 						fallback.</span> Reading systems MAY also provide the option for users to skip non-linear
 					content by default or not.</p>
 
-				<p id="confreq-rs-spine-progression-default" data-tests="#pkg-spine-progression-default">If the [=EPUB
-					creator=] has not specified the <a data-cite="epub-34#attrdef-spine-page-progression-direction"
-							><code>page-progression-direction</code> attribute</a> [[epub-34]], the reading system MUST
-					assume the value of <code>default</code>. When <code>page-progression-direction</code> value is
-						<code>default</code>, the reading system can choose the rendering direction.</p>
+				<p id="confreq-rs-spine-progression-default" data-tests="#pkg-spine-progression-default">If the <a
+						data-cite="epub-34#attrdef-spine-page-progression-direction"
+							><code>page-progression-direction</code> attribute</a> [[epub-34]] is not set, the reading
+					system MUST assume the value of <code>default</code>. When <code>page-progression-direction</code>
+					value is <code>default</code>, the reading system can choose the rendering direction.</p>
 
 				<p id="confreq-rs-spine-progression-pre-paginated" data-tests="#pkg-spine-progression-pre-paginated">If
 					the <code>page-progression-direction</code> attribute has a value other than <code>default</code>,
@@ -1201,8 +1200,8 @@
 								>CSS Style Sheets — Prefixed properties</a> [[epub-34]].</p>
 					</li>
 					<li>
-						<p id="confreq-css-creator-styles">SHOULD apply [=EPUB creator=] style sheets as written to
-							[=EPUB content documents=].</p>
+						<p id="confreq-css-creator-styles">SHOULD apply style sheets referenced from [=EPUB content
+							documents=] as written.</p>
 					</li>
 					<li>
 						<p id="confreq-css-rs-html-default">SHOULD support the [[html]] <a data-cite="html#rendering"
@@ -1212,7 +1211,7 @@
 
 				<div class="note">
 					<p>Reading system developers are expected to publicly document their user agent style sheet(s) and
-						how they interact with EPUB creator's style settings. </p>
+						how they interact with the styling set in EPUB publications.</p>
 				</div>
 
 				<section id="sec-css-overrides">
@@ -1471,8 +1470,8 @@
 			</ul>
 
 			<p id="confreq-nav-spine" data-tests="#nav-spine_in-spine,#nav-spine_not-in-spine">Reading systems MUST
-				honor the above requirements irrespective of whether EPUB creators also include the EPUB navigation
-				document in the [=EPUB spine | spine=].</p>
+				honor the above requirements irrespective of whether the EPUB navigation document is also included in
+				the [=EPUB spine | spine=].</p>
 		</section>
 		<section id="sec-rendering-control">
 			<h2>Layout rendering control processing</h2>
@@ -1807,8 +1806,8 @@
 						reading systems that support this property MUST center each virtual page.</p>
 
 					<p>This specification does not define a default rendering behavior when reading systems do not
-						support this property or [=EPUB creators=] do not specify it. Reading systems MAY render spine
-						items by their own design.</p>
+						support this property or it is not set in an [=EPUB publication=]. Reading systems MAY render
+						spine items by their own design.</p>
 				</section>
 			</section>
 
@@ -1905,12 +1904,12 @@
 
 					<ul>
 						<li id="mol-audio-no-clipbegin" data-tests="#mol-audio-no-clipbegin">
-							<p>If the [=EPUB creator=] has not specified a <code>clipBegin</code> attribute, reading
-								systems MUST assume the value "<code>0</code>".</p>
+							<p>If a <code>clipBegin</code> attribute is not set, reading systems MUST assume the value
+									"<code>0</code>".</p>
 						</li>
 						<li id="mol-audio-no-clipend" data-tests="#mol-audio-no-clipend">
-							<p>If the EPUB creator has not specified a <code>clipEnd</code> attribute, reading systems
-								MUST assume the value to be the full duration of the physical media.</p>
+							<p>If a <code>clipEnd</code> attribute is not set, reading systems MUST assume the value to
+								be the full duration of the physical media.</p>
 						</li>
 						<li id="mol-audio-exceeding-clipend" data-tests="#mol-audio-exceeding-clipend">
 							<p>If the value of <code>clipEnd</code> exceeds the full duration of the physical media,
@@ -1972,18 +1971,18 @@
 						navigation point target.</p>
 
 					<div class="note">
-						<p>[=EPUB creators=] may associate a [=media overlay document=] directly with an <a>EPUB
-								navigation document</a> in order to provide synchronized playback of its contents,
-							regardless of whether the [=XHTML content document=] in which it resides is included in the
-							[=EPUB spine | spine=]. See <a data-cite="epub-34#sec-mo-nav-doc">EPUB navigation
-								document</a> [[epub-34]] for more information.</p>
+						<p>A [=media overlay document=] can be associated directly with an <a>EPUB navigation
+								document</a> in order to provide synchronized playback of its contents, regardless of
+							whether the [=XHTML content document=] in which it resides is included in the [=EPUB spine |
+							spine=]. See <a data-cite="epub-34#sec-mo-nav-doc">EPUB navigation document</a> [[epub-34]]
+							for more information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
-						<p>EPUB creators may associate media overlay document elements with EPUB content document
-							structures such as tables. Reading systems should ensure that media overlay playback remains
-							synchronized with user navigation of table rows and cells. The reading system might also
-							play the corresponding table header preceding the contents of the cell.</p>
+						<p>Media overlay document elements can be associated with EPUB content document structures such
+							as tables. Reading systems should ensure that media overlay playback remains synchronized
+							with user navigation of table rows and cells. The reading system might also play the
+							corresponding table header preceding the contents of the cell.</p>
 					</div>
 				</section>
 
@@ -2112,8 +2111,8 @@
 						<p>In this algorithm:</p>
 						<ul>
 							<li><var>baseURL</var> will hold the base URL associated with the value, whether this URL is
-								assigned by the EPUB creator, corresponds to a default vocabulary, or comes from a
-								reserved prefix.</li>
+								assigned in a <code>prefix</code> attribute, corresponds to a default vocabulary, or
+								comes from a reserved prefix.</li>
 							<li><var>expandedURL</var> will hold the final URL that results from the concatenation of
 								the base URL and property reference.</li>
 							<li><var>propertyPrefix</var> will hold the property's <a
@@ -2252,8 +2251,7 @@
 					<details class="explanation">
 						<summary>Explanation</summary>
 						<p>Although an expanded value may be obtained, it is not necessarily the case that it is a valid
-							URL. This is only likely to occur when the EPUB creator assigns an invalid base URL to a
-							prefix.</p>
+							URL. This is only likely to occur when an invalid base URL is assigned to a prefix.</p>
 					</details>
 				</li>
 			</ol>
@@ -2262,7 +2260,7 @@
 				<p>Reading systems do not have to [=url parser | parse the resulting URL=] [[url]] or attempt to
 					dereference the resulting expanded URL. Expanding a <code>property</code> data type value to a full
 					URL only ensures a reading system has encountered the value it expects (i.e., because different EPUB
-					creators can assign the same prefix to different URLs, two values may appear the same until
+					publications might assign the same prefix to different URLs, two values may appear the same until
 					expanded).</p>
 			</div>
 		</section>
@@ -2403,10 +2401,10 @@
 						<p>Calls to remote resources can also be used to track information about users (e.g., through
 							server logs). Reading systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the [=EPUB
-							creator=] and specific to each reading system implementation. Consequently, if the EPUB
-							creator hosts remote resources on a web server they control, the server effectively cannot
-							use security features that require specifying allowable origins, such as headers for <a
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both specific to each reading
+							system implementation and not known outside that implementation. Consequently, even when
+							remote resources are hosted on a trusted web server, the server effectively cannot use
+							security features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
 									><code>Content-Security-Policy</code></a>, or <a
@@ -2564,9 +2562,9 @@ partial interface Navigator {
 
 				<div class="note">
 					<p>This specification does not define an <code>epubReadingSystem</code> property extension for the
-						{{WorkerNavigator}} object [[html]]. Reading systems therefore do not have to expose the
-							<code>epubReadingSystem</code> object in the scripting context of Workers, and [=EPUB
-						creators=] cannot rely on its presence.</p>
+						{{WorkerNavigator}} object [[html]]. Therefore, reading systems do not have to expose the
+							<code>epubReadingSystem</code> object in the scripting context of Workers, so its presence
+						cannot be relied on.</p>
 				</div>
 			</section>
 
@@ -2609,9 +2607,9 @@ partial interface Navigator {
 							feature, or <code>undefined</code> if the reading system does not recognize the specified
 							feature.</p>
 
-						<p>The optional <code>version</code> parameter allows [=EPUB creators=] to query custom features
-							that could change in incompatible ways over time. The return value indicates support only
-							for the specified version of the feature.</p>
+						<p>The optional <code>version</code> parameter allows querying of custom features that could
+							change in incompatible ways over time. The return value indicates support only for the
+							specified version of the feature.</p>
 
 						<p><a href="#app-ers-hasFeature-features">Features defined in this specification</a> are
 							versionless. If a reading system supports a feature defined in this specification, it MUST

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1088,7 +1088,7 @@
 							</li>
 						</ul>
 
-						<p class="note">Reading systems can use third-party libraries such as <a
+						<p class="note">Reading systems can opt to use third-party libraries such as <a
 								href="https://www.mathjax.org/">MathJax</a> to provide MathML rendering.</p>
 					</section>
 
@@ -1970,7 +1970,7 @@
 
 					<div class="note">
 						<p>A [=media overlay document=] can be associated directly with an <a>EPUB navigation
-								document</a> in order to provide synchronized playback of its contents, regardless of
+								document</a> in order to provide synchronized playback of its contents regardless of
 							whether the [=XHTML content document=] in which it resides is included in the [=EPUB spine |
 							spine=]. See <a data-cite="epub-34#sec-mo-nav-doc">EPUB navigation document</a> [[epub-34]]
 							for more information.</p>
@@ -2288,7 +2288,7 @@
 			<p>Although the primary focus of this specification is on how to process and render [=EPUB publications=],
 				it does not mandate specific user interfaces that all [=reading systems=] have to offer. This does not
 				mean that there are not common accessibility issues that all reading systems developers need to be aware
-				of, or seek to avoid in their applications.</p>
+				of or seek to avoid in their applications.</p>
 
 			<p>The W3C's User Agent Accessibility Guidelines [[uaag20]] provides many useful practices developers can
 				apply to improve their reading systems as many browser accessibility issues have parallels in

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -266,29 +266,29 @@
 					systems MUST meet these alternative requirements when not supporting a feature.</p>
 
 				<div class="note">
-					<p>EPUB publications frequently contain information not required by this specification (e.g.,
+					<p>EPUB publications frequently contain additional information not specified in [[epub-34]] (e.g.,
 						[=package document=] metadata). Reading systems can use this additional information for any
-						purposes (e.g., to improve the user interface).</p>
+						purposes, such as to improve the user interface.</p>
 				</div>
 			</section>
 
 			<section id="rs-conf-error-handling">
 				<h3>Error handling</h3>
 
-				<p>Reading systems are not required to load [=EPUB publications=], or resources within them, when they
+				<p>Reading systems do not have to load [=EPUB publications=], or resources within them, when they
 					violate content authoring or processing requirements.</p>
 			</section>
 
 			<section id="rs-conf-error-reporting" class="informative">
 				<h3>Error reporting</h3>
 
-				<p>Although reading systems are not required to report errors encountered while processing and rendering
+				<p>Although reading systems do not have to report errors encountered while processing and rendering
 					[=EPUB publications=] (e.g., if the dimensions of a [=fixed-layout document=] have been inferred),
 					they are strongly encouraged to provide a means of accessing this information. A comparable example
 					are the developer tools that web browsers provide for debugging HTML pages and applications.</p>
 
 				<p>Access to such processing information allows, for example, more efficient debugging of EPUB
-					publications. For maximum use in debugging, it is recommended that reading systems not only report
+					publications. For maximum use in debugging, it is advised that reading systems not only report
 					issues they directly encounter but also issues reported by any applications they use (e.g., HTML,
 					CSS, and JavaScript errors reported from a browser core used to render the content, or validation
 					issues reported by <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>).</p>
@@ -316,11 +316,11 @@
 					capability to render prerecorded audio, it MUST support the <a data-cite="epub-34#cmt-grp-audio"
 						>audio core media type resources</a> [[epub-34]].</p>
 
-				<p class="note" id="note-video-codecs">It is recommended that reading systems support at least one of
-					the H.264 [[h264]] and VP8 [[rfc6386]] video codecs, but this is not a conformance requirement
-					&#8212; a reading system can support any video codec, or none at all. Reading system developers have
-					to take into consideration factors such as breadth of adoption, playback quality, and technology
-					royalties when deciding which video formats to support.</p>
+				<p class="note" id="note-video-codecs">It is advised that reading systems support at least one of the
+					H.264 [[h264]] and VP8 [[rfc6386]] video codecs, but this is not a conformance requirement &#8212; a
+					reading system can support any video codec, or none at all. Reading system developers have to take
+					into consideration factors such as breadth of adoption, playback quality, and technology royalties
+					when deciding which video formats to support.</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-foreign-res">
@@ -378,11 +378,10 @@
 			<section id="sec-epub-rs-i18n">
 				<h2>Internationalization</h2>
 
-				<p> As part of processing [=publication resources=], a reading system is required to process the
-					attributes to set the language and the base directions in [=XHTML content documents=] or [=SVG
-					content documents=], as well as the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code>
-						attribute</a> for all XML documents (e.g., the [=package document=] and [=media overlay
-					documents=]). </p>
+				<p> As part of processing [=publication resources=], a reading system has to process the attributes to
+					set the language and the base directions in [=XHTML content documents=] or [=SVG content
+					documents=], as well as the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> for
+					all XML documents (e.g., the [=package document=] and [=media overlay documents=]). </p>
 
 				<p id="confreq-rs-pkg-dir-intro"
 					data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
@@ -2081,8 +2080,8 @@
 				mechanisms.</p>
 
 			<p>Reading systems that do not support the [[epub-34]] vocabulary association mechanisms MAY process
-					<code>property</code> values as plain [=string=] values [[infra]]. It is not required to support the
-				expansion of these values to URLs to add reading system behaviors based on their presence.</p>
+					<code>property</code> values as plain [=string=] values [[infra]]. They do not have to support the
+				expansion of these values to URLs or add reading system behaviors based on their presence.</p>
 
 			<p>The algorithm describes the process using the terminology and data types defined in [[infra]], and, if
 				successful, results in a [=string=] value with the expanded URL being returned. A <a
@@ -2151,10 +2150,10 @@
 								colon.</p>
 						</li>
 					</ol>
-					<p>If <var>propertyReference</var> is not a valid [=path-relative-scheme-less-URL string=], as
-						required by the <a data-cite="epub-34#property.ebnf.reference"><code>property</code> data type
-							definition</a> [[epub-34]], the value is invalid. Return <a data-cite="infra#nulls"
-						>null</a>.</p>
+					<p>If <var>propertyReference</var> is not a valid [=path-relative-scheme-less-URL string=], as the
+							<a data-cite="epub-34#property.ebnf.reference"><code>property</code> data type
+							definition</a> [[epub-34]] requires, the value is invalid. Return <a data-cite="infra#nulls"
+							>null</a>.</p>
 					<details class="explanation">
 						<summary>Explanation</summary>
 						<p>The path-relative-scheme-less-URL string definition has a number of restrictions that apply
@@ -2457,7 +2456,7 @@
 				<p>If a reading system allows users to store persistent data, especially personally identifiable
 					information, it SHOULD treat that data as sensitive and not allow access to it by third parties.</p>
 
-				<p>It is understood that the collection of some user data is often required for the sale, delivery, and
+				<p>It is understood that the collection of some user data is often necessary for the sale, delivery, and
 					operation of an [=EPUB publication=], particularly on platforms where the sale of an EPUB
 					publication and the method of reading it are connected. In these cases, the reading system SHOULD
 					identify the data being collected, how it is used, and allow for user opt-outs (retailers could
@@ -2465,7 +2464,7 @@
 					Anonymization of any collected data is RECOMMENDED for the privacy and the security of the user and
 					reading system.</p>
 
-				<p>It is also understood that user data could be required or helpful for some reading system
+				<p>It is also understood that user data could be necessary or helpful for some reading system
 					affordances. In these cases, anonymization is also RECOMMENDED. Reading systems SHOULD also inform
 					users of what data is needed, what it is to be used for, and to provide methods to opt-out.</p>
 
@@ -2606,9 +2605,9 @@ partial interface Navigator {
 							feature, or <code>undefined</code> if the reading system does not recognize the specified
 							feature.</p>
 
-						<p>The optional <code>version</code> parameter allows querying of custom features that could
-							change in incompatible ways over time. The return value indicates support only for the
-							specified version of the feature.</p>
+						<p>The <code>version</code> parameter allows querying of custom features that could change in
+							incompatible ways over time. The return value indicates support only for the specified
+							version of the feature.</p>
 
 						<p><a href="#app-ers-hasFeature-features">Features defined in this specification</a> are
 							versionless. If a reading system supports a feature defined in this specification, it MUST

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1088,7 +1088,7 @@
 							</li>
 						</ul>
 
-						<p class="note">Reading systems can opt to use third-party libraries such as <a
+						<p class="note">Reading systems can opt for third-party libraries such as <a
 								href="https://www.mathjax.org/">MathJax</a> to provide MathML rendering.</p>
 					</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2322,7 +2322,7 @@
 				<li>Document Object Model (DOM) &#8212; Provide access to the [[dom]] of EPUB content documents so that
 					users can investigate the semantics and structure expressed in the source.</li>
 				<li>Table of Contents &#8212; Ensure that users can access the link text, including <a
-						data-cite="epub-34#confreq-nav-a-title">text alternatives for visual content</a>. Ensure users
+						data-cite="epub-34#confreq-nav-a-title">text alternatives for visual content</a>, and that users
 					can activate the table of contents links using different inputs.</li>
 			</ul>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2158,7 +2158,7 @@
 						<summary>Explanation</summary>
 						<p>The path-relative-scheme-less-URL string definition has a number of restrictions that apply
 							to the reference whether it has a prefix or not.</p>
-						<p>For example, the reference cannot begin with a [=URL-scheme string=] followed by a colon.
+						<p>For example, the reference is not allowed to begin with a [=URL-scheme string=] followed by a colon.
 							This restriction means that the following is not a valid <code>property</code> value as the
 							second colon could represent a scheme: <code>foo:bar:baz/qux</code>.</p>
 						<p>There are also restrictions on what characters have to be percent encoded.</p>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Reading Systems 3.4</title>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2466,7 +2466,7 @@
 					reading system.</p>
 
 				<p>It is also understood that user data could be required or helpful for some reading system
-					affordances. In these cases, anonymization is also RECOMMENDED. Reading systems also SHOULD inform
+					affordances. In these cases, anonymization is also RECOMMENDED. Reading systems SHOULD also inform
 					users of what data is needed, what it is to be used for, and to provide methods to opt-out.</p>
 
 				<p>Content processors &#8212; defined as entities that handle the ingestion of EPUB content for


### PR DESCRIPTION
In addition to finishing up the removal of epub creator, I also rewrote all the normative keywords that were masking as non-normative by being lowercase. I know there's an RFC that allows this but every time I come across them I have to try and figure out if they're mistakenly lowercase and really normative, even in informative sections (and that's not even getting into how accessible the practice really is). Just as we don't need epub creator we don't need to be using these keywords outside their intended use. The only place I left them is in the iana registrations since those are technically external documents we're reproducing. (I'm going to go back and do the same for the accessibility documents next.)

Fixes #2216 

***

Reading Systems 1.2:
* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-2216/epub34/rs/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-2216/epub34/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2804.html" title="Last updated on Oct 2, 2025, 12:47 PM UTC (41578d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2804/599d0f4...41578d9.html" title="Last updated on Oct 2, 2025, 12:47 PM UTC (41578d9)">Diff</a>