### PR TITLE
Rewrite normative-sounding keywords from a11y docs

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>
@@ -129,8 +129,9 @@
 
 				<p>This document is not intended to be read in isolation, in other words, as it does not define
 					conformance requirements for making accessibility claims or cover every method for producing
-					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.2 to
-					make a claim of accessibility; verifying only the techniques in this document is not sufficient.</p>
+					accessible content. An EPUB publication has to meet all the requirements of EPUB Accessibility 1.2
+					to make a claim of accessibility; verifying only the techniques in this document is not
+					sufficient.</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -149,9 +150,9 @@
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
 				create <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> that conform to the requirements
-				in [[epub-a11y-12]], but they are not all applicable in all situations and there may be other ways to
-				meet the requirements of that specification. As a result, this document should not be read as providing
-				prescriptive requirements.</p>
+				in [[epub-a11y-12]], but they are not all applicable in all situations and there can be other ways to
+				meet the requirements of that specification. As a result, this document is not intended to be read as
+				providing prescriptive requirements.</p>
 
 			<p>These techniques also do not address issues in digital publishing for which no universally accessible
 				solutions exist. The W3C's Digital Publishing Interest Group has published a note that outlines many of
@@ -230,8 +231,8 @@
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>
 
-					<p>Anyone unfamiliar with [[wcag2]] may find the number of techniques daunting, as they are intended
-						to provide broad coverage of possible solutions.</p>
+					<p>Anyone unfamiliar with [[wcag2]] might find the number of techniques daunting, as they are
+						intended to provide broad coverage of possible solutions.</p>
 
 					<p>Assistance applying these techniques to EPUB content documents is available from the following
 						sources:</p>
@@ -264,7 +265,7 @@
 
 					<p>As EPUB allows two <a data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> to
 						be rendered together in a <a data-cite="epub/#spread">synthetic spread</a> [[epub]], the order
-						of content within a single document cannot always be evaluated in isolation. Content may span
+						of content within a single document cannot always be evaluated in isolation. Content might span
 						visually from one document to the next. For example, a sidebar might span the bottom of two
 						pages.</p>
 
@@ -327,8 +328,8 @@
 						<h5>Note about the table of contents</h5>
 
 						<p>A common question about the EPUB table of contents is what completeness it needs to have with
-							respect to the headings of the publication. Although the obvious answer seems like it should
-							be a simple aggregation of all headings for all sections, practically there are several
+							respect to the headings of the publication. Although the obvious answer is to create a
+							simple aggregation of all the headings for all the sections, practically there are several
 							usability challenges to this approach.</p>
 
 						<p>Factors such as device screen sizes can make the table of contents for publications with a
@@ -369,12 +370,12 @@
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
 						understand the structure and ordering of an <a data-cite="epub/#dfn-epub-publication">EPUB
-							publication</a>. Consequently, users may have difficulty locating where they are in a
+							publication</a>. Consequently, users might have difficulty locating where they are in a
 						publication, where they want to go, and also how to return to previous locations when the order
 						of entries in the table of contents does not match the linear reading order.</p>
 
 					<p>To ensure that the table of contents matches the linear order of the content, the order of its
-						entries should reflect both:</p>
+						entries needs to reflect both:</p>
 
 					<ul>
 						<li>the order of <a data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> in
@@ -382,15 +383,15 @@
 						<li>the order of each referenced section within its respective EPUB content document.</li>
 					</ul>
 
-					<p>Only if there is a logical case for an alternative arrangement of entries should the ordering
-						differ. Such scenarios typically only occur when the content does not have to be read linearly
-						or when additional information is included at the end of a table of contents. For example, the
-						table of contents for a magazine might be ordered to list all the major articles first, followed
-						by features, etc.</p>
+					<p>Only if there is a logical case for an alternative arrangement of entries is it advised that the
+						ordering differ. Such scenarios typically only occur when the content does not have to be read
+						linearly or when additional information is included at the end of a table of contents. For
+						example, the table of contents for a magazine might be ordered to list all the major articles
+						first, followed by features, etc.</p>
 
 					<p>When the ordering of the table of contents does not match the content, the <a
 							href="https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/#accessibilitySummary"
-							>accessibility summary</a> should explain why.</p>
+							>accessibility summary</a> needs to explain why.</p>
 
 					<p>Avoid linking directly to supplementary content from of the table of contents. Instead, define
 						navigation lists to group together related links, such as a table of figures or a table of
@@ -423,11 +424,12 @@
 						This success criterion does not apply to typical EPUB publications, however, as EPUB content
 						documents do not repeat content in the same way that web sites do.</p>
 
-					<p>Each new content document may begin with similar content, such as learning objectives or key
+					<p>Each new content document might begin with similar content, such as learning objectives or key
 						terms, but this content is part of the body of the publication and not identical to what came
-						before. Consequently, it is not required to add a link to skip it. (Secondary content should be
-						identified in accordance with <a href="https://www.w3.org/TR/WCAG/#info-and-relationships"
-							>success criterion 1.3.1</a>, however.)</p>
+						before. Consequently, it is not required to add a link to skip it. (Secondary content still
+						needs to be identified in accordance with <a
+							href="https://www.w3.org/TR/WCAG/#info-and-relationships">success criterion 1.3.1</a>,
+						however.)</p>
 
 					<div class="note">
 						<p>If an EPUB publication were to reproduce a set of web pages with their full site trappings,
@@ -452,7 +454,7 @@
 								document</a> to identify key structures.</p>
 					</div>
 
-					<p>Although the <code>role</code> attribute may seem similar in nature to the <a
+					<p>Although the <code>role</code> attribute might seem similar in nature to the <a
 							data-cite="epub/#sec-epub-type-attribute"><code>type</code> attribute</a> [[epub]], their
 						target uses in EPUB content documents do not overlap.</p>
 
@@ -539,7 +541,7 @@
 &lt;/html></pre>
 
 					<div class="note">
-						<p>When more than one instance of a role is included in a document, each must be uniquely
+						<p>When more than one instance of a role is included in a document, each has to be uniquely
 							identified. The <code>aria-labelledby</code> attribute provides the name of each landmark in
 							the preceding example. The attribute is not required if only one instance is present, so it
 							is omitted from the following examples.</p>
@@ -609,9 +611,9 @@
 						navigation in its own way.</p>
 
 					<p>The EPUB specification does not require that EPUB publications include a specific set of
-						landmarks, but it is recommended that they include a link to the start of the body matter as
-						well as to any major reference sections (e.g., table of contents, endnotes, bibliography,
-						glossary, index).</p>
+						landmarks; it only recommends to include a link to the start of the body matter as well as to
+						any major reference sections (e.g., table of contents, endnotes, bibliography, glossary,
+						index).</p>
 
 					<aside class="example" title="Landmarks expressed in the EPUB 3 navigation document">
 						<pre>&lt;nav epub:type="landmarks">
@@ -783,12 +785,12 @@
 						needs to have a numbered heading element that reflects its actual position in the
 						publication.</p>
 
-					<p>EPUB publications should also be chunked so that the first heading in a document always has the
-						highest number. For example, if a document starts with an <code>h3</code> heading, there should
-						not be an <code>h2</code> heading later in the document (e.g., do not include the start of a new
-						section with the trailing subsections of the previous). It is acceptable for there to be
-						subsequent headings at the same level as the first (e.g., multiple subsections in one document
-						could all have <code>h3</code> headings).</p>
+					<p>It is advised to chunk EPUB publications so that the first heading in a document always has the
+						highest number. For example, if a document starts with an <code>h3</code> heading,
+							an <code>h1</code> or <code>h2</code> heading does not appear later in the document (e.g.,
+						do not include the start of a new section with the trailing subsections of the previous). It is
+						acceptable for there to be subsequent headings at the same level as the first (e.g., multiple
+						subsections in one document could all have <code>h3</code> headings).</p>
 
 					<aside class="example" title="Heading order across documents">
 						<p>In this example, there are two consecutive EPUB content documents in a textbook. The first
@@ -844,8 +846,8 @@
 					<h4>Heading topic or purpose</h4>
 
 					<p><a data-cite="wcag2#non-text-content">Success Criterion 2.4.6</a> [[wcag2]] currently states that
-						all headings must describe their topic or purpose. The implication of this wording is that all
-						chapters in a novel, for example, have a topic or purpose and that the topic or purpose is
+						all headings have to describe their topic or purpose. The implication of this wording is that
+						all chapters in a novel, for example, have a topic or purpose and that the topic or purpose is
 						always clearly reflected by the title of the chapter. Not only is this not always the case, but
 						this success criterion also complicates the use of chapter numbers as headings since these do
 						not establish a topic.</p>
@@ -857,8 +859,7 @@
 						wording &#8212; namely, that the requirement for headings is only that they establish a unique
 						context for the content.</p>
 
-					<p>By this interpretation, the headings in publications should always pass provided they are
-						unique.</p>
+					<p>By this interpretation, the headings in publications always pass provided they are unique.</p>
 
 					<p>It is expected that the wording of the success criterion will be updated to better reflect the
 						uniqueness requirement, likely in the future WCAG 3 due the complexities of changing the wording
@@ -876,7 +877,7 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p>Image-based content in <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> must now
+					<p>Image-based content in <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> now has to
 						meet [[wcag2]] requirements for alternative text and extended descriptions to conform with
 						[[epub-a11y-12]].</p>
 
@@ -942,7 +943,7 @@
 						proper language for users.</p>
 
 					<p class="note">The languages specified in the package document have no effect on individual EPUB
-						content documents (i.e., the language of each document must be specified using the language
+						content documents (i.e., the language of each document has to be specified using the language
 						expression mechanisms it provides).</p>
 				</section>
 
@@ -968,9 +969,9 @@
 
 					<p>Although it is not strictly required to set this information to meet <a
 							data-cite="wcag2#language-of-page">Success Criterion 3.1.1</a> [[wcag2]], as it is
-						non-normative, it should be considered a best practice to always set this field with the proper
-						language information. (Note that EPUB3 requires the language always be specified, so omitting
-						will fail validation requirements.)</p>
+						non-normative, it is best practice to always set this field with the proper language
+						information. (Note that EPUB3 requires the language always be specified, so omitting will fail
+						validation requirements.)</p>
 
 					<p>Although <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not use this
 						language information to render the text content of the EPUB publication, they do use it to
@@ -979,7 +980,7 @@
 
 					<p class="note">The languages specified in the package document have no effect on individual <a
 							data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> (i.e., the language
-						of each document must be specified using the language expression mechanisms it provides).</p>
+						of each document has to be specified using the language expression mechanisms it provides).</p>
 				</section>
 			</section>
 
@@ -1036,8 +1037,8 @@
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB publication might not be readable by them.</p>
 
-				<p>Using multiple renditions to meet accessibility requirements should only be done when there is no
-					other alternative. EPUB publications that contain multiple renditions are conformant to the
+				<p>Using multiple renditions to meet accessibility requirements is only advised when there is no other
+					alternative. EPUB publications that contain multiple renditions are conformant to the
 					[[epub-a11y-12]] specification if at least one rendition meets all the content requirements, but
 					such publications, at a minimum, need to note that a reading system that supports multiple
 					renditions is required in their <a
@@ -1068,9 +1069,9 @@
 					<p>For accessibility purposes, it is most important to specify the <code>role</code> attribute value
 						as this is what <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>
 						will process. The <code>epub:type</code> attribute is not recognized by these devices, but it
-						may be used by <a data-cite="epub/#dfn-epub-reading-system">epub reading systems</a> to enhance
-						the user experience. For compatibility with both types of devices, it is recommended to apply
-						both attributes, although only the <code>role</code> attribute is strictly required for
+						could be used by <a data-cite="epub/#dfn-epub-reading-system">epub reading systems</a> to
+						enhance the user experience. For compatibility with both types of devices, it is advised to
+						apply both attributes, although only the <code>role</code> attribute is strictly required for
 						accessibility conformance.</p>
 
 					<aside class="example" title="Expressing a page break">
@@ -1085,10 +1086,10 @@
 					<p>A <code>title</code> or <code>aria-label</code> attribute is required on the element, as it
 						provides the value that is announced to the user.</p>
 
-					<p>The page number may be inserted as text content within the element, but assistive technologies
-						may not provide a way to disable announcing of the numbers. As a result, users may hear the
-						numbers announced wherever they occur, which could cause confusion (e.g., the number may seem to
-						be part of the sentence it occurs within).</p>
+					<p>The page number can be inserted as text content within the element, but assistive technologies
+						might not provide a way to disable announcing of the numbers. As a result, users might hear the
+						numbers announced wherever they occur, which could cause confusion (e.g., the number might seem
+						to be part of the sentence it occurs within).</p>
 
 					<aside class="example" title="Text page break">
 						<pre>&lt;p>With a philosophical flourish Cato throws himself 
@@ -1139,11 +1140,10 @@
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
-					<p>To mitigate this potential annoyance to readers, page announcements in <a
-							data-cite="epub/#dfn-media-overlay-document">media overlay documents</a> should be
-						identified when they are included. Identification allows a <a
-							data-cite="epub/#dfn-epub-reading-system">reading system</a> to provide a playback
-						experience where the numbers are automatically skipped.</p>
+					<p>To mitigate this potential annoyance to readers, it is advised to identify page announcements in
+							<a data-cite="epub/#dfn-media-overlay-document">media overlay documents</a> when they are
+						included. Identification allows a <a data-cite="epub/#dfn-epub-reading-system">reading
+							system</a> to provide a playback experience where the numbers are automatically skipped.</p>
 
 					<p>To identify page numbers in media overlay documents, attach an <code>epub:type</code> attribute
 						with the value "<a data-cite="epub-ssv-11/#pagebreak"><code>pagebreak</code></a>" [[epub-ssv]]
@@ -1312,8 +1312,8 @@
 					</aside>
 
 					<div class="note">
-						<p>The <a data-cite="epub/#sec-source-of"><code>source-of</code> property</a> was previously
-							recommended in these techniques to identify the <a
+						<p>These techniques previously advised using the <a data-cite="epub/#sec-source-of"
+									><code>source-of</code> property</a> to identify the <a
 								data-cite="epub/#sec-opf-dcmes-optional-def"><code>dc:source</code> element</a>
 							containing the source of the pagination [[epub]]. This method came with a number of
 							limitations, however. It was not future proof, for example, as it relied on the EPUB 3 <a
@@ -1322,11 +1322,10 @@
 							element.</p>
 
 						<p>The <a data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a>
-							[[epub]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly
-							recommended that anyone using the <code>source-of</code> property switch to using the
+							[[epub]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly advised
+							that anyone using the <code>source-of</code> property switch to using the
 								<code>pageBreakSource</code> property. Although the <code>source-of</code> method will
-							remain valid for backwards compatibility purposes, it is no longer recommended for new
-							publications.</p>
+							remain valid for backwards compatibility purposes, its use is no longer advised.</p>
 					</div>
 
 					<p>If an ISBN is not available, include as much information as possible about the source publication
@@ -1390,33 +1389,33 @@
 						embedded audio and video in the document).</p>
 
 					<div class="note">
-						<p>Media overlays should not synchronize to hidden text content. Synchronizing audio with
-							invisible text will be confusing for sighted readers following the playback.</p>
+						<p>Do not synchronize media overlays to hidden text content. Synchronizing audio with invisible
+							text will be confusing for sighted readers following the playback.</p>
 
 						<p>Text content in a collapsed element, like the <a data-lt="details"><code>details</code>
 								element</a> [[html]], is not considered hidden content.</p>
 					</div>
 
-					<p>In addition to synchronizing the visible text, synchronized text-audio playback must also address
-						text alternatives for image-based content. Images may have alternative text and descriptions
-						that are not visible to all users. As synchronization is also meant to aid users who cannot see
-						the images, including these text alternatives and descriptions in the playback is essential to
-						providing the user all the information in the EPUB publication.</p>
+					<p>In addition to synchronizing the visible text, synchronized text-audio playback also has to
+						address text alternatives for image-based content. Images can have alternative text and
+						descriptions that are not visible to all users. As synchronization is also meant to aid users
+						who cannot see the images, including these text alternatives and descriptions in the playback is
+						essential to providing the user all the information in the EPUB publication.</p>
 
-					<p>Text alternatives and descriptions in HTML may be represented in the <a
+					<p>Text alternatives and descriptions in HTML can be represented in the <a
 							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[html]] and linked by ARIA
 						attributes (e.g., <a data-cite="wai-aria#aria-describedby"><code>aria-describedby</code></a> and
 							<a data-cite="wai-aria#aria-details"><code>aria-details</code></a> [[wai-aria]]).
 						Descriptions for image elements in SVG are typically represented in a <a
 							href="https://www.w3.org/TR/SVG/struct.html#DescElement"><code>desc</code> element</a> but
-						ARIA attributes may also be used.</p>
+						ARIA attributes can also be used.</p>
 				</section>
 
 				<section id="sync-reading-order">
 					<span id="sync-002"></span>
 					<h4>Specifying the reading order</h4>
 
-					<p>The default reading order should typically represent the order in which <a
+					<p>The default reading order typically represents the order in which <a
 							data-cite="epub/#dfn-epub-reading-system">reading systems</a> render content to users during
 						synchronized text-audio playback. For <a data-cite="epub/#dfn-epub-publication">EPUB
 							publications</a>, this is a combination of the sequence of <a
@@ -1431,14 +1430,14 @@
 						order.</p>
 
 					<p>Use caution when making alterations, however, as other accessibility issues can arise when the
-						logical order does not match the default order. For example, the content may not be accessible
+						logical order does not match the default order. For example, the content might not be accessible
 						to users of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> when
 						the order in the markup does not match how the assistive technology reads the content. In these
 						cases, using playback to create a logical order can make the EPUB publication fail WCAG
 						conformance requirements.</p>
 
-					<p>One case where the logical may diverge from the reading order and remain accessible is in tables,
-						as assistive technologies typically allow users to choose whether to read by row or by
+					<p>One case where the logical order can diverge from the reading order and remain accessible is in
+						tables, as assistive technologies typically allow users to choose whether to read by row or by
 						column.</p>
 				</section>
 
@@ -1448,8 +1447,8 @@
 
 					<p>Some content elements are not critical to read when following the primary narrative of a work,
 						and that would interrupt a user's concentration if they had to stop and listen to. Footnotes and
-						endnotes are examples of such content, as users may only want to come back and read this content
-						after finishing the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>. The
+						endnotes are examples of such content, as users might only want to come back and read this
+						content after finishing the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>. The
 						announcement of page break numbers can be similarly annoying to readers.</p>
 
 					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] does not
@@ -1460,7 +1459,7 @@
 							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements [[epub]]. These semantics
 						are what allow reading systems to provide users the option to skip their playback sequences.</p>
 
-					<p>The recommended structures to identify for skippability are:</p>
+					<p>It is strongly advised to identify the following structures for skippability:</p>
 
 					<ul>
 						<li>Endnotes &#8212; use the <a data-cite="epub-ssv-11#endnotes"><code>endnotes</code></a> and
@@ -1548,10 +1547,10 @@
 					<h4>Identifying escapable structures</h4>
 
 					<p>Some content elements are containers for expressing complex information. A table, for example,
-						has data arranged in rows and cells. Lists similarly may contain many items. While users may be
-						interested in some of the information in these structures, they also often want to escape from
-						them to keep reading, not have to listen to the entire content before being able to move on.
-						These are called escapable elements, because the user needs to be able to escape from them
+						has data arranged in rows and cells. Lists similarly can contain many items. While users might
+						be interested in some of the information in these structures, they also often want to escape
+						from them to keep reading, not have to listen to the entire content before being able to move
+						on. These are called escapable elements, because the user needs to be able to escape from them
 						whenever they choose to simplify the reading experience.</p>
 
 					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] only
@@ -1562,7 +1561,7 @@
 						are what allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to provide users
 						the option to escape their playback sequences.</p>
 
-					<p>The recommended structures to identify for escapability are:</p>
+					<p>It is strongly advised to identify the following structures for escapability:</p>
 
 					<ul>
 						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code> semantic</a>
@@ -1579,7 +1578,7 @@
 						requirement.</p>
 
 					<div class="note">
-						<p>Identifying nested escapable structures is not recommended at this time. Refer to <a
+						<p>Identifying nested escapable structures is not advised at this time. Refer to <a
 								data-cite="epub/#sec-escapability">Escapability</a> [[epub]] for more information.</p>
 					</div>
 
@@ -1687,7 +1686,7 @@
 					generate text-to-speech playback, or for a refreshable braille display to have access to the
 					underlying text, as well as cause other accessibility issues.</p>
 
-				<p>The application of digital rights management therefore must not impair or impede the functionality of
+				<p>Therefore, the application of digital rights management cannot impair or impede the functionality of
 					assistive technologies on EPUB publications users have the right to access.</p>
 			</section>
 

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>
@@ -211,9 +211,9 @@
 						[[epub]], for example, which ensures the correct character data can be used (i.e., avoiding the
 						need to use images of text). Although this is an important feature, it is often not enough on
 						its own to ensure that the text is fully accessible in any given language (e.g., additional
-						information about directionality, emphasis, pronunciation, etc. may also be needed).</p>
+						information about directionality, emphasis, pronunciation, etc. might also be needed).</p>
 
-					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
+					<p>Consequently, there can also be language- or culture-specific practices for meeting accessibility
 						requirements. Whether these practices are defined within this specification and its techniques
 						or elsewhere (e.g., in WCAG techniques or language-specific best practice recommendations) will
 						depend on whether the issues are specific to EPUB or broadly affect all web content.</p>
@@ -231,11 +231,11 @@
 					discoverability requirements. Ideally, though, EPUB 2 publications will be upgraded to the latest
 					version of EPUB 3 to get access to the most advanced accessibility features and techniques.</p>
 
-				<p>Note that not all metadata expressions defined in this specification are supported in EPUB 2 as it
-					does not have an equivalent to the <a data-cite="epub/#attrdef-refines"><code>refines</code>
+				<p>Note that EPUB 2 does not support all metadata expressions defined in this specification as it does
+					not have an equivalent to the <a data-cite="epub/#attrdef-refines"><code>refines</code>
 						attribute</a> [[epub]]. If metadata expressions that require a <code>refines</code> attribute
 					cannot be avoided, there will be a certain amount of ambiguity in the statements (i.e.,
-					relationships between expression may only be apparent by their placement in the package document
+					relationships between expression might only be apparent by their placement in the package document
 					metadata).</p>
 			</section>
 
@@ -277,7 +277,7 @@
 				<p>Unlike web pages, <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> are distributed
 					through many channels for personal consumption — a model that has made EPUB a successful format for
 					ebooks and other types of digital publications. A consequence of this model, however, is that
-					specific details about the accessibility of a publication must travel with it.</p>
+					specific details about the accessibility of a publication have to travel with it.</p>
 
 				<p>An online bookstore aggregating content from publishers and authors, for example, does not know the
 					production quality that went into each submission unless the publisher informs them through
@@ -464,7 +464,7 @@
 						<li>
 							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[wcag20]],
 								but it is strongly RECOMMENDED that it meet the requirements of the <a
-									data-cite="wcag2#">latest recommended version of WCAG 2</a>.</p>
+									data-cite="wcag2#">latest W3C Recommendation of WCAG 2</a>.</p>
 						</li>
 
 						<li>
@@ -490,7 +490,7 @@
 
 					<p>Ideally, EPUB publications will conform to the latest version of WCAG 2 at Level AA, but local
 						and national laws, or procurer or distributor requirements, will define the formal thresholds
-						they must meet.</p>
+						they have to meet.</p>
 
 					<div class="note">
 						<p>Examples of legislative requirements for accessibility include the <a
@@ -574,7 +574,8 @@
 							<li>The "<a data-cite="wcag2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
 								page cannot be excluded when making a conformance claim -- applies to every <a
 									data-cite="epub/#dfn-epub-content-document">EPUB content document</a> in the EPUB
-								publication (i.e., they must all conform in full to the conformance level claimed).</li>
+								publication (i.e., they all have to conform in full to the conformance level
+								claimed).</li>
 						</ul>
 					</section>
 				</section>
@@ -727,8 +728,9 @@
 										reproduced in the digital edition).</p>
 									<p>The page list MUST include links to all the <a href="#sec-page-breaks-obj">page
 											break markers</a> in the content.</p>
-									<p>The page list should include links to all pages in the source, whether they are
-										reproduced or not, but this is not a conformance requirement.</p>
+									<p>It is encouraged to include links to all pages in the source in the page list,
+										whether they are reproduced or not, but this is not a conformance
+										requirement.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageList">Provide a page list</a>
 											[[epub-a11y-tech-12]] for more information on meeting this objective.</p>
@@ -766,8 +768,8 @@
 									<p>If an EPUB publication includes page break markers, the page break markers SHOULD
 										identify all pages reproduced from the source (i.e., blank pages and content not
 										reproduced in the digital edition do not require markers).</p>
-									<p>It is recommended that there be page break markers for all the pages in the
-										source, whether reproduced or not, but this is not a requirement.</p>
+									<p>It is encouraged to include page break markers for all the pages in the source,
+										whether reproduced or not, but this is not a requirement.</p>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
 										of the content (e.g., EPUB 3 media overlays [[?epub]]), the page break markers
 										MUST be identified in the playback instructions (e.g., using the <a
@@ -991,7 +993,7 @@
 										out of.</p>
 									<p>The same ease of escaping from content is only possible if <a
 											data-cite="epub/#dfn-epub-publication">EPUB publications</a> include
-										structural semantics in the synchronized text/audio format. Users may not be
+										structural semantics in the synchronized text/audio format. Users might not be
 										able to escape from lists, sidebars, figures, and other highly structured
 										content, without the structural semantics of those elements being available.</p>
 									<p>When the synchronized text-audio playback instructions include this information,
@@ -1030,8 +1032,8 @@
 									<p>Reading systems typically provide their own interfaces to the navigation aids in
 										the EPUB navigation document. For example, they open the table of contents as a
 										specialized interface on top of the content the user is reading.</p>
-									<p>To access these interfaces, users typically must rely on text-to-speech playback,
-										when available, to hear the entries.</p>
+									<p>To access these interfaces, users typically rely on text-to-speech playback, when
+										available, to hear the entries.</p>
 									<p>Providing synchronized text-audio playback for the EPUB navigation document
 										provides reading systems the ability to use auditory labels for the links,
 										improving the experience for auditory readers.</p>
@@ -1410,7 +1412,7 @@
 
 					<p>How long a conformance evaluation of an <a data-cite="epub/#dfn-epub-publication">EPUB
 							publication</a> is good for is a complex question. Unlike web sites, which are continuously
-						evolving, EPUB publications may not be updated again after their initial publication. As a
+						evolving, EPUB publications often do not get updated again after their initial publication. As a
 						result, an unmodified EPUB publication will always conform to its last evaluation.</p>
 
 					<p>It is common in publishing, however, to release updated versions of an EPUB publication to fix
@@ -1434,10 +1436,10 @@
 						release, only the new modifications will likely need evaluation to re-confirm conformance.</p>
 
 					<p>If an updated version of this specification or [[wcag2]] has been published since the last
-						release of the EPUB publication, a new evaluation is recommended to ensure conformance to the
-						latest standards. A full re-evaluation may not be necessary even in this case (e.g., only new or
-						modified success criteria may need checking unless the standards undergo major changes to
-						methodology or conformance).</p>
+						release of the EPUB publication, a new evaluation is advised to ensure conformance to the latest
+						standards. A full re-evaluation might not be necessary even in this case. For example, only new
+						or modified success criteria might need checking unless the standards undergo major changes to
+						methodology or conformance.</p>
 
 					<p>Conversely, an EPUB publication does not need a re-evaluation when only non-substantive changes
 						are made to it, such as:</p>
@@ -1451,18 +1453,18 @@
 							metadata.</li>
 					</ul>
 
-					<p>Individuals qualified to assess the accessibility of EPUB publications should make the
-						determination of whether changes are substantive or not. An editor, for example, may not realize
-						the impact of seemingly minor formatting changes.</p>
+					<p>Individuals qualified to assess the accessibility of EPUB publications need to determine whether
+						changes are substantive or not. An editor, for example, might not realize the impact of
+						seemingly minor formatting changes.</p>
 
 					<p>Even in the case of non-substantive changes, this specification recommends an updated evaluation
 						(full or partial) if the accessibility standards have changed.</p>
 
-					<p>Even more progressive approaches than those described here should also be considered. Waiting for
-						content changes before reviewing and updating the accessibility of EPUB publications can leave
-						them lacking recent improvements. For example, a publisher might prioritize periodic reviews of
-						their top-selling EPUB publications to ensure they remain maximally usable to the widest
-						possible audience.</p>
+					<p>It is strongly encouraged to consider even more progressive approaches than those described here.
+						Waiting for content changes before reviewing and updating the accessibility of EPUB publications
+						can leave them lacking recent improvements. For example, a publisher might prioritize periodic
+						reviews of their top-selling EPUB publications to ensure they remain maximally usable to the
+						widest possible audience.</p>
 				</section>
 			</section>
 
@@ -1480,7 +1482,7 @@
 					using the <a href="#contactEmail"><code>a11y:contactEmail</code> property</a>.</p>
 
 				<p>The email in this field is expected to direct user feedback and questions directly to the party or
-					individual reponsible for the accessibility of publications. It should not be a general purpose
+					individual reponsible for the accessibility of publications. It SHOULD NOT be a general purpose
 					feedback address.</p>
 
 				<div class="example" title="Publisher contact for accessibility information">
@@ -1585,27 +1587,26 @@
 
 			<p>Defining requirements for optimized publications is outside the scope of this specification, as is
 				formally recognizing other standards and guidelines that address these specific needs. The general model
-				of this specification can be used as a basis for identifying how an EPUB publication has been optimized,
-				however.</p>
+				of this specification can be used as a basis for identifying how an EPUB publication has been
+				optimized.</p>
 
 			<p>In particular, if an EPUB publication meets the requirements of an optimization standard, the following
-				best practices are recommended:</p>
+				best practices are also advised:</p>
 
 			<ul>
-				<li>The EPUB publication should meet the <a href="#sec-discovery">discovery metadata requirements</a> of
-					this specification so its accessible properties are machine-readable.</li>
-				<li>The EPUB publication should identify the standard or guidelines it follows in a
-						<code>conformsTo</code> property in accordance with [[dcterms]] so this information can be made
-					available to users.</li>
+				<li>The EPUB publication meet the <a href="#sec-discovery">discovery metadata requirements</a> of this
+					specification so its accessible properties are machine-readable.</li>
+				<li>The EPUB publication identify the standard or guidelines it follows in a <code>conformsTo</code>
+					property in accordance with [[dcterms]] so this information can be made available to users.</li>
 				<li>If the standard does not define conformance values for use in the <code>conformsTo</code> property,
-					the <code>conformsTo</code> property should include a URL [[url]] to where the standard is publicly
+					the <code>conformsTo</code> property include a URL [[url]] to where the standard is publicly
 					available so users can look up the specific details of the optimization.</li>
 				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
-					not publicly available), the metadata should provide additional information about the content has
-					been optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
+					not publicly available), the metadata provide additional information about the content has been
+					optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
 			</ul>
 
-			<p>When creating guidelines for optimized EPUB publications, it is recommended that these practices be
+			<p>When creating guidelines for optimized EPUB publications, it is advised that these practices be
 				integrated as a formal requirement for conformance.</p>
 
 			<div class="note">
@@ -1677,7 +1678,7 @@
 			<p>While many aspects of the distribution process are outside the scope of this specification, there are
 				factors that can be controlled. For example, while a publisher typically does not control the
 				accessibility of the digital rights management (DRM) scheme applied to their EPUB publications, they do
-				control what usage rights to apply to their EPUB publications. So even though a DRM scheme may allow a
+				control what usage rights to apply to their EPUB publications. So even though a DRM scheme might allow a
 				publisher to block access to the text of the publication, that publisher needs to take care not to apply
 				such a restriction as it could block the ability for <a>assistive technologies</a> to read the text
 				aloud.</p>
@@ -1712,8 +1713,8 @@
 				bookstores and any other interface that can build a profile of the user, on the other hand, has the
 				potential to violate the user's privacy. While it might seem helpful to store and anticipate the type of
 				content a user is most likely to consume, for example, or how best to initiate its playback, developers
-				should not engage in such profiling unless explicit permission is obtained from the user and a means of
-				easily removing the profile is available.</p>
+				are advised not engage in such profiling unless explicit permission is obtained from the user and a
+				means of easily removing the profile is available.</p>
 
 			<p>Even in the case where a user assents to the application maintaining information about their
 				accessibility needs, developers SHOULD ensure that this information is kept private (e.g., not share the
@@ -1946,7 +1947,7 @@ href="https://example.com/a11y-report/"/></pre>
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility 1.1</a> — those that may affect the
+					href="https://w3.org/TR/epub-a11y-11/">EPUB Accessibility 1.1</a> — those that can affect the
 				conformance of EPUB publications.</p>
 
 			<p>For a list of all issues addressed, refer to the <a

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>


### PR DESCRIPTION
In keeping with #2804, this pull request builds on #2801 to rewrite all normative-sounding keywords where they aren't being used normatively.

***

EPUB Accessibility 1.2:
* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/non-norm-rewrite/epub34/a11y/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2216/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/non-norm-rewrite/epub34/a11y/index.html)

EPUB Accessibility Techniques 1.2:
* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/non-norm-rewrite/epub34/a11y-tech/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2216/epub34/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/non-norm-rewrite/epub34/a11y-tech/index.html)
