### PR TITLE
Added the AVIF format to the list of core media types

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1007,28 +1007,28 @@
 								<code>image/avif</code>
 							</td>
 							<td> [[av1-avif]] </td>
-							<td>AVIF Images</td>
+							<td>AVIF images</td>
 						</tr>
 						<tr>
 							<td id="cmt-gif" data-tests="#pub-cmt-gif">
 								<code>image/gif</code>
 							</td>
 							<td> [[gif]] </td>
-							<td>GIF Images</td>
+							<td>GIF images</td>
 						</tr>
 						<tr>
 							<td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
 								<code>image/jpeg</code>
 							</td>
 							<td> [[jpeg]] </td>
-							<td>JPEG Images</td>
+							<td>JPEG images</td>
 						</tr>
 						<tr>
 							<td id="cmt-png" data-tests="#pub-cmt-png">
 								<code>image/png</code>
 							</td>
 							<td> [[png]] </td>
-							<td>PNG Images</td>
+							<td>PNG images</td>
 						</tr>
 						<tr>
 							<td id="cmt-svg" data-tests="#pub-cmt-svg,#cnt-svg-support">
@@ -1044,7 +1044,7 @@
 								<code>image/webp</code>
 							</td>
 							<td> [[rfc9649]] </td>
-							<td>WebP Images</td>
+							<td>WebP images</td>
 						</tr>
 						<tr>
 							<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1003,6 +1003,13 @@
 							<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
 						</tr>
 						<tr>
+							<td id="cmt-avif" data-tests="#pub-cmt-avif">
+								<code>image/avif</code>
+							</td>
+							<td> [[av1-avif]] </td>
+							<td>AVIF Images</td>
+						</tr>
+						<tr>
 							<td id="cmt-gif" data-tests="#pub-cmt-gif">
 								<code>image/gif</code>
 							</td>
@@ -12018,6 +12025,8 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>06-October-2025: Added AVIF as a core media type for images. See 
+						<a href="https://github.com/w3c/epub-specs/issues/2794">issue 2794</a>.</li>
 					<li>26-June-2025: Moved the <code>xsd</code>, <code>msv</code>, and <code>prism</code> reserved
 						prefixes to the deprecated features section. See <a
 							href="https://github.com/w3c/epub-specs/issues/2739">issue 2739</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -308,7 +308,7 @@
 				<h4>Core Media types</h4>
 
 				<p id="confreq-rs-epub3-images"
-					data-tests="#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a reading system
+					data-tests="#pub-cmt-avif,#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a reading system
 					has a [=viewport=], it MUST support the <a data-cite="epub-34#cmt-grp-image">image core media type
 						resources</a> [[epub-34]].</p>
 


### PR DESCRIPTION
Following the [WG Resolution](https://w3c.github.io/pm-wg/minutes/2025-10-02.html#eda2) on AVIF, i.e., on #2794

Fix #2794

---

See:

* For EPUB 3 Overview:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/adding-avif/epub34/overview/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/overview/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/adding-avif/epub34/overview/index.html)
* For EPUB 3.4:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/adding-avif/epub34/authoring/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/authoring/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/adding-avif/epub34/authoring/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2811.html" title="Last updated on Oct 9, 2025, 1:32 PM UTC (4291489)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2811/ebfac4b...4291489.html" title="Last updated on Oct 9, 2025, 1:32 PM UTC (4291489)">Diff</a>