### PR TITLE
Restructure optimized publications section

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>
@@ -162,12 +162,6 @@
 					provide a clear set of guidelines to evaluate content against and allow certification of quality. An
 					accessible EPUB publication is one that meets the accessibility requirements described in <a
 						href="#sec-accessible-pubs"></a>.</p>
-
-				<p>The specification also discusses the practice of optimizing EPUB publications for specific reading
-					modalities. In these cases, although the content cannot meet the broad accessibility requirements of
-					this specification, if the publications follow the discoverability and reporting requirements they
-					can improve the ability of users to determine if the content still meets their needs. Refer to <a
-						href="#sec-optimized-pubs"></a> for more information.</p>
 
 				<p>The specification also addresses the impact of distribution on the accessibility and discoverability
 					of content in <a href="#sec-distribution"></a>.</p>
@@ -1468,6 +1462,29 @@
 				</section>
 			</section>
 
+			<section id="sec-targeted-accessibility" class="informative">
+				<h3>Targeted accessibility</h3>
+
+				<p>Although WCAG [[wcag2]] provides a general set of guidelines for making content broadly accessible,
+					conformant content is not always optimal for specific user groups. Conversely, content optimized for
+					a specific need or reading modality is often not conformant to WCAG exactly because it targets a
+					specific audience.</p>
+
+				<p>For example, an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> with synchronized text
+					and audio can contain a full audio recording of the content but limit the text content to only the
+					major headings. In this case, the EPUB publication is consumable by users who needs to hear the
+					content (i.e., they can listen to the full publication and can navigate between headings) but is not
+					usable by anyone who cannot hear the audio.</p>
+
+				<p>In other words, when targeting an EPUB publication to a specific reading modality, the failure to
+					achieve a WCAG conformance level does not make the publication any less accessible to the intended
+					audience.</p>
+
+				<p>Although defining requirements for publications targeted to specific reader needs is outside the
+					scope of this specification, <a href="#app-optimized-pubs"></a> provides some best practices for
+					creating such standards in keeping with the objectives of this document.</p>
+			</section>
+
 			<section id="sec-feedback">
 				<h3>Feedback</h3>
 
@@ -1567,96 +1584,6 @@
 				</dl>
 			</section>
 		</section>
-		<section id="sec-optimized-pubs" class="informative">
-			<h2>Optimized publications</h2>
-
-			<p>Although WCAG [[wcag2]] provides a general set of guidelines for making content broadly accessible,
-				conformant content is not always optimal for specific user groups. Conversely, content optimized for a
-				specific need or reading modality is often not conformant to WCAG exactly because it targets a specific
-				audience.</p>
-
-			<p>For example, an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> with synchronized text and
-				audio can contain a full audio recording of the content but limit the text content to only the major
-				headings. In this case, the EPUB publication is consumable by users who needs to hear the content (i.e.,
-				they can listen to the full publication and can navigate between headings), but it is not usable by
-				anyone who cannot hear the audio.</p>
-
-			<p>In other words, when optimizing an EPUB publication for a specific reading modality, the failure to
-				achieve a WCAG conformance level does not make the publication any less accessible to the intended
-				audience.</p>
-
-			<p>Defining requirements for optimized publications is outside the scope of this specification, as is
-				formally recognizing other standards and guidelines that address these specific needs. The general model
-				of this specification can be used as a basis for identifying how an EPUB publication has been
-				optimized.</p>
-
-			<p>In particular, if an EPUB publication meets the requirements of an optimization standard, the following
-				best practices are also advised:</p>
-
-			<ul>
-				<li>The EPUB publication meet the <a href="#sec-discovery">discovery metadata requirements</a> of this
-					specification so its accessible properties are machine-readable.</li>
-				<li>The EPUB publication identify the standard or guidelines it follows in a <code>conformsTo</code>
-					property in accordance with [[dcterms]] so this information can be made available to users.</li>
-				<li>If the standard does not define conformance values for use in the <code>conformsTo</code> property,
-					the <code>conformsTo</code> property include a URL [[url]] to where the standard is publicly
-					available so users can look up the specific details of the optimization.</li>
-				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
-					not publicly available), the metadata provide additional information about the content has been
-					optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
-			</ul>
-
-			<p>When creating guidelines for optimized EPUB publications, it is advised that these practices be
-				integrated as a formal requirement for conformance.</p>
-
-			<div class="note">
-				<p>Refer to the <a href="https://w3c.github.io/epub-specs/docs/optimized-pubs/">Guide to Optimized
-						Publication Standards</a> for a non-normative list of standards.</p>
-			</div>
-
-			<aside class="example" title="Expressing conformance to an optimization standard">
-				<p>In this example, the conformance statement indicates the EPUB 3 publication conforms to the DAISY
-					Navigable Audio-only EPUB 3 Guidelines [[daisyaudio]].</p>
-				<pre>&lt;metadata …>
-   …
-   &lt;link
-       rel="dcterms:conformsTo"
-       href="https://daisy.org/info-help/guidance-training/standards/navigable-audio-only-epub3-guidelines/"/>
-   …
-&lt;/metadata></pre>
-			</aside>
-
-			<aside class="example" title="Describing conformance in a summary">
-				<p>In this example, the accessibility summary for an EPUB publication explains that it is optimized for
-					braille rendering.</p>
-				<pre>&lt;metadata …>
-   …
-   &lt;meta property="schema:accessibilitySummary">
-       This publication is optimized for braille readers. It will not be 
-       usable by persons who cannot read braille. The publication is designed
-       for braille reading devices capable of displaying 6-character cells and
-       40-character line lengths. The text is not contracted, and follows 
-       Unified English Braille formatting conventions. All characters are
-       encoded using the Unicode braille character set.
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-			</aside>
-
-			<aside class="example" title="Summary for a publication optimized for audio rendering">
-				<pre>&lt;metadata …>
-   …
-   &lt;meta property="schema:accessibilitySummary">
-       This publication is an audio book. It will not be usable by persons who 
-       cannot hear the audio. The publication is recorded by a professional
-       narrator. There is navigation to the beginning of each chapter. The text
-       of the publication is not included. Images are not included, but the
-       photo captions are narrated at the end of the chapter where they occur.
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-			</aside>
-		</section>
 		<section id="sec-distribution" class="informative">
 			<h2>Distribution</h2>
 
@@ -1723,6 +1650,80 @@
 			<p>Developers SHOULD NOT store or mine information about the types of searches a user performs when
 				searching for content based on its accessibility characteristics. This information can be used to
 				indirectly profile the abilities of users.</p>
+		</section>
+		<section id="app-optimized-pubs" class="appendix informative">
+			<h2>Guidelines for optimized publication standards</h2>
+
+			<p>An optimized publication is one that has been created to address a specific accessibility need, as
+				discussed in <a href="#sec-targeted-accessibility"></a>.</p>
+
+			<p>Although these publications cannot conform to the requirements of this specification, its general model
+				of accessible discovery and conformance reporting can be used as a template for ensuring that users can
+				find optimized content when they prefer it.</p>
+
+			<p>In particular, it is advised that the following practices be integrated as formal requirements for
+				conformance in any EPUB optimization standard:</p>
+
+			<ul>
+				<li>The EPUB publication meet the <a href="#sec-discovery">discovery metadata requirements</a> of this
+					specification so its accessible properties are machine-readable.</li>
+				<li>The EPUB publication identify the standard or guidelines it follows in a <code>conformsTo</code>
+					property in accordance with [[dcterms]] so this information can be made available to users.</li>
+				<li>If the standard does not define conformance values for use in the <code>conformsTo</code> property,
+					the <code>conformsTo</code> property include a URL [[url]] to where the standard is publicly
+					available so users can look up the specific details of the optimization.</li>
+				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
+					not publicly available), the metadata provide additional information about the content has been
+					optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
+			</ul>
+
+			<div class="note">
+				<p>For a list of optimization standards that can be used to produce accessible EPUB publications, refer
+					to <span class="ednote">new link TBD</span>.</p>
+			</div>
+
+			<aside class="example" title="Expressing conformance to an optimization standard">
+				<p>In this example, the conformance statement indicates the EPUB 3 publication conforms to the DAISY
+					Navigable Audio-only EPUB 3 Guidelines [[daisyaudio]].</p>
+				<pre>&lt;metadata …>
+   …
+   &lt;link
+       rel="dcterms:conformsTo"
+       href="https://daisy.org/info-help/guidance-training/standards/navigable-audio-only-epub3-guidelines/"/>
+   …
+&lt;/metadata></pre>
+			</aside>
+
+			<aside class="example" title="Describing conformance in a summary">
+				<p>In this example, the accessibility summary for an EPUB publication explains that it is optimized for
+					braille rendering.</p>
+				<pre>&lt;metadata …>
+   …
+   &lt;meta property="schema:accessibilitySummary">
+       This publication is optimized for braille readers. It will not be 
+       usable by persons who cannot read braille. The publication is designed
+       for braille reading devices capable of displaying 6-character cells and
+       40-character line lengths. The text is not contracted, and follows 
+       Unified English Braille formatting conventions. All characters are
+       encoded using the Unicode braille character set.
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+			</aside>
+
+			<aside class="example" title="Summary for a publication optimized for audio rendering">
+				<pre>&lt;metadata …>
+   …
+   &lt;meta property="schema:accessibilitySummary">
+       This publication is an audio book. It will not be usable by persons who 
+       cannot hear the audio. The publication is recorded by a professional
+       narrator. There is navigation to the beginning of each chapter. The text
+       of the publication is not included. Images are not included, but the
+       photo captions are narrated at the end of the chapter where they occur.
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+			</aside>
 		</section>
 		<section id="app-a11y-vocab" class="appendix vocab">
 			<h2>EPUB accessibility vocabulary</h2>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1654,32 +1654,42 @@
 		<section id="app-optimized-pubs" class="appendix informative">
 			<h2>Guidelines for optimized publication standards</h2>
 
-			<p>An optimized publication is one that has been created to address a specific accessibility need, as
-				discussed in <a href="#sec-targeted-accessibility"></a>.</p>
+			<p>An optimized <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> is one that has been created
+				to address a specific accessibility need, as discussed in <a href="#sec-targeted-accessibility"
+				></a>.</p>
 
 			<p>Although these publications cannot conform to the requirements of this specification, its general model
 				of accessible discovery and conformance reporting can be used as a template for ensuring that users can
 				find optimized content when they prefer it.</p>
 
-			<p>In particular, it is advised that the following practices be integrated as formal requirements for
-				conformance in any EPUB optimization standard:</p>
+			<p>In particular, it is advised to integrated the following practices as formal requirements in any
+				optimization standard:</p>
 
 			<ul>
-				<li>The EPUB publication meet the <a href="#sec-discovery">discovery metadata requirements</a> of this
-					specification so its accessible properties are machine-readable.</li>
-				<li>The EPUB publication identify the standard or guidelines it follows in a <code>conformsTo</code>
-					property in accordance with [[dcterms]] so this information can be made available to users.</li>
-				<li>If the standard does not define conformance values for use in the <code>conformsTo</code> property,
-					the <code>conformsTo</code> property include a URL [[url]] to where the standard is publicly
-					available so users can look up the specific details of the optimization.</li>
-				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
-					not publicly available), the metadata provide additional information about the content has been
-					optimized in the <a href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</li>
+				<li>
+					<p>That conforming EPUB publications meet the <a href="#sec-discovery">discovery metadata
+							requirements</a> of this specification so their accessible properties are
+						machine-readable.</p>
+				</li>
+				<li>
+					<p>That conforming EPUB publications identify the standard they follow in a <code>conformsTo</code>
+						property in accordance with [[dcterms]] so this information can be made available to users. If
+						this is not possible:</p>
+					<ul>
+						<li>because the standard does not define conformance values, it recommend conforming
+							publications include a <code>conformsTo</code> property that includes a URL [[url]] to where
+							the standard is publicly available so users can look up the specific details of the
+							optimization.</li>
+						<li>because the identifier is not sufficient for a user to understand conformance (e.g., the
+							standard is not publicly available), it recommend conforming publications provide additional
+							information about their optimization in the <a href="#confreq-schema-accessibilitySummary"
+								>accessibility summary</a>.</li>
+					</ul>
+				</li>
 			</ul>
 
 			<div class="note">
-				<p>For a list of optimization standards that can be used to produce accessible EPUB publications, refer
-					to <span class="ednote">new link TBD</span>.</p>
+				<p>For a list of optimization standards, refer to <span class="ednote">new link TBD</span>.</p>
 			</div>
 
 			<aside class="example" title="Expressing conformance to an optimization standard">


### PR DESCRIPTION
As we discussed on the TF call today, this pull request breaks the optimized publications section in two.

The text that explains how publications that don't meet wcag conformance level but are targeted to specific user needs are still accessible is now included under section 3 on accessible publications. I've named that subsection "Targeted accessibility" to avoid the perception that we're defining optimizations.

The rest of the text that recommends adding accessibility and discoverability metadata based on this document is now in an appendix called "guidelines for optimization standards".

The old section was informative and the new sections are informative so I haven't listed this in the change log as a substantive change. I'm open to listing it anyway if it might confuse people what happened to the old section.

One question: do we want to keep all three examples showing theoretical ways of describing conformance or maybe just keep the one using the link to the daisy audio guidelines since that's rooted in a real standard?

When we figure out hosting for a new page detailing optimization standards on the daisy site we can update the link. I've left an editor's note for now. I'll also update the existing registry document to redirect to the new page.

Fixes #2802 

***

EPUB Accessibility 1.2:
* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2802/epub34/a11y/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2216/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2802/epub34/a11y/index.html)