### PR TITLE
Fix all remaining references to 1.1.1

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.2</title>
@@ -63,6 +63,11 @@
 							"Madeleine Rothberg",
 							"Matt Garrish"
 						]
+					},
+					"epub-3": {
+						"title": "EPUB 3",
+						"href": "https://www.w3.org/TR/epub/",
+						"publisher": "W3C"
 					},
 					"iso24751-3": {
 						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
@@ -137,8 +142,9 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses terminology defined in <a data-cite="epub/#sec-terminology">EPUB 3.3</a> [[epub]]
-					and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.2</a> [[epub-a11y-12]]:</p>
+				<p>This document uses terminology defined in <a data-cite="epub/#sec-terminology">EPUB 3.3</a>
+					[[epub-3]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.2</a>
+					[[epub-a11y-12]]:</p>
 
 				<div class="note">
 					<p>Only the first instance of a term in a section links to its definition.</p>
@@ -264,7 +270,7 @@
 						the underlying markup).</p>
 
 					<p>As EPUB allows two <a data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> to
-						be rendered together in a <a data-cite="epub/#spread">synthetic spread</a> [[epub]], the order
+						be rendered together in a <a data-cite="epub/#spread">synthetic spread</a> [[epub-3]], the order
 						of content within a single document cannot always be evaluated in isolation. Content might span
 						visually from one document to the next. For example, a sidebar might span the bottom of two
 						pages.</p>
@@ -295,7 +301,7 @@
 							>EPUB content documents</a>, <a data-cite="epub/#dfn-epub-reading-system">reading
 							systems</a> automatically provide the ability for the user to move seamlessly from one
 						document to the next, so long as they are listed in the <a data-cite="epub/#sec-spine-elem"
-							>spine</a> [[epub]]. To the user, an EPUB publication is a single document they have
+							>spine</a> [[epub-3]]. To the user, an EPUB publication is a single document they have
 						complete access to, not a set of disconnected pages that they need links to move through.</p>
 
 					<p>The required table of contents provides a second method to access the major headings of the
@@ -455,7 +461,7 @@
 					</div>
 
 					<p>Although the <code>role</code> attribute might seem similar in nature to the <a
-							data-cite="epub/#sec-epub-type-attribute"><code>type</code> attribute</a> [[epub]], their
+							data-cite="epub/#sec-epub-type-attribute"><code>type</code> attribute</a> [[epub-3]], their
 						target uses in EPUB content documents do not overlap.</p>
 
 					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
@@ -917,7 +923,7 @@
 					<p>Consequently, it is necessary to provide the language of all text content in the package document
 						to conform with these WCAG success criteria. The easiest way to meet this requirement is to add
 						an <code>xml:lang</code> attribute on the root <a data-cite="epub/#sec-package-elem"
-								><code>package</code> element</a> [[epub]].</p>
+								><code>package</code> element</a> [[epub-3]].</p>
 
 					<aside class="example" title="All text declared to be in Japanese by default">
 						<pre><code>&lt;package … xml:lang="jp">
@@ -954,7 +960,7 @@
 					<p>In addition to being able to express the language of text content, the <a
 							data-cite="epub/#dfn-package-document">package document</a> also allows the identification
 						of the languages of the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> in <a
-							data-cite="epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a> [[epub]].</p>
+							data-cite="epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a> [[epub-3]].</p>
 
 					<aside class="example" title="Setting the language of an EPUB publication to Italian">
 						<pre><code>&lt;package …>
@@ -1147,7 +1153,7 @@
 
 					<p>To identify page numbers in media overlay documents, attach an <code>epub:type</code> attribute
 						with the value "<a data-cite="epub-ssv-11/#pagebreak"><code>pagebreak</code></a>" [[epub-ssv]]
-						to each <a data-cite="epub#sec-smil-par-elem"><code>par</code> element</a> [[epub]] that
+						to each <a data-cite="epub#sec-smil-par-elem"><code>par</code> element</a> [[epub-3]] that
 						identifies a page number.</p>
 
 					<aside class="example" title="A page number identified in a media overlays document">
@@ -1211,7 +1217,7 @@
 
 					<p>The <a data-cite="epub/#dfn-epub-navigation-document">EPUB navigation document</a> allows the
 						inclusion of a <a data-cite="epub/#sec-nav-pagelist"><code>page-list</code>
-							<code>nav</code></a> [[epub]], while the EPUB 2 NCX file provides the same functionality
+							<code>nav</code></a> [[epub-3]], while the EPUB 2 NCX file provides the same functionality
 						through the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2"
 								><code>pageList</code> element</a> [[opf-201]].</p>
 
@@ -1296,7 +1302,8 @@
 
 					<p>To allow users to determine the suitability of the pagination, identify the ISBN of the source
 						work in the <a data-cite="epub/#dfn-package-document">package document</a> metadata using the <a
-							data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a> [[epub]].</p>
+							data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a>
+						[[epub-3]].</p>
 
 					<aside class="example" title="Expressing the source of pagination">
 						<p>In this example, the <code>pageBreakSource</code> property contains the ISBN of the print
@@ -1315,15 +1322,15 @@
 						<p>These techniques previously advised using the <a data-cite="epub/#sec-source-of"
 									><code>source-of</code> property</a> to identify the <a
 								data-cite="epub/#sec-opf-dcmes-optional-def"><code>dc:source</code> element</a>
-							containing the source of the pagination [[epub]]. This method came with a number of
+							containing the source of the pagination [[epub-3]]. This method came with a number of
 							limitations, however. It was not future proof, for example, as it relied on the EPUB 3 <a
-								data-cite="epub/#attrdef-refines"><code>refines</code> attribute</a> [[epub]] and it
+								data-cite="epub/#attrdef-refines"><code>refines</code> attribute</a> [[epub-3]] and it
 							could not handle pagination without a source due to the reliance on a <code>dc:source</code>
 							element.</p>
 
 						<p>The <a data-cite="epub#sec-pageBreakSource"><code>pageBreakSource</code> property</a>
-							[[epub]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly advised
-							that anyone using the <code>source-of</code> property switch to using the
+							[[epub-3]] replaces <code>source-of</code> in newer version of EPUB 3. It is strongly
+							advised that anyone using the <code>source-of</code> property switch to using the
 								<code>pageBreakSource</code> property. Although the <code>source-of</code> method will
 							remain valid for backwards compatibility purposes, its use is no longer advised.</p>
 					</div>
@@ -1368,9 +1375,9 @@
 						even audio-only playback, have access to the same information as users who do not require
 						synchronized playback.</p>
 
-					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] allows audio
-						to be synchronized with any element in an <a data-cite="epub/#dfn-epub-content-document">EPUB
-							content document</a>, so there is no technical barrier to providing synchronized
+					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub-3]] allows
+						audio to be synchronized with any element in an <a data-cite="epub/#dfn-epub-content-document"
+							>EPUB content document</a>, so there is no technical barrier to providing synchronized
 						playback.</p>
 
 					<p>The primary consideration for this objective is what constitutes the text content of an EPUB
@@ -1384,9 +1391,9 @@
 
 					<p>The media overlays <a data-cite="epub/#sec-smil-text-elem"><code>text</code> element</a> is used
 						to reference these elements, either to play back the pre-recorded audio in a sibling <a
-							data-cite="epub/#sec-smil-audio-elem"><code>audio</code> element</a> [[epub]] or to initiate
-						playback of an audio or video element if the <code>audio</code> element is missing (e.g., for
-						embedded audio and video in the document).</p>
+							data-cite="epub/#sec-smil-audio-elem"><code>audio</code> element</a> [[epub-3]] or to
+						initiate playback of an audio or video element if the <code>audio</code> element is missing
+						(e.g., for embedded audio and video in the document).</p>
 
 					<div class="note">
 						<p>Do not synchronize media overlays to hidden text content. Synchronizing audio with invisible
@@ -1426,8 +1433,8 @@
 						content) diverges from the default reading order, order the playback sequence of <a
 							data-cite="epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
 							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements in a <a
-							data-cite="epub/#sec-overlay-docs">media overlays document</a> [[epub]] to match the logical
-						order.</p>
+							data-cite="epub/#sec-overlay-docs">media overlays document</a> [[epub-3]] to match the
+						logical order.</p>
 
 					<p>Use caution when making alterations, however, as other accessibility issues can arise when the
 						logical order does not match the default order. For example, the content might not be accessible
@@ -1451,13 +1458,14 @@
 						content after finishing the <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>. The
 						announcement of page break numbers can be similarly annoying to readers.</p>
 
-					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] does not
+					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub-3]] does not
 						allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to determine if playback
 						sequences are skippable unless additional semantics are added to the markup using the <a
-							data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code></a> attribute [[epub]] on
+							data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code></a> attribute [[epub-3]] on
 							<a data-cite="epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
-							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements [[epub]]. These semantics
-						are what allow reading systems to provide users the option to skip their playback sequences.</p>
+							data-cite="epub/#sec-smil-par-elem"><code>par</code></a> elements [[epub-3]]. These
+						semantics are what allow reading systems to provide users the option to skip their playback
+						sequences.</p>
 
 					<p>It is strongly advised to identify the following structures for skippability:</p>
 
@@ -1553,13 +1561,13 @@
 						on. These are called escapable elements, because the user needs to be able to escape from them
 						whenever they choose to simplify the reading experience.</p>
 
-					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub]] only
+					<p>EPUB 3's <a data-cite="epub/#sec-media-overlays">media overlays feature</a> [[epub-3]] only
 						supports escapability if structural semantics are added to the markup using the <a
-							data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[epub]] on
+							data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[epub-3]] on
 							<a data-cite="epub/#sec-smil-seq-elem"><code>seq</code></a> and <a
-							data-cite="epub/#sec-smil-seq-elem"><code>par</code></a> elements [[epub]]. These semantics
-						are what allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to provide users
-						the option to escape their playback sequences.</p>
+							data-cite="epub/#sec-smil-seq-elem"><code>par</code></a> elements [[epub-3]]. These
+						semantics are what allow <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> to
+						provide users the option to escape their playback sequences.</p>
 
 					<p>It is strongly advised to identify the following structures for escapability:</p>
 
@@ -1579,7 +1587,7 @@
 
 					<div class="note">
 						<p>Identifying nested escapable structures is not advised at this time. Refer to <a
-								data-cite="epub/#sec-escapability">Escapability</a> [[epub]] for more information.</p>
+								data-cite="epub/#sec-escapability">Escapability</a> [[epub-3]] for more information.</p>
 					</div>
 
 					<aside class="example" title="Identifying an escapable list">

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>
@@ -80,6 +80,11 @@
 						"date": "05 January 2017",
 						"publisher": "IDPF"
 					},
+					"epub-3": {
+						"title": "EPUB 3",
+						"href": "https://www.w3.org/TR/epub/",
+						"publisher": "W3C"
+					},
 					"marc21": {
 						"title": "MARC 21 XML",
 						"href": "https://www.loc.gov/standards/marcxml/"		
@@ -108,7 +113,7 @@
 						data: [
 							{
 								value: "EPUB 3",
-								href: "./epub-a11y-111.epub"
+								href: "./epub-a11y-12.epub"
 							}
 						]
 					}
@@ -208,9 +213,9 @@
 					<p>At the same time, the language and writing conventions of the authored text will influence the
 						techniques necessary to meet the accessibility requirements. EPUB <a
 							href="https://www.w3.org/TR/epub/#confreq-xml-enc">requires support for Unicode text</a>
-						[[epub]], for example, which ensures the correct character data can be used (i.e., avoiding the
-						need to use images of text). Although this is an important feature, it is often not enough on
-						its own to ensure that the text is fully accessible in any given language (e.g., additional
+						[[epub-3]], for example, which ensures the correct character data can be used (i.e., avoiding
+						the need to use images of text). Although this is an important feature, it is often not enough
+						on its own to ensure that the text is fully accessible in any given language (e.g., additional
 						information about directionality, emphasis, pronunciation, etc. might also be needed).</p>
 
 					<p>Consequently, there can also be language- or culture-specific practices for meeting accessibility
@@ -233,7 +238,7 @@
 
 				<p>Note that EPUB 2 does not support all metadata expressions defined in this specification as it does
 					not have an equivalent to the <a data-cite="epub/#attrdef-refines"><code>refines</code>
-						attribute</a> [[epub]]. If metadata expressions that require a <code>refines</code> attribute
+						attribute</a> [[epub-3]]. If metadata expressions that require a <code>refines</code> attribute
 					cannot be avoided, there will be a certain amount of ambiguity in the statements (i.e.,
 					relationships between expression might only be apparent by their placement in the package document
 					metadata).</p>
@@ -243,7 +248,7 @@
 				<h3>Terminology</h3>
 
 				<p>This specification uses <a data-cite="epub/#sec-terminology">terminology defined in EPUB 3</a>
-					[[epub]].</p>
+					[[epub-3]].</p>
 
 				<p>It also defines the following term:</p>
 
@@ -382,7 +387,7 @@
 				<h3>Linked metadata records</h3>
 
 				<p>Accessibility metadata can also be included in <a data-cite="epub/#sec-link-elem">linked records</a>
-					[[epub]] (i.e., metadata records referenced from <code>link</code> elements), but the inclusion of
+					[[epub-3]] (i.e., metadata records referenced from <code>link</code> elements), but the inclusion of
 					such metadata solely in a linked record does not satisfy the discoverability requirements of this
 					specification.</p>
 			</section>
@@ -566,10 +571,10 @@
 								to access such fallbacks. If an EPUB publication uses fallbacks, both the primary
 								content and its fallback(s) MUST meet the requirements for the conformance level
 								claimed. EPUB-specific fallback mechanisms include <a
-									data-cite="epub/#sec-manifest-fallbacks">manifest fallbacks</a> [[epub]], <a
-									data-cite="epub/#sec-opf-bindings">bindings</a> [[epub]] and content switching via
+									data-cite="epub/#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-3]], <a
+									data-cite="epub/#sec-opf-bindings">bindings</a> [[epub-3]] and content switching via
 								the <a data-cite="epub/#sec-xhtml-content-switch"><code>epub:switch</code> element</a>
-								[[epub]].</li>
+								[[epub-3]].</li>
 
 							<li>The "<a data-cite="wcag2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
 								page cannot be excluded when making a conformance claim -- applies to every <a
@@ -821,8 +826,8 @@
 						<h5>Applicability</h5>
 
 						<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> with synchronized text-audio
-							playback MUST conform to all requirements in [[epub]]. It is not necessary to meet any
-							additional requirements beyond those defined in [[epub]] to be conformant with this
+							playback MUST conform to all requirements in [[epub-3]]. It is not necessary to meet any
+							additional requirements beyond those defined in [[epub-3]] to be conformant with this
 							specification.</p>
 
 						<p>To maximize the effectiveness of synchronized text-audio playback for people with different
@@ -1044,7 +1049,7 @@
 									<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> SHOULD include
 										synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
-											document</a> [[epub]].</p>
+											document</a> [[epub-3]].</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-nav">Synchronizing the
 												navigation document</a> [[epub-a11y-tech-12]] for more information on
@@ -1105,8 +1110,8 @@
 					<h4>Publication conformance</h4>
 
 					<p>To indicate conformance to the accessibility requirements of this specification, an <a
-							data-cite="epub/#dfn-epub-publication">EPUB publication</a> [[epub]] MUST specify in its <a
-							data-cite="epub/#sec-pkg-metadata">metadata section</a> a <a
+							data-cite="epub/#dfn-epub-publication">EPUB publication</a> [[epub-3]] MUST specify in its
+							<a data-cite="epub/#sec-pkg-metadata">metadata section</a> a <a
 							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
 								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[dcterms]] whose value,
 						after <a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]], exactly matches
@@ -1273,7 +1278,7 @@
 						<p>If the date the evaluation was performed on is known, include that information in a <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
 									><code>dcterms:date</code> property</a> [[dcterms]] <a
-								data-cite="epub/#subexpression">associated with</a> [[epub]] the <a
+								data-cite="epub/#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<p>It is REQUIRED that the date string conform to [[iso8601-1]], particularly the subset
@@ -1305,7 +1310,7 @@
 						<p>If the evaluator has credentials or badges that establish their authority to evaluate
 							content, include that information in an <a href="#certifierCredential"><code
 									id="a11y-certifierCredential">a11y:certifierCredential</code> properties</a>
-							<a data-cite="epub/#subexpression">associated with</a> [[epub]] the <a
+							<a data-cite="epub/#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<div class="note">
@@ -1350,7 +1355,7 @@
 						<p>If the evaluator provides a publicly-readable report of its assessment, provide a link to the
 							assessment in an <a href="#certifierReport"><code id="a11y-certifierReport"
 									>a11y:certifierReport</code> property</a>
-							<a data-cite="epub/#subexpression">associated with</a> [[epub]] the <a
+							<a data-cite="epub/#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<aside class="example" title="An external accessibility report">
@@ -1500,7 +1505,7 @@
 
 				<dl>
 					<dt>
-						<a data-cite="epub-a11y-12/#">EPUB Accessibility Techniques 1.2</a>
+						<a data-cite="epub-a11y-tech-12/#">EPUB Accessibility Techniques 1.2</a>
 					</dt>
 					<dd>
 						<p>The EPUB Accessibility techniques [[epub-a11y-tech-12]] provide specific guidance on how to

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -112,8 +112,8 @@
 							and present their content to users.</p>
 					</li>
 					<li>
-						<p><a data-cite="epub-a11y-111#">EPUB Accessibility</a> [[epub-a11y-111]] — defines
-							accessibility conformance and discovery requirements for EPUB publications.</p>
+						<p><a data-cite="epub-a11y-12#">EPUB Accessibility</a> [[epub-a11y-12]] — defines accessibility
+							conformance and discovery requirements for EPUB publications.</p>
 					</li>
 				</ul>
 
@@ -164,7 +164,7 @@
 					proper rendering, such as images, audio and video clips, scripts, and style sheets.</p>
 
 				<p>Refer to <a href="#sec-contentdocs"></a> for detailed information about the rules and requirements to
-					produce EPUB content documents, and [[epub-a11y-111]] for accessibility requirements.</p>
+					produce EPUB content documents, and [[epub-a11y-12]] for accessibility requirements.</p>
 
 				<p>An EPUB publication also includes another key file called the [=EPUB navigation document=]. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
@@ -702,7 +702,7 @@
 				</li>
 				<li>
 					<p id="confreq-a11y">SHOULD conform to the accessibility requirements defined in
-						[[epub-a11y-111]].</p>
+						[[epub-a11y-12]].</p>
 				</li>
 				<li>
 					<p id="confreq-ocf">MUST be packaged in an [=EPUB container=] as defined in <a href="#sec-ocf"
@@ -3739,7 +3739,7 @@
 						in EPUB specifications.</p>
 
 					<div class="note">
-						<p>See [[epub-a11y-111]] for accessibility metadata recommendations.</p>
+						<p>See [[epub-a11y-12]] for accessibility metadata recommendations.</p>
 					</div>
 				</section>
 
@@ -5825,7 +5825,7 @@ No Entry</pre>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
-							[[epub-a11y-111]] applies to HTML content documents. See <a href="#confreq-a11y"
+							[[epub-a11y-12]] applies to HTML content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -6064,7 +6064,7 @@ No Entry</pre>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
-							[[epub-a11y-111]] applies to SVG content documents. See <a href="#confreq-a11y"
+							[[epub-a11y-12]] applies to SVG content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -9438,13 +9438,13 @@ html.my-document-playing * {
 			</dl>
 
 			<p>These standards also form the basis for making [=EPUB publications=] accessible. As the current WCAG
-				guidelines (version 2) are heavily focused on web pages, however, the <a data-cite="epub-a11y-111#">EPUB
-					Accessibility</a> standard [[epub-a11y-111]] defines how to apply these standards to EPUB
+				guidelines (version 2) are heavily focused on web pages, however, the <a data-cite="epub-a11y-12#">EPUB
+					Accessibility</a> standard [[epub-a11y-12]] defines how to apply these standards to EPUB
 				publications and adds EPUB-specific requirements and recommendations for metadata, pagination, and media
 				overlays.</p>
 
 			<p>This specification recommends that EPUB publications <a href="#confreq-a11y">conform to the accessibility
-					requirements</a> defined in&#160;[[epub-a11y-111]]. A benefit of following this recommendation is
+					requirements</a> defined in&#160;[[epub-a11y-12]]. A benefit of following this recommendation is
 				that it helps to ensure that EPUB publications meet the accessibility requirements legislated in
 				jurisdictions around the world.</p>
 
@@ -10419,8 +10419,9 @@ html.my-document-playing * {
 					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for example, will often reject new prefixes until they update their [=EPUB
-							conformance checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
+						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for
+							example, will often reject new prefixes until they update their [=EPUB conformance
+							checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
 					</div>
 
 					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"
@@ -10451,8 +10452,8 @@ html.my-document-playing * {
 										<td>a11y</td>
 										<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
 										<td>To declare properties from them EPUB Accessibility namespace. These are
-											typically defined in <a data-cite="epub-a11y-111#app-a11y-vocab">EPUB
-												Accessibility 1.1.1</a> [[epub-a11y-111]].</td>
+											typically defined in <a data-cite="epub-a11y-12#app-a11y-vocab">EPUB
+												Accessibility 1.2</a> [[epub-a11y-12]].</td>
 									</tr>
 									<tr>
 										<td>dcterms</td>

--- a/epub34/errata.html
+++ b/epub34/errata.html
@@ -96,10 +96,10 @@
       </section>
 
       <section data-erratalabel="Spec-Accessibility">
-        <h2>Open Errata on the “EPUB Accessibility 1.1.1” Recommendation</h2>
+        <h2>Open Errata on the “EPUB Accessibility 1.2” Recommendation</h2>
         <dl>
             <dt>Latest Published Version:</dt>
-            <dd><a href="https://www.w3.org/TR/epub-a11y-111/">https://www.w3.org/TR/epub-a11y-111/</a></dd>
+            <dd><a href="https://www.w3.org/TR/epub-a11y-12/">https://www.w3.org/TR/epub-a11y-12/</a></dd>
             <dt>Editors’ draft:</dt>
             <dd><a href="https://w3c.github.io/epub-specs/epub34/a11y/">https://w3c.github.io/epub-specs/epub34/a11y/</a></dd>
         </dl>
@@ -112,10 +112,10 @@
       </section>
 
       <section data-erratalabel="Spec-A11YTechniques">
-        <h2>Open Errata on the “EPUB Accessibility Techniques 1.1.1” Working Group Note</h2>
+        <h2>Open Errata on the “EPUB Accessibility Techniques 1.2” Working Group Note</h2>
         <dl>
             <dt>Latest Published Version:</dt>
-            <dd><a href="https://www.w3.org/TR/epub-a11y-tech-111/">https://www.w3.org/TR/epub-a11y-tech-111/</a></dd>
+            <dd><a href="https://www.w3.org/TR/epub-a11y-tech-12/">https://www.w3.org/TR/epub-a11y-tech-12/</a></dd>
             <dt>Editors’ draft:</dt>
             <dd><a href="https://w3c.github.io/epub-specs/epub34/a11y-tech/">https://w3c.github.io/epub-specs/epub34/a11y-tech/</a></dd>
         </dl>

--- a/epub34/index-page/index.html
+++ b/epub34/index-page/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>

--- a/epub34/index-page/index.html
+++ b/epub34/index-page/index.html
@@ -8,8 +8,8 @@
 		<script>
             const specs = [
                 "epub-34",
-                "epub-a11y-111",
-                "epub-a11y-tech-111",
+                "epub-a11y-12",
+                "epub-a11y-tech-12",
                 "epub-overview-34",
                 "epub-rs-34",
             ];
@@ -60,28 +60,6 @@
                 github: {
                     repoURL: "https://github.com/w3c/epub-specs",
                     branch: "main"
-                },
-                localBiblio: {
-					"epub-a11y-111": {
-						"title": "EPUB Accessibility 1.1.1",
-						"href": "https://w3c.github.io/epub-specs/epub34/a11y/",
-						"publisher": "W3C"
-					},
-					"epub-a11y-tech-111": {
-						"title": "EPUB Accessibility Techniques 1.1.1",
-						"href": "https://w3c.github.io/epub-specs/epub34/a11y-tech/",
-						"publisher": "W3C"
-					},
-					"epub-34": {
-						"title": "EPUB 3.4",
-						"href": "https://w3c.github.io/epub-specs/epub34/authoring/",
-						"publisher": "W3C"
-					},
-					"epub-rs-34": {
-						"title": "EPUB Reading Systems 3.4",
-						"href": "https://w3c.github.io/epub-specs/epub34/rs/",
-						"publisher": "W3C"
-					}
                 }
             };
         </script>
@@ -129,14 +107,14 @@
 							data-cite="epub-33#sec-ocf">container format</a>. </li>
 					<li>EPUB Reading Systems 3.4 [[epub-rs-34]]: defines the conformance requirements for EPUB 3 reading
 						systems — the user agents that render EPUB 3 Publications. </li>
-					<li>EPUB Accessibility 1.1.1 [[epub-a11y-111]]: specifies content conformance requirements for
+					<li>EPUB Accessibility 1.2 [[epub-a11y-12]]: specifies content conformance requirements for
 						verifying the accessibility of EPUB 3 Publications. </li>
 				</ul>
 
 				<div class="note"> The recommendation-track documents include detailed change logs on the substantive
 					changes since the previous official releases. See the change log for <a
 						data-cite="epub-34#change-log">EPUB 3.4</a>, <a data-cite="epub-rs-34#change-log">EPUB reading
-						systems 3.4</a>, and <a data-cite="epub-a11y-111#change-log">EPUB Accessibility 1.1.1</a>,
+						systems 3.4</a>, and <a data-cite="epub-a11y-12#change-log">EPUB Accessibility 1.2</a>,
 					respectively. </div>
 			</section>
 
@@ -149,8 +127,8 @@
 				<ul>
 					<li> EPUB 3 Overview [[epub-overview-34]]: gives a high level overview of the main EPUB 3.4 concepts
 						and terms. </li>
-					<li> EPUB Accessibility Techniques 1.1.1 [[epub-a11y-tech-111]]: provides guidance on how to meet the
-						EPUB Accessibility 1.1.1 [[epub-a11y-111]] discovery and accessibility requirements for EPUB
+					<li> EPUB Accessibility Techniques 1.2 [[epub-a11y-tech-12]]: provides guidance on how to meet the
+						EPUB Accessibility 1.2 [[epub-a11y-12]] discovery and accessibility requirements for EPUB
 						publications. </li>
 				</ul>
 			</section>

--- a/epub34/overview/index.html
+++ b/epub34/overview/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Overview</title>

--- a/epub34/overview/index.html
+++ b/epub34/overview/index.html
@@ -135,7 +135,7 @@
 					requirements. With the release of EPUB 3.3, however, there is now only one the document to read.</p> -->
 
 				<p>In addition, accessibility requirements for [=EPUB publications=] are described in the EPUB
-					Accessibility specification [[epub-a11y-111]]. One of the great advantages of a digital format like
+					Accessibility specification [[epub-a11y-12]]. One of the great advantages of a digital format like
 					EPUB 3 is that it breaks down the accessibility barriers of static print content. When constructed
 					with accessibility in mind, publications are usable by users with diverse needs.</p>
 
@@ -625,14 +625,14 @@
 							overlays</a>, and the <a href="#sec-container">container format</a>. </li>
 					<li>EPUB Reading Systems 3.4 [[epub-rs-34]]: defines the conformance requirements for EPUB 3 reading
 						systems — the user agents that render EPUB 3 Publications. </li>
-					<li>EPUB Accessibility 1.1.1 [[epub-a11y-111]]: specifies content conformance requirements for
+					<li>EPUB Accessibility 1.2 [[epub-a11y-12]]: specifies content conformance requirements for
 						verifying the accessibility of EPUB 3 Publications. </li>
 				</ul>
 
 				<div class="note"> The recommendation-track documents include detailed change logs on the substantive
 					changes since the previous official releases. See the change log for <a
 						data-cite="epub-34#change-log">EPUB 3.4</a>, <a data-cite="epub-rs-34#change-log">EPUB reading
-						systems 3.4</a>, and <a data-cite="epub-a11y-111#change-log">EPUB Accessibility 1.1.1</a>,
+						systems 3.4</a>, and <a data-cite="epub-a11y-12#change-log">EPUB Accessibility 1.2</a>,
 					respectively. </div>
 			</section>
 
@@ -647,8 +647,8 @@
 						that the technical requirements of the <a
 							href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">European
 							Accessibility Act</a> related to ebooks are met by the EPUB standard.</li>
-					<li>EPUB Accessibility Techniques 1.1.1 [[epub-a11y-tech-111]]: provides guidance on how to meet the
-						EPUB Accessibility 1.1.1 [[epub-a11y-111]] discovery and accessibility requirements for EPUB
+					<li>EPUB Accessibility Techniques 1.2 [[epub-a11y-tech-12]]: provides guidance on how to meet the
+						EPUB Accessibility 1.2 [[epub-a11y-12]] discovery and accessibility requirements for EPUB
 						publications. </li>
 					<li>
 						[[[epub-a11y-exemption]]] [[epub-a11y-exemption]]: the <code>exemption</code> property is used

--- a/epub34/reports/a11y-properties-use.html
+++ b/epub34/reports/a11y-properties-use.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="color-scheme" content="light dark" />
 
-    <title>EPUB Accessibility 1.1.1 Metadata Usage Report</title>
+    <title>EPUB Accessibility 1.2 Metadata Usage Report</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>
       .todo {
@@ -73,7 +73,7 @@
 <body>
     <section id="abstract">
         <p>
-            This document provides information on the usage of the accessibility metadata defined by the [[epub-a11y-111]] specification.
+            This document provides information on the usage of the accessibility metadata defined by the [[epub-a11y-12]] specification.
             It corresponds to the specification's <a href="exit_criteria.html#exit-criteria-a11y-2">category 2 exit criteria</a>.
     </section>
     <section id="sotd">

--- a/epub34/reports/a11y-properties-use.md
+++ b/epub34/reports/a11y-properties-use.md
@@ -1,7 +1,7 @@
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
-the [EPUB Accessibility 1.1.1](https://www.w3.org/TR/epub-a11y-111/) specification for
+the [EPUB Accessibility 1.2](https://www.w3.org/TR/epub-a11y-12/) specification for
 consideration as a W3C Proposed Recommendation after documenting implementation of each feature.
 
 For this specification to advance to Proposed Recommendation, it has to be
@@ -20,11 +20,11 @@ metadata for their EPUB publications (as appropriate for each title).
 ### Schema.org discovery metadata
 
 The following table provides a list of publishers who have stated that they are currently using
-the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package)
+the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-12/#sec-disc-package)
 in production or who are in the process of rolling out their implementations.
 
 Discovery properties are expressed in the
-[`meta` element's `property` attribute](https://www.w3.org/TR/epub-a11y-111/#attrdef-meta-property).
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-a11y-12/#attrdef-meta-property).
 
 <table>
     <thead>
@@ -35,7 +35,7 @@ Discovery properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessibilityFeature">schema:accessibilityFeature</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-12/#confreq-schema-accessibilityFeature">schema:accessibilityFeature</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -79,7 +79,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessibilityHazard">schema:accessibilityHazard</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-12/#confreq-schema-accessibilityHazard">schema:accessibilityHazard</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -123,7 +123,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="hhttps://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessibilitySummary">schema:accessibilitySummary</a></td>
+            <td><a href="hhttps://www.w3.org/TR/epub-a11y-12/#confreq-schema-accessibilitySummary">schema:accessibilitySummary</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -166,7 +166,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessMode">schema:accessMode</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-12/#confreq-schema-accessMode">schema:accessMode</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -210,7 +210,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://www.w3.org/TR/epub-a11y-111/#confreq-schema-accessModeSufficient">schema:accessModeSufficient</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-12/#confreq-schema-accessModeSufficient">schema:accessModeSufficient</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -276,7 +276,7 @@ and in the
     </thead>
     <tbody>
         <tr>
-        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#dcterms-conformsTo">dcterms:conformsTo</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-12/#dcterms-conformsTo">dcterms:conformsTo</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -320,7 +320,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#a11y-certifiedBy">a11y:certifiedBy</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-12/#a11y-certifiedBy">a11y:certifiedBy</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -363,7 +363,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#a11y-certifierCredential">a11y:certifierCredential</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-12/#a11y-certifierCredential">a11y:certifierCredential</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -406,7 +406,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td><a href="https://www.w3.org/TR/epub-a11y-111/#a11y-certifierReport">a11y:certifierReport</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-12/#a11y-certifierReport">a11y:certifierReport</a></td>
             <td>
             	<ul>
                     <li>Fondazione LIA</li>
@@ -430,7 +430,7 @@ The tool additionally allows authors to generate discovery and certifier metadat
 ## Vendor Implementations
 
 The following is a list of vendors who have stated that they are currently including
-the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package) for the publishers they serve. For publishers who have received third-party certification, they also include the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting) on their behalf.
+the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-12/#sec-disc-package) for the publishers they serve. For publishers who have received third-party certification, they also include the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-12/#sec-conf-reporting) on their behalf.
 
 - Amnet
 - Apex
@@ -443,8 +443,8 @@ the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-1
 
 ## Bookstore Implementations
 
-The following is a list of Bookstore's who display the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package)
-and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting) when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
+The following is a list of Bookstore's who display the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-12/#sec-disc-package)
+and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-12/#sec-conf-reporting) when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
 
 - [RedShelf](https://redshelf.com)
 - [VitalSource](https://www.vitalsource.com)
@@ -452,6 +452,6 @@ and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a
 
 ## Catalog Feed
 
-The following is a list of Vendors who provide the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-disc-package) and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting) in their catalog feed to partners when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
+The following is a list of Vendors who provide the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-12/#sec-disc-package) and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-12/#sec-conf-reporting) in their catalog feed to partners when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
 
 - [VitalSource](https://www.vitalsource.com)

--- a/epub34/reports/a11y-usage.html
+++ b/epub34/reports/a11y-usage.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="color-scheme" content="light dark" />
 
-    <title>EPUB Accessibility 1.1.1 Usage Report</title>
+    <title>EPUB Accessibility 1.2 Usage Report</title>
     <style>
         .todo {
           background-color: yellow;

--- a/epub34/reports/a11y-usage.md
+++ b/epub34/reports/a11y-usage.md
@@ -1,13 +1,13 @@
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
-the [EPUB Accessibility 1.1.1](https://www.w3.org/TR/epub-a11y-111/) specification for
+the [EPUB Accessibility 1.2](https://www.w3.org/TR/epub-a11y-12/) specification for
 consideration as a W3C Proposed Recommendation after documenting that publishers can
 meet the requirements at WCAG 2.0 Level AA.
 
 For this specification to advance to Proposed Recommendation, it has to be
 proven that at least 5 publishers will produce at least 1 EPUB publication each that 
-conform to [EPUB Accessibility 1.1 - WCAG 2.0 Level AA](https://www.w3.org/TR/epub-a11y-111/#sec-conf-reporting-pub).
+conform to [EPUB Accessibility 1.1 - WCAG 2.0 Level AA](https://www.w3.org/TR/epub-a11y-12/#sec-conf-reporting-pub).
 
 Publishers are not expected to be producing content that claims conformance
 to the specification prior to it becoming a recommendation, only that they have

--- a/epub34/reports/exit_criteria.html
+++ b/epub34/reports/exit_criteria.html
@@ -179,7 +179,7 @@
         <section>
             <h2 id="epub-accessibility-1.1">EPUB Accessibility 1.1</h2>
             <p>
-              The goals of the <a href="https://www.w3.org/TR/epub-a11y-111/">EPUB Accessibility 1.1</a> document is to define accessibility conformance of EPUB publications beyond the accessibility requirements defined by WCAG for publication resources. The normative features of this specification can be divided, roughly, into the following categories:
+              The goals of the <a href="https://www.w3.org/TR/epub-a11y-12/">EPUB Accessibility 1.2</a> document is to define accessibility conformance of EPUB publications beyond the accessibility requirements defined by WCAG for publication resources. The normative features of this specification can be divided, roughly, into the following categories:
             </p>
             <ol>
                 <li>

--- a/epub34/reports/exit_criteria.html
+++ b/epub34/reports/exit_criteria.html
@@ -177,7 +177,7 @@
             </section>
         </section>
         <section>
-            <h2 id="epub-accessibility-1.1">EPUB Accessibility 1.1</h2>
+            <h2 id="epub-accessibility-1.2">EPUB Accessibility 1.2</h2>
             <p>
               The goals of the <a href="https://www.w3.org/TR/epub-a11y-12/">EPUB Accessibility 1.2</a> document is to define accessibility conformance of EPUB publications beyond the accessibility requirements defined by WCAG for publication resources. The normative features of this specification can be divided, roughly, into the following categories:
             </p>

--- a/epub34/reports/index.html
+++ b/epub34/reports/index.html
@@ -101,10 +101,10 @@
           <li>
             <p>
               <a href="exit_criteria.html#exit-criteria-a11y-1">Category 1</a>: at least 5 publishers produce at least 1 EPUB publication each that
-              conforms to <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.  
+              conforms to <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">EPUB Accessibility 1.2 - WCAG 2.0 Level AA</a>.  
             </p>
             <p>
-              See the <a href="a11y-usage.html">EPUB Accessibility 1.1 Usage Report</a> document.
+              See the <a href="a11y-usage.html">EPUB Accessibility 1.2 Usage Report</a> document.
             </p>
           </li>
           <li>
@@ -113,7 +113,7 @@
               target communities, i.e., at least two organizations regularly include them in the [=package document=] metadata for their EPUB publications (as appropriate for each title).
             </p>
             <p>
-              See the <a href="a11y-properties-use.html">EPUB Accessibility 1.1 Metadata Usage Report</a> document.
+              See the <a href="a11y-properties-use.html">EPUB Accessibility 1.2 Metadata Usage Report</a> document.
             </p>
           </li>
         </ul>


### PR DESCRIPTION
Now that specref is picking up the new 1.2 versions, this pr fixes all the 1.1.1 references in the /epub34 folder.

Also includes a fix for an incorrect self-referencing link in the a11y spec and adds back the undated epub-3 references for the accessibility docs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2812.html" title="Last updated on Oct 7, 2025, 12:58 PM UTC (1f76ec7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2812/ebfac4b...1f76ec7.html" title="Last updated on Oct 7, 2025, 12:58 PM UTC (1f76ec7)">Diff</a>