### PR TITLE
Add section for obsolete but conforming features

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3148,8 +3148,7 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and
-						[^package^].</p>
+					<p>Allowed on: <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and [^package^].</p>
 				</section>
 
 
@@ -3190,8 +3189,9 @@
 						<pre>&lt;dc:title id="pub-title"&gt;The Lord of the Rings&lt;/dc:title&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^item^],
-						[^itemref^], [^link^], [^manifest^], [^meta^], [^package^], and [^spine^].</p>
+					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a href="#sec-opf-dcmes"
+							>Dublin Core elements</a>, [^item^], [^itemref^], [^link^], [^manifest^], [^meta^],
+						[^package^], and [^spine^].</p>
 				</section>
 
 				<section id="attrdef-media-type">
@@ -3322,7 +3322,7 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and
+					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and
 						[^package^].</p>
 				</section>
 			</section>
@@ -3429,7 +3429,8 @@
 								</p>
 							</li>
 							<li>
-								<p> [^collection^] <code>[0 or more]</code>
+								<p> <a href="#sec-collection-elem"><code>collection</code></a> <code>[0 or more]</code>
+									<span class="legacy">([=obsolete but conforming=])</span>
 								</p>
 							</li>
 						</ul>
@@ -9435,8 +9436,8 @@ html.my-document-playing * {
 						</ul>
 					</dd>
 
-					<dt>Collections</dt>
-					<dd id="sec-pkg-collections">
+					<dt id="sec-pkg-collections">Collections</dt>
+					<dd>
 						<ul>
 							<li id="sec-collection-elem">
 								<a data-cite="epub-33#sec-collection-elem"><code>collection</code> element</a>
@@ -9450,7 +9451,7 @@ html.my-document-playing * {
 						</div>
 					</dd>
 
-					<dt>Legacy features</dt>
+					<dt id="sec-pkg-legacy">Legacy features</dt>
 					<dd>
 						<ul>
 							<li id="sec-opf2-meta">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
@@ -76,6 +76,10 @@
 		<style>
 			pre {
 				white-space: break-spaces !important;
+			}
+			#app-unsupported dt {
+				margin-top: 2rem;
+				margin-bottom: 1rem;
 			}</style>
 	</head>
 	<body>
@@ -1160,7 +1164,7 @@
 								<code>application/x-dtbncx+xml</code>
 							</td>
 							<td> [[opf-201]] </td>
-							<td>The <a href="#obsolete-but-conforming">obsolete but conforming</a> NCX</td>
+							<td>The [=obsolete but conforming=] NCX</td>
 						</tr>
 						<tr>
 							<td id="cmt-smil">
@@ -1669,8 +1673,8 @@
 					archive: the "physical container". The rules for ZIP physical containers build upon the ZIP
 					technologies used by [[odf]].</p>
 
-				<p>OCF also retains an <a href="#sec-font-obfuscation">obsolete but conforming algorithm for obfuscating
-						embedded fonts</a> but this functionality is no longer advised.</p>
+				<p>OCF also retains an [=obsolete but conforming=] algorithm for <a href="#sec-font-obfuscation"
+						>obfuscating embedded fonts</a> but this functionality is no longer advised.</p>
 			</section>
 
 			<section id="sec-container-abstract">
@@ -1709,8 +1713,8 @@
 						</dt>
 						<dd>
 							<p>Contains information about the encryption of [=publication resources=]. This file is
-								mandatory when using the <a href="#sec-font-obfuscation">obsolete but conforming font
-									obfuscation feature</a>.</p>
+								mandatory when using the [=obsolete but conforming=] <a href="#sec-font-obfuscation"
+									>font obfuscation feature</a>.</p>
 						</dd>
 
 						<dt>
@@ -2536,9 +2540,9 @@
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
 									of embedded fonts referenced by an [=EPUB publication=] to make them more difficult
 									to extract for unrestricted use. Although obfuscation is not encryption, reading
-									systems use the <code>encryption.xml</code> file in conjunction with the <a
-										href="#sec-font-obfuscation">obsolete but conforming font obfuscation
-										algorithm</a> to identify fonts to deobfuscate.</p>
+									systems use the <code>encryption.xml</code> file in conjunction with the [=obsolete
+									but conforming=] <a href="#sec-font-obfuscation">font obfuscation algorithm</a> to
+									identify fonts to deobfuscate.</p>
 
 								<p id="encryption-restrictions">The following files MUST NOT be encrypted:</p>
 
@@ -3425,7 +3429,7 @@
 										<code>guide</code>
 									</a>
 									<code>[0 or 1]</code>
-									<a href="#obsolete-but-conforming" class="legacy">(obsolete but conforming)</a>
+									<span class="legacy">([=obsolete but conforming=])</span>
 								</p>
 							</li>
 							<li>
@@ -3516,7 +3520,7 @@
 									<p>
 										<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
 										<code>[0 or more]</code>
-										<a href="#obsolete-but-conforming" class="legacy">(obsolete but conforming)</a>
+										<span class="legacy">([=obsolete but conforming=])</span>
 									</p>
 								</li>
 								<li>
@@ -5241,7 +5245,7 @@ No Entry</pre>
 											<code>toc</code>
 										</a>
 										<code>[optional]</code>
-										<a href="#obsolete-but-conforming" class="legacy">(obsolete but conforming)</a>
+										<span class="legacy">([=obsolete but conforming=])</span>
 									</p>
 								</li>
 							</ul>
@@ -5291,9 +5295,9 @@ No Entry</pre>
 						mechanisms to override the default direction (e.g., buttons or settings that allow the
 						application of alternate style sheets).</p>
 
-					<p>The <a href="#obsolete-but-conforming">obsolete but conforming</a>
-						<code>toc</code> attribute takes an <a data-cite="xml#idref">IDREF</a> [[xml]] that identifies
-						the manifest item that represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
+					<p>The [=obsolete but conforming=] <code>toc</code> attribute takes an <a data-cite="xml#idref"
+							>IDREF</a> [[xml]] that identifies the manifest item that represents the <a
+							href="#sec-opf2-ncx">NCX</a>.</p>
 				</section>
 
 				<section id="sec-itemref-elem" data-epubcheck="true"
@@ -9498,11 +9502,11 @@ html.my-document-playing * {
 				EPUB 2 reading systems. This section defines the meanings of the designations attached to these features
 				and their support expectations.</p>
 
-			<section id="under-implemented">
+			<section id="sec-under-implemented">
 				<h3>Under-implemented features</h3>
 
-				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.3 [[epub-33]]
-					for which the Working Group has not been able to establish enough <a
+				<p>An <dfn id="under-implemented">under-implemented</dfn> feature is a feature introduced prior to EPUB
+					3.3 [[epub-33]] for which the Working Group has not been able to establish enough <a
 						href="https://www.w3.org/policies/process/#adequate-implementation">implementation
 						experience</a>.</p>
 
@@ -9525,72 +9529,82 @@ html.my-document-playing * {
 				</div>
 			</section>
 
-			<section id="obsolete-but-conforming">
+			<section id="sec-obs-conform">
 				<h3>Obsolete but conforming features</h3>
 
-				<p>An <dfn>obsolete but conforming</dfn> feature is one that is not deprecated but that is also either
-					not designed for use in EPUB 3 [=reading systems=] or that would ideally be deprecated except that
-					it would invalidate a significant base of existing [=EPUB publications=].</p>
+				<p>An <dfn id="obsolete-but-conforming">obsolete but conforming</dfn> feature is one that is not
+					deprecated but that is also either not designed for use in EPUB 3 [=reading systems=] or that would
+					ideally be deprecated except that it would invalidate a significant base of existing [=EPUB
+					publications=].</p>
 
-				<p>[=EPUB publications=] MAY include the obsolete but conforming features defined in this section.</p>
+				<p>[=EPUB publications=] MAY include the obsolete but conforming features defined in this section. Their
+					usage MUST conform to their referenced definitions.</p>
+
+				<dl>
+					<dt>Open Container Format (OCF)</dt>
+					<dd>
+						<ul>
+							<li id="sec-font-obfuscation">
+								<p><a data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]]</p>
+								<div class="caution">
+									<p>NIST is advising that use of the SHA-1 algorithm [[fips-180-4]] be phased out by
+										the end of 2030. The Publishing Maintenance Working Group does not intend to
+										support font obfuscation in EPUB publications past that date due to its reliance
+										on SHA-1, although reading systems will have to continue to support
+										deobfuscation for existing EPUB publications.</p>
+									<p>Better methods of protecting fonts exist. Both [[woff]] and [[woff2]] fonts, for
+										example, allow the embedding of licensing information and provide some
+										protection through font table compression. The use of remotely hosted fonts also
+										allows for font subsetting.</p>
+								</div>
+							</li>
+						</ul>
+					</dd>
+
+					<dt>Package document</dt>
+					<dd>
+						<ul>
+							<li id="sec-opf2-meta">
+								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2">OPF 2
+											<code>meta</code> element</a> [[opf-201]]</p>
+							</li>
+
+							<li id="sec-opf2-guide">
+								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">OPF 2
+											<code>guide</code> element</a>&#160;[[opf-201]]</p>
+							</li>
+
+							<li id="sec-opf2-ncx">
+								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">OPF 2
+										NCX</a> [[opf-201]]</p>
+							</li>
+						</ul>
+						<div class="note">
+							<p>EPUB 3 reading systems ignore these features. They are replaced by the [^meta^] element,
+								the <a href="#sec-nav-landmarks">landmarks nav</a>, and the <a href="#sec-nav-toc">toc
+									nav</a>, respectively.</p>
+							<p>The features are retained only to provide a measure of backwards compatibility with
+								reading systems that only support EPUB 2. As such reading systems are now rare,
+								including these features has limited value.</p>
+						</div>
+					</dd>
+				</dl>
 
 				<div class="note">
 					<p>The Working Group advises that [=EPUB conformance checkers=] not issue alerts about the presence
 						of obsolete but conforming features in [=EPUB publications=]. Only issue alerts if a feature
 						does not conform to its definition or otherwise breaks a usage requirement.</p>
 				</div>
-
-				<dl>
-					<dt>OCF</dt>
-					<dd>
-						<p id="sec-font-obfuscation">This specification previously defined an <a
-								data-cite="epub-33#sec-font-obfuscation">algorithm for obfuscating fonts</a>
-							[[epub-33]]. Due to its weak encryption capabilities and its reliance on SHA-1, which will
-							be deprecated as of 2030, the use of font obfuscation is no longer advised even though it
-							remains conforming. Better methods of protecting fonts exist. Both [[woff]] and [[woff2]]
-							fonts, for example, allow the embedding of licensing information and provide some protection
-							through font table compression. The use of remotely hosted fonts also allows for font
-							subsetting.</p>
-					</dd>
-
-					<dt>Package document</dt>
-					<dd>
-						<p>The following features are retained only to provide a measure of backwards compatibility with
-							reading systems that only support EPUB 2 publications. They are ignored by EPUB 3 reading
-							systems. As reading systems that only handle EPUB 2 publications are now rare, including
-							these features has limited value.</p>
-						<ul>
-							<li id="sec-opf2-meta">
-								<p>OPF 2 <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-											><code>meta</code> element</a> [[opf-201]] &#8212; EPUB 3 reading systems
-									only recognize the EPUB 3 [^meta^] element for metadata. For cover images, EPUB 3
-									reading systems only recognize the the <a href="#sec-cover-image"
-											><code>cover-image</code> property</a>.</p>
-							</li>
-
-							<li id="sec-opf2-guide">
-								<p>OPF 2 <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-											><code>guide</code> element</a>&#160;[[opf-201]] &#8212; EPUB 3 reading
-									systems only recognize the <a href="#sec-nav-landmarks">landmarks nav</a>.</p>
-							</li>
-
-							<li id="sec-opf2-ncx">
-								<p>OPF 2 <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1"
-										>NCX</a> [[opf-201]] &#8212; EPUB 3 reading systems only recognize the <a
-										href="#sec-nav">EPUB navigation document</a>.</p>
-							</li>
-						</ul>
-					</dd>
-				</dl>
 			</section>
 
-			<section id="deprecated">
+			<section id="sec-deprecated">
 				<h3>Deprecated features</h3>
 
-				<p>The following <strong>deprecated</strong> features SHOULD NOT be used. These features have limited or
-					no support in [=reading systems=] and/or usage in [=EPUB publications=].</p>
+				<p>A <dfn id="deprecated">deprecated</dfn> feature is one that has limited or no support in [=reading
+					systems=] and/or usage in [=EPUB publications=].</p>
 
-				<p>When used, their usage MUST conform to their referenced definitions.</p>
+				<p>The following deprecated features SHOULD NOT be used. When used, their usage MUST conform to their
+					referenced definitions.</p>
 
 				<dl>
 					<dt>Package document</dt>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3110,13 +3110,20 @@
 
 				<section id="attrdef-dir" data-epubcheck="true"
 					data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L24">
-					<h4>The <code>dir</code> attribute (under-implemented)</h4>
+					<h4>The <code>dir</code> attribute</h4>
 
 					<div class="note">
-						<p>The <code>dir</code> attribute is marked <a href="#under-implemented">under-implemented</a>
-							as [=reading systems=] often only support a single default directionality for text display.
-							Regardless, it is still strongly encouraged to set the proper directionality of text values
-							in the [=package document=] to ensure proper rendering once this situation improves.</p>
+						<p>The <code>dir</code> attribute currently does not have sufficient <a
+								href="https://www.w3.org/policies/process/#adequate-implementation">implementation
+								experience</a>, as [=reading systems=] typically only support a single default
+							directionality for metadata display.</p>
+						<p>Although it lacks the necessary reading system support, it is integral to the content model
+							on which EPUB is built (i.e., for internationalization support in the [=package document=]).
+							Consequently, it is strongly encouraged to set the proper directionality of text values in
+							the package document to ensure proper rendering once this situation improves.</p>
+						<p>The lessening of requirements for this attribute was only done to account for the different
+							process under which EPUB was developed prior to being brought into W3C. New features
+							developed under W3C processes will not receive a similar exemption.</p>
 					</div>
 
 					<p
@@ -3150,6 +3157,12 @@
 
 					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a href="#sec-opf-dcmes"
 							>Dublin Core elements</a>, [^meta^], and [^package^].</p>
+
+					<div class="note">
+						<p>The Working Group advises that [=EPUB conformance checkers=] alert about the presence of
+								<code>dir</code> when encountered in EPUB publications but as its inclusion is not a
+							violation of the standard to not emit an error or warning.</p>
+					</div>
 				</section>
 
 
@@ -9374,47 +9387,15 @@ html.my-document-playing * {
 					privacy and security.</p>
 			</section>
 		</section>
-		<section id="app-unsupported" class="appendix">
-			<h2>Unsupported features</h2>
-
-			<p>This specification contains certain features that are not yet fully supported in [=reading systems=],
-				that the Working Group no longer recommends for use, or that are only retained for interoperability with
-				EPUB 2 reading systems. This section defines the meanings of the designations attached to these features
-				and their support expectations.</p>
-
-			<section id="sec-under-implemented">
-				<h3>Under-implemented features</h3>
-
-				<p>An <dfn id="under-implemented">under-implemented</dfn> feature is a feature introduced prior to EPUB
-					3.3 [[epub-33]] for which the Working Group has not been able to establish enough <a
-						href="https://www.w3.org/policies/process/#adequate-implementation">implementation
-						experience</a>.</p>
-
-				<p>Only the <a href="#attrdef-dir"><code>dir</code> attribute</a> is designated as under-implemented.
-					Although it lacks the necessary reading system support, it is integral to the content model on which
-					EPUB is built (i.e., for internationalization support in the package document).</p>
-
-				<p>This feature MAY be used as described.</p>
-
-				<div class="note">
-					<p>The Working Group advises that [=EPUB conformance checkers=] alert about the presence of
-						under-implemented features when encountered in EPUB publications but as their inclusion is not a
-						violation of the standard to not emit as errors or warnings).</p>
-				</div>
-
-				<div class="note">
-					<p>The marking of features as under-implemented was a one-time event to account for the different
-						process under which EPUB was developed prior to being brought into W3C. This label will not be
-						used for new features developed under W3C processes.</p>
-				</div>
-			</section>
+		<section id="app-obsolete" class="appendix">
+			<h2>Obsolete features</h2>
 
 			<section id="sec-obs-conform">
 				<h3>Obsolete but conforming features</h3>
 
 				<p>An <dfn id="obsolete-but-conforming">obsolete but conforming</dfn> feature is one that is not
 					deprecated but that is also either not designed for use in EPUB 3 [=reading systems=] or that would
-					ideally be deprecated except that it would invalidate a significant base of existing [=EPUB
+					ideally be [=deprecated=] except that it would invalidate a significant base of existing [=EPUB
 					publications=].</p>
 
 				<p>[=EPUB publications=] MAY include the obsolete but conforming features defined in this section. Their
@@ -9541,7 +9522,7 @@ html.my-document-playing * {
 				</div>
 			</section>
 
-			<section id="sec-deprecated">
+			<section id="sec-obs-deprecated">
 				<h3>Deprecated features</h3>
 
 				<p>A <dfn id="deprecated">deprecated</dfn> feature is one that has limited or no support in [=reading
@@ -11544,8 +11525,9 @@ EPUB/images/cover.png</pre>
 						than the font obfuscation are advised. See <a
 							href="https://github.com/w3c/epub-specs/issues/2807">issue 2807</a>.</li>
 					<li>10-Oct-2025: Created an obsolete but conforming classification for features and moved font
-						obfuscation, the legacy package document features, and the prefixed CSS properties to it. See <a
-							href="https://github.com/w3c/epub-specs/issues/2807">issue 2807</a>.</li>
+						obfuscation, the <code>collection</code> element, the legacy package document features, and the
+						prefixed CSS properties to it. See <a href="https://github.com/w3c/epub-specs/issues/2807">issue
+							2807</a>.</li>
 					<li>26-June-2025: Moved the <code>xsd</code>, <code>msv</code>, and <code>prism</code> reserved
 						prefixes to the deprecated features section. See <a
 							href="https://github.com/w3c/epub-specs/issues/2739">issue 2739</a>.</li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
@@ -3431,7 +3431,9 @@
 							</li>
 							<li>
 								<p>
-									<a href="#sec-collection-elem"><code>collection</code></a>
+									<a href="#sec-collection-elem">
+										<code>collection</code>
+									</a>
 									<code>[0 or more]</code>
 									<span class="legacy">([=obsolete but conforming=])</span>
 								</p>
@@ -11538,6 +11540,12 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>10-Oct-2025: Added caution that SHA-1 is being phased out so other methods of protecting fonts
+						than the font obfuscation are advised. See <a
+							href="https://github.com/w3c/epub-specs/issues/2807">issue 2807</a>.</li>
+					<li>10-Oct-2025: Created an obsolete but conforming classification for features and moved font
+						obfuscation, the legacy package document features, and the prefixed CSS properties to it. See <a
+							href="https://github.com/w3c/epub-specs/issues/2807">issue 2807</a>.</li>
 					<li>26-June-2025: Moved the <code>xsd</code>, <code>msv</code>, and <code>prism</code> reserved
 						prefixes to the deprecated features section. See <a
 							href="https://github.com/w3c/epub-specs/issues/2739">issue 2739</a>.</li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6047,21 +6047,17 @@ No Entry</pre>
 					<section id="sec-css-prefixed">
 						<h4>Prefixed properties</h4>
 
-						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to
-							world languages were not yet mature. To ensure backwards compatibility for content authored
-							using these prefixes, they have been retained in this specification. Unless otherwise noted,
-							prefixed properties and values behave exactly as their unprefixed equivalents as described
-							in the appropriate CSS specification. The prefixed properties are documented in <a
-								href="#css-prefixes"></a>.</p>
+						<p>Earlier version of EPUB included <a href="#css-prefixes">prefixed CSS properties</a>, as many
+							CSS features related to world languages were not yet mature. To ensure backwards
+							compatibility for content authored using these prefixes, they have been retained in this
+							specification as [=obsolete but conforming=] features. Unless otherwise noted in their last
+							maintained definitions, prefixed properties and values behave exactly as their unprefixed
+							equivalents as described in the appropriate CSS specification.</p>
 
 						<div class="caution">
 							<p>The Working Group recommends switching to the unprefixed versions as soon as CSS support
 								allows as these prefixed properties are not expected to be maintained in the next major
 								version of EPUB.</p>
-
-							<p>This specification retains the widely used prefixed properties from
-								[[epubcontentdocs-301]] but removes support for the less-used ones. It is strongly
-								advised to use CSS-native solutions for the removed properties whenever available.</p>
 						</div>
 					</section>
 				</section>
@@ -9588,6 +9584,48 @@ html.my-document-playing * {
 								including these features has limited value.</p>
 						</div>
 					</dd>
+
+					<dt id="css-prefixes">Prefixed CSS properties</dt>
+					<dd>
+						<ul>
+							<li id="sec-css-prefixed-writing-modes-text-orientation">
+								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-orientation"
+										><code>-epub-text-orientation</code></a> [[epub-33]]</li>
+							<li id="sec-css-prefixed-writing-modes-writing-mode">
+								<a data-cite="epub-33#sec-css-prefixed-writing-modes-writing-mode"
+										><code>-epub-writing-mode</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-writing-modes-text-combine">
+								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
+										><code>-epub-text-combine-horizontal</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-hyphens">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-hyphens"><code>-epub-hyphens</code></a>
+								[[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-line-break">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-line-break"
+										><code>-epub-line-break</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-align-last">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-align-last"
+										><code>-epub-text-align-last</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-word-break">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-word-break"
+										><code>-epub-word-break</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-text-transform"><code>text-transform</code> value <a
+									data-cite="epub-33#sec-css-prefixed-text-text-transform"
+										><code>-epub-fullwidth</code></a> [[epub-33]]</li>
+							<li id="sec-css-prefixed-text-epub-text-emphasis-color">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-color"
+										><code>-epub-text-emphasis-color</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-emphasis-position">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-position"
+										><code>-epub-text-emphasis-position</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-emphasis-style">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-style"
+										><code>-epub-text-emphasis-style</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-underline-position">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-underline-position"
+										><code>-epub-text-underline-position</code></a> [[epub-33]] </li>
+						</ul>
+					</dd>
 				</dl>
 
 				<div class="note">
@@ -10450,391 +10488,6 @@ html.my-document-playing * {
 			<div data-include="vocab/itemref-properties.html" data-include-replace="true"></div>
 
 			<div data-include="vocab/overlays.html" data-include-replace="true"></div>
-		</section>
-		<section id="css-prefixes" class="appendix">
-			<h2>Prefixed CSS properties</h2>
-
-			<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
-
-			<p class="note">The prefix definitions are no longer being synchronized with their CSS counterparts. In some
-				cases, the unprefixed versions of these properties now support additional values. [=Reading systems=]
-				might not support the new syntax with the prefixed properties, so it is advised to use the unprefixed
-				versions for newer features.</p>
-
-			<section id="sec-css-prefixed-writing-modes">
-				<h5>CSS writing modes</h5>
-
-				<p>This section describes the <code>-epub-</code> prefixed properties for [[css-writing-modes-3]].</p>
-
-				<section id="sec-css-prefixed-writing-modes-text-orientation" data-tests="#css-epub-text-orientation">
-					<h6>The <code>-epub-text-orientation</code> property</h6>
-
-					<p>This property is a prefixed version of the <a
-							data-cite="css-writing-modes-3#propdef-text-orientation"><code>text-orientation</code>
-							property</a> [[css-writing-modes-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-text-orientation</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> mixed | upright | sideways | sideways-right </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>For compatibility with existing content, the <code>-epub-text-orientation</code> property also
-						supports the deprecated <code>vertical-right</code>, <code>rotate-right</code>, and
-							<code>rotate-normal</code> keywords. The following table specifies the effect these have
-						when specified.</p>
-
-					<table class="data">
-						<thead>
-							<tr>
-								<th>Deprecated value</th>
-								<th>Value to be used</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code>vertical-right</code>
-								</td>
-								<td>
-									<code>mixed</code>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<code>rotate-right</code>
-								</td>
-								<td>
-									<code>sideways</code>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<code>rotate-normal</code>
-								</td>
-								<td>
-									<code>sideways</code>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-writing-modes-writing-mode" data-tests="#css-epub-writing-mode">
-					<h6>The <code>-epub-writing-mode</code> property</h6>
-
-					<p>This property is a prefixed version of the <a
-							data-cite="css-writing-modes-3#propdef-writing-mode"><code>writing-mode</code> property</a>
-						[[css-writing-modes-3]], with the same syntax and behavior.</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-writing-mode</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> horizontal-tb | vertical-rl | vertical-lr </td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-writing-modes-text-combine" data-tests="#css-epub-text-combine-horizontal">
-					<h6>The <code>-epub-text-combine-horizontal</code> property</h6>
-
-					<p>This property is a prefixed version of the <a
-							data-cite="css-writing-modes-3#text-combine-upright"><code>text-combine-upright</code>
-							property</a> [[css-writing-modes-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-text-combine-horizontal</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> none | all </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>For compatibility with existing content, the <code>-epub-text-combine-horizontal</code> property
-						also supports a number of deprecated keywords. The following table specifies the effect these
-						have when specified.</p>
-
-					<table class="data">
-						<thead>
-							<tr>
-								<th>Prefixed version</th>
-								<th>CSS equivalent</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>
-									<code>-epub-text-combine-horizontal: none</code>
-								</td>
-								<td>
-									<code>text-combine-upright: none</code>
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<code>-epub-text-combine-horizontal: all</code>
-								</td>
-								<td>
-									<code>text-combine-upright: all</code>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-			</section>
-
-			<section id="sec-css-prefixed-text">
-				<h5>CSS text level 3</h5>
-
-				<p>This section describes the <code>-epub-</code> prefixed properties (and one prefixed value) for
-					[[css-text-3]].</p>
-
-				<section id="sec-css-prefixed-text-epub-hyphens" data-tests="#css-epub-hyphens">
-					<h6>The <code>-epub-hyphens</code> property</h6>
-
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#hyphens-property"
-								><code>hyphens</code> property</a> [[css-text-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-hyphens</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> none | manual | auto | all </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>For compatibility with existing content, the <code>-epub-hyphens</code> property also supports
-						the deprecated <code>all</code> keyword. The value is no longer supported in CSS and there is no
-						equivalent to use in its place.</p>
-				</section>
-
-				<section id="sec-css-prefixed-text-epub-line-break" data-tests="#css-epub-line-break">
-					<h6>The <code>-epub-line-break</code> property</h6>
-
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#line-break-property"
-								><code>line-break</code> property</a> [[css-text-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-line-break</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> auto | loose | normal | strict </td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-text-epub-text-align-last" data-tests="#css-epub-text-align-last">
-					<h6>The <code>-epub-text-align-last</code> property</h6>
-
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#text-align-last-property"
-								><code>text-align-last</code> property</a> [[css-text-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-text-align-last</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> auto | start | end | left | right | center | justify </td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-text-epub-word-break" data-tests="#css-epub-word-break">
-					<h6>The <code>-epub-word-break</code> property</h6>
-
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#word-break-property"
-								><code>word-break</code> property</a> [[css-text-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-word-break</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> normal | keep-all | break-all </td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-text-text-transform" data-tests="#css-epub-text-transform">
-					<h6>The <code>text-transform</code> property</h6>
-
-					<p>This property is a prefixed value for the <a data-cite="css-text-3#text-transform-property"
-								><code>text-transform</code> property</a> [[css-text-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>text-transform</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> -epub-fullwidth </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>For compatibility with existing content, the <code>text-transform</code> property also supports
-						the deprecated <code>-epub-fullwidth</code> keyword. When specified, this has the same effect as
-							<code>text-transform: full-width</code>.</p>
-				</section>
-			</section>
-
-			<section id="sec-css-prefixed-text-decoration">
-				<h5>CSS text decoration level 3</h5>
-
-				<p>This section describes the <code>-epub-</code> prefixed properties for [[css-text-decor-3]].</p>
-
-				<section id="sec-css-prefixed-text-epub-text-emphasis-color" data-tests="#css-epub-text-emphasis">
-					<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
-
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-emphasis-color-property"><code>text-emphasis-color</code>
-							property</a> [[css-text-decor-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-text-emphasis-color</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> &lt;color&gt; </td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-text-epub-text-emphasis-position" data-tests="#css-epub-text-emphasis">
-					<h6>The <code>-epub-text-emphasis-position</code> property</h6>
-
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-emphasis-position-property"
-								><code>text-emphasis-position</code> property</a> [[css-text-decor-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-text-emphasis-position</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> [ over | under ] &amp;&amp; [ right | left ] </td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-text-epub-text-emphasis-style" data-tests="#css-epub-text-emphasis">
-					<h6>The <code>-epub-text-emphasis-style</code> property</h6>
-
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-emphasis-style-property"><code>text-emphasis-style</code>
-							property</a> [[css-text-decor-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-text-emphasis-style</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]
-									] | &lt;string&gt; </td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-css-prefixed-text-epub-text-underline-position"
-					data-tests="#css-epub-text-underline-position">
-					<h6>The <code>-epub-text-underline-position</code> property</h6>
-
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-underline-position-property"
-								><code>text-underline-position</code> property</a> [[css-text-decor-3]].</p>
-
-					<table class="tabledef">
-						<tbody>
-							<tr>
-								<th>Name: </th>
-								<td>
-									<code>-epub-text-underline-position</code>
-								</td>
-							</tr>
-							<tr class="value">
-								<th>Value:</th>
-								<td> auto | [ under || [ left | right ] ] | alphabetic </td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>For compatibility with existing content, the value <code>-epub-text-underline-position</code>
-						property also supports the deprecated <code>alphabetic</code> keyword. When specified, this has
-						the same effect as <code>text-underline-position: auto</code>.</p>
-				</section>
-			</section>
 		</section>
 		<section id="app-viewport-meta" class="appendix">
 			<h2>The <code>viewport meta</code> tag</h2>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
@@ -3075,10 +3075,6 @@
 							resources in the set. The spine defines the default reading order.</p>
 					</li>
 					<li>
-						<p><a href="#sec-collection-elem">Collections</a> — a method of encapsulating and identifying
-							subcomponents within the EPUB publication.</p>
-					</li>
-					<li>
 						<p>[=Manifest fallback chains=] — a mechanism that defines an ordered list of top-level
 							resources as content equivalents. A reading system can then choose between the resources
 							based on which it is capable of rendering.</p>
@@ -5446,107 +5442,6 @@ No Entry</pre>
        linear="no"/&gt;
 &lt;/spine&gt;
 </pre>
-					</aside>
-				</section>
-			</section>
-
-			<section id="sec-pkg-collections">
-				<h3>Collections</h3>
-
-				<section id="sec-collection-elem" data-epubcheck="true"
-					data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L791,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L796">
-					<h4>The <code>collection</code> element</h4>
-
-					<p>The <code>collection</code> element defines a related group of resources.</p>
-
-					<dl id="elemdef-collection" class="elemdef">
-						<dt>Element Name:</dt>
-						<dd>
-							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
-									<code>collection</code>
-								</dfn>
-							</p>
-						</dd>
-
-						<dt>Usage:</dt>
-						<dd>
-							<p>OPTIONAL sixth element of <code>package</code>. Repeatable.</p>
-						</dd>
-
-						<dt>Attributes:</dt>
-						<dd>
-							<ul class="nomark">
-								<li>
-									<p>
-										<a href="#attrdef-dir">
-											<code>dir</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-id">
-											<code>id</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-collection-role">
-											<code>role</code>
-										</a>
-										<code>[required]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-xml-lang">
-											<code>xml:lang</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</li>
-							</ul>
-						</dd>
-
-						<dt>Content Model:</dt>
-						<dd>
-							<p>In this order: <code>metadata</code>
-								<code>[0 or 1]</code>, ( [^collection^] <code>[1 or more]</code> or ( [^collection^]
-									<code>[0 or more]</code>, <code>link</code>
-								<code>[1 or more]</code> ))</p>
-						</dd>
-					</dl>
-
-					<p>The <code>collection</code> element allows resources to be assembled into logical groups for a
-						variety of potential uses: enabling reassembly into a meaningful unit of content split across
-						multiple [=EPUB content documents=] (e.g., an index split across multiple documents),
-						identifying resources for specialized purposes (e.g., preview content), or collecting together
-						resources that present additional information about the [=EPUB publication=].</p>
-
-					<p id="attrdef-collection-role">The role of each <code>collection</code> element MUST be identified
-						in its <code>role</code> attribute, whose value MUST be one or more NMTOKENs [[xmlschema-2]]
-						and/or [=absolute-URL-with-fragment strings=] [[url]].</p>
-
-					<p>The requirements for authoring specialized collections are defined by their respective
-						specifications.</p>
-
-					<div class="note">
-						<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3 Working
-							Group maintained both a <a href="https://idpf.org/epub/registries/roles/">registry of role
-								extensions</a> and a list of <a href="https://idpf.org/epub/extensions/roles/">custom
-								extension roles</a>. This Working Group no longer maintains these registries.</p>
-					</div>
-
-					<aside class="example" title="A multi-document index">
-						<pre>&lt;collection role="index"&gt;
-   &lt;link href="subjectIndex01.xhtml"/&gt;
-   &lt;link href="subjectIndex02.xhtml"/&gt;
-   &lt;link href="subjectIndex03.xhtml"/&gt;
-&lt;/collection&gt;</pre>
 					</aside>
 				</section>
 			</section>
@@ -9540,7 +9435,22 @@ html.my-document-playing * {
 						</ul>
 					</dd>
 
-					<dt>Package document</dt>
+					<dt>Collections</dt>
+					<dd id="sec-pkg-collections">
+						<ul>
+							<li id="sec-collection-elem">
+								<a data-cite="epub-33#sec-collection-elem"><code>collection</code> element</a>
+								[[epub-33]] </li>
+						</ul>
+						<div class="caution">
+							<p>When EPUB 3 was maintained by IDPF, a number of specifications were developed that relied
+								on the <code>collection</code> element. Due to a lack of adoption and implementation in
+								reading systems, these specifications are no longer maintained and use of the element is
+								no longer advised.</p>
+						</div>
+					</dd>
+
+					<dt>Legacy features</dt>
 					<dd>
 						<ul>
 							<li id="sec-opf2-meta">
@@ -9608,7 +9518,6 @@ html.my-document-playing * {
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-underline-position"
 										><code>-epub-text-underline-position</code></a> [[epub-33]] </li>
 						</ul>
-
 						<div class="caution">
 							<p>EPUB 3 originally included these prefixed properties as many CSS features related to
 								world languages were not yet mature. They are only retained now to ensure backwards

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3148,7 +3148,8 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and [^package^].</p>
+					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a href="#sec-opf-dcmes"
+							>Dublin Core elements</a>, [^meta^], and [^package^].</p>
 				</section>
 
 
@@ -3322,8 +3323,8 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a href="#sec-opf-dcmes">Dublin Core elements</a>, [^meta^], and
-						[^package^].</p>
+					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a href="#sec-opf-dcmes"
+							>Dublin Core elements</a>, [^meta^], and [^package^].</p>
 				</section>
 			</section>
 
@@ -3429,7 +3430,9 @@
 								</p>
 							</li>
 							<li>
-								<p> <a href="#sec-collection-elem"><code>collection</code></a> <code>[0 or more]</code>
+								<p>
+									<a href="#sec-collection-elem"><code>collection</code></a>
+									<code>[0 or more]</code>
 									<span class="legacy">([=obsolete but conforming=])</span>
 								</p>
 							</li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5980,8 +5980,8 @@ No Entry</pre>
 								</ul>
 							</li>
 							<li>
-								<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a
-										href="#sec-css-prefixed"></a>.</p>
+								<p id="confreq-css-prefixed">MAY include the [=obsolete but conforming=] <a
+										href="#css-prefixes">prefixed properties</a>.</p>
 							</li>
 							<li>
 								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16&#160;[[unicode]], with
@@ -6042,23 +6042,6 @@ No Entry</pre>
 							the user experience is not negatively impacted (i.e., the users' style choices not being
 							universally applied). Although some reading systems will override inline styles, such
 							behavior is not guaranteed.</p>
-					</section>
-
-					<section id="sec-css-prefixed">
-						<h4>Prefixed properties</h4>
-
-						<p>Earlier version of EPUB included <a href="#css-prefixes">prefixed CSS properties</a>, as many
-							CSS features related to world languages were not yet mature. To ensure backwards
-							compatibility for content authored using these prefixes, they have been retained in this
-							specification as [=obsolete but conforming=] features. Unless otherwise noted in their last
-							maintained definitions, prefixed properties and values behave exactly as their unprefixed
-							equivalents as described in the appropriate CSS specification.</p>
-
-						<div class="caution">
-							<p>The Working Group recommends switching to the unprefixed versions as soon as CSS support
-								allows as these prefixed properties are not expected to be maintained in the next major
-								version of EPUB.</p>
-						</div>
 					</section>
 				</section>
 
@@ -9625,6 +9608,14 @@ html.my-document-playing * {
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-underline-position"
 										><code>-epub-text-underline-position</code></a> [[epub-33]] </li>
 						</ul>
+
+						<div class="caution">
+							<p>EPUB 3 originally included these prefixed properties as many CSS features related to
+								world languages were not yet mature. They are only retained now to ensure backwards
+								compatibility for content authored using these prefixes. The Working Group recommends
+								switching to the unprefixed versions as soon as CSS support allows as these prefixed
+								properties are not expected to be maintained in the next major version of EPUB.</p>
+						</div>
 					</dd>
 				</dl>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
@@ -350,7 +350,9 @@
 							unless it also has the media type of an EPUB content document.</p>
 					</dd>
 
-					<dt><dfn class="export">EPUB conformance checker</dfn></dt>
+					<dt>
+						<dfn class="export">EPUB conformance checker</dfn>
+					</dt>
 					<dd>
 						<p>An application that verifies the requirements of this specification against [=EPUB
 							publications=] and reports on their conformance.</p>
@@ -1081,9 +1083,15 @@
 						<tr>
 							<td id="cmt-sfnt">
 								<ol class="cmt">
-									<li><code>font/ttf</code></li>
-									<li><code>application/font-sfnt</code></li>
-									<li><code>application/x-font-ttf</code></li>
+									<li>
+										<code>font/ttf</code>
+									</li>
+									<li>
+										<code>application/font-sfnt</code>
+									</li>
+									<li>
+										<code>application/x-font-ttf</code>
+									</li>
 								</ol>
 							</td>
 							<td>[[truetype]] </td>
@@ -1092,9 +1100,15 @@
 						<tr>
 							<td id="cmt-otf">
 								<ol class="cmt">
-									<li><code>font/otf</code></li>
-									<li><code>application/font-sfnt</code></li>
-									<li><code>application/vnd.ms-opentype</code></li>
+									<li>
+										<code>font/otf</code>
+									</li>
+									<li>
+										<code>application/font-sfnt</code>
+									</li>
+									<li>
+										<code>application/vnd.ms-opentype</code>
+									</li>
 								</ol>
 							</td>
 							<td>[[opentype]]</td>
@@ -1103,8 +1117,12 @@
 						<tr>
 							<td id="cmt-woff">
 								<ol class="cmt">
-									<li><code>font/woff</code></li>
-									<li><code>application/font-woff</code></li>
+									<li>
+										<code>font/woff</code>
+									</li>
+									<li>
+										<code>application/font-woff</code>
+									</li>
 								</ol>
 							</td>
 							<td> [[woff]] </td>
@@ -1123,9 +1141,15 @@
 						<tr>
 							<td id="cmt-js">
 								<ol class="cmt">
-									<li><code>application/javascript</code></li>
-									<li><code>application/ecmascript</code></li>
-									<li><code>text/javascript</code></li>
+									<li>
+										<code>application/javascript</code>
+									</li>
+									<li>
+										<code>application/ecmascript</code>
+									</li>
+									<li>
+										<code>text/javascript</code>
+									</li>
 								</ol>
 							</td>
 							<td> [[rfc4329]] </td>
@@ -1136,7 +1160,7 @@
 								<code>application/x-dtbncx+xml</code>
 							</td>
 							<td> [[opf-201]] </td>
-							<td>The <a href="#sec-pkg-legacy-intro">legacy</a> NCX</td>
+							<td>The <a href="#obsolete-but-conforming">obsolete but conforming</a> NCX</td>
 						</tr>
 						<tr>
 							<td id="cmt-smil">
@@ -1645,8 +1669,8 @@
 					archive: the "physical container". The rules for ZIP physical containers build upon the ZIP
 					technologies used by [[odf]].</p>
 
-				<p>OCF also defines a standard method for <a href="#sec-font-obfuscation">obfuscating embedded fonts</a>
-					for those EPUB publications that require this functionality.</p>
+				<p>OCF also retains an <a href="#sec-font-obfuscation">obsolete but conforming algorithm for obfuscating
+						embedded fonts</a> but this functionality is no longer advised.</p>
 			</section>
 
 			<section id="sec-container-abstract">
@@ -1685,7 +1709,8 @@
 						</dt>
 						<dd>
 							<p>Contains information about the encryption of [=publication resources=]. This file is
-								mandatory when using <a href="#sec-font-obfuscation">font obfuscation</a>.</p>
+								mandatory when using the <a href="#sec-font-obfuscation">obsolete but conforming font
+									obfuscation feature</a>.</p>
 						</dd>
 
 						<dt>
@@ -2175,8 +2200,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>container</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>container</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2219,8 +2245,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>rootfiles</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>rootfiles</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2254,8 +2281,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>rootfile</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>rootfile</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2318,8 +2346,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>links</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>links</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2437,14 +2466,17 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>encryption</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>encryption</code>
+											</dfn>
 										</p>
 									</dd>
 
 									<dt>Namespace:</dt>
 									<dd>
-										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
+										<p>
+											<code>urn:oasis:names:tc:opendocument:xmlns:container</code>
+										</p>
 									</dd>
 
 									<dt>Usage:</dt>
@@ -2505,8 +2537,8 @@
 									of embedded fonts referenced by an [=EPUB publication=] to make them more difficult
 									to extract for unrestricted use. Although obfuscation is not encryption, reading
 									systems use the <code>encryption.xml</code> file in conjunction with the <a
-										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
-									deobfuscate.</p>
+										href="#sec-font-obfuscation">obsolete but conforming font obfuscation
+										algorithm</a> to identify fonts to deobfuscate.</p>
 
 								<p id="encryption-restrictions">The following files MUST NOT be encrypted:</p>
 
@@ -2611,8 +2643,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>Compression</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>Compression</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2743,14 +2776,17 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>signatures</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>signatures</code>
+											</dfn>
 										</p>
 									</dd>
 
 									<dt>Namespace:</dt>
 									<dd>
-										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
+										<p>
+											<code>urn:oasis:names:tc:opendocument:xmlns:container</code>
+										</p>
 									</dd>
 
 									<dt>Usage:</dt>
@@ -3001,201 +3037,6 @@
 						<p>Refer to <a href="#app-media-type"></a> for further information about the
 								<code>application/epub+zip</code> media type.</p>
 					</div>
-				</section>
-			</section>
-
-			<section id="sec-font-obfuscation">
-				<h3>Font obfuscation</h3>
-
-				<div class="caution">
-					<p>Better methods of protecting fonts exist. Both [[woff]] and [[woff2]] fonts, for example, allow
-						the embedding of licensing information and provide some protection through font table
-						compression. The use of remotely hosted fonts also allows for font subsetting. It is advised to
-						use font obfuscation as defined in this section only when no other options are available. See
-						also the <a href="#fobfus-limitations">limitations of obfuscation</a>.</p>
-				</div>
-
-				<section id="fobfus-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>Since an [=OCF ZIP container=] is fundamentally a ZIP file, commonly available ZIP tools can be
-						used to extract any unencrypted content stream from the package. Moreover, the nature of ZIP
-						files means that their contents might appear like any other native container on some systems
-						(e.g., a folder).</p>
-
-					<p>While this simplicity of ZIP files is quite useful, it also poses a problem as it makes it easy
-						for others to extract and re-use the fonts in an [=EPUB publication=] if they are not encrypted.
-						More critically, many commercial fonts allow embedding, but embedding a font implies making it
-						an integral part of the EPUB publication, not just providing the original font file along with
-						the content.</p>
-
-					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
-						in the [=OCF ZIP container=] is insufficient to signify that the font cannot be reused in other
-						contexts. This uncertainty can undermine the otherwise useful font embedding capability of EPUB
-						publications.</p>
-
-					<p>To discourage reuse of their fonts, some font vendors might only allow their use in EPUB
-						publications if the fonts are bound in some way to the EPUB publication. That is, if the font
-						file cannot be installed directly for use on an operating system with the built-in tools of that
-						computing device, and it cannot be directly used by other EPUB publications.</p>
-
-					<p>It is beyond the scope of this specification to provide a digital rights management or
-						enforcement system for fonts. This section instead defines a method of obfuscation that will
-						require additional work on the part of the final OCF recipient to gain general access to any
-						obfuscated fonts.</p>
-				</section>
-
-				<section id="fobfus-limitations" class="informative">
-					<h4>Limitations</h4>
-
-					<p>This specification does not claim that obfuscation constitutes encryption, nor does it guarantee
-						that the resource will be secure from copyright infringement. The hope is only that this
-						algorithm will meet the requirements of vendors who require some assurance that their fonts
-						cannot be extracted simply by unzipping the [=OCF ZIP container=] and copying the resource.</p>
-
-					<p>Obfuscation, like any protection scheme, cannot fully protect fonts from being accessed in their
-						deobfuscated state. The mechanism only provides an obstacle for those who are unaware of the
-						license details. It will not prevent a determined user from gaining full access to the font
-						through such alternative means as:</p>
-
-					<ul>
-						<li>applying the deobfuscation algorithm to extract the raw font file;</li>
-						<li>accessing the deobfuscated font through a [=reading system=] that has to deobfuscate it to
-							render the content (e.g., by accessing the resources through a browser-based reading
-							system); or</li>
-						<li>accessing the deobfuscated font through authoring tools that provide the visual rendering of
-							the content.</li>
-					</ul>
-
-					<p>As a result, whether this method of obfuscation satisfies the requirements of individual font
-						licenses remains a question for the licensor and licensee. Licensees are responsible for
-						ensuring the use of obfuscation meets their font licensing requirements.</p>
-
-					<p>It is also worth noting that obfuscation can lead to interoperability issues in reading systems
-						as they do not have to deobfuscate fonts. As a result, the visual presentation of a publication
-						could differ from reading system to reading system.</p>
-
-					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a
-						general-purpose mechanism for obfuscating any resource in the EPUB container.</p>
-				</section>
-
-				<section id="obfus-keygen">
-					<h4>Obfuscation key</h4>
-
-					<p id="obfus-key-unique-id" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">The key
-						used in the obfuscation algorithm MUST be derived the from the [=unique identifier=].</p>
-
-					<p>All whitespace characters, as defined in <a data-cite="xml#sec-common-syn">section 2.3 of the XML
-							1.0 specification</a> [[xml]], MUST be removed from this identifier — specifically, the
-						Unicode code points <code>U+0020</code>, <code>U+0009</code>, <code>U+000D</code> and
-							<code>U+000A</code>.</p>
-
-					<p>A SHA-1 digest of the UTF-8 representation of the resulting string, as specified by the Secure
-						Hash Standard [[fips-180-4]], MUST then be generated. This digest can then be used as the key
-						for the algorithm.</p>
-				</section>
-
-				<section id="obfus-algorithm">
-					<h4>Obfuscation algorithm</h4>
-
-					<p>The algorithm employed to obfuscate fonts consists of modifying the first 1040 bytes (~1KB) of
-						the font file. (In the unlikely event that the font file is less than 1040 bytes, this process
-						will modify the entire file.)</p>
-
-					<p>To obfuscate the original data, store, as the first byte of the embedded font, the result of
-						performing a logical exclusive or (XOR) on the first byte of the raw font file and the first
-						byte of the <a href="#obfus-keygen">obfuscation key</a>.</p>
-
-					<p>Repeat this process with the next byte of source and key and continue for all bytes in the key.
-						At this point, the process continues starting with the first byte of the key and 21st byte of
-						the source. Once 1040 bytes are encoded in this way (or the end of the source is reached),
-						directly copy any remaining data in the source to the destination.</p>
-
-					<p>Fonts MUST be obfuscated before compressing and adding them to the [=OCF ZIP container=]. Note
-						that as obfuscation is not encryption, this requirement is not a violation of the one in <a
-							href="#sec-container-metainf-encryption.xml"></a> to compress fonts before encrypting
-						them.</p>
-
-					<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
-
-					<ol class="algorithm">
-						<li>set <var>ocf</var> to OCF ZIP container file</li>
-						<li>set <var>source</var> to font file</li>
-						<li>set <var>destination</var> to obfuscated font file</li>
-						<li>set <var>keyData</var> to key for file</li>
-						<li>set <var>outer</var> to 0</li>
-						<li>
-							<span>while <var>outer</var> &lt; 52 and not (<var>source</var> at EOF)</span>
-							<ol>
-								<li>set <var>inner</var> to 0</li>
-								<li>
-									<span>while <var>inner</var> &lt; 20 and not (<var>source</var> at EOF)</span>
-									<ol>
-										<li>read 1 byte from <var>source</var> (Assumes read advances file
-											position)</li>
-										<li>set <var>sourceByte</var> to result of read</li>
-										<li>set <var>keyByte</var> to byte <var>inner</var> of <var>keyData</var></li>
-										<li>set <var>obfuscatedByte</var> to (<var>sourceByte</var> XOR
-												<var>keyByte</var>)</li>
-										<li>write <var>obfuscatedByte</var> to <var>destination</var></li>
-										<li>increment <var>inner</var></li>
-									</ol>
-									<span>end while</span>
-								</li>
-								<li>increment <var>outer</var></li>
-							</ol>
-							<span>end while</span>
-						</li>
-						<li>
-							<span>if not (<var>source</var> at EOF) then</span>
-							<ol>
-								<li>read <var>source</var> to EOF</li>
-								<li>write result of read to <var>destination</var></li>
-							</ol>
-							<span>end if</span>
-						</li>
-						<li>Deflate <var>destination</var></li>
-						<li>store <var>destination</var> as <var>source</var> in <var>ocf</var></li>
-					</ol>
-				</section>
-
-				<section id="obfus-specifying" data-epubcheck="true"
-					data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L358,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L363,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L369">
-					<h4>Specifying obfuscated fonts</h4>
-
-					<p>Although not technically encrypted data, all obfuscated fonts MUST have an entry in the <code
-							class="filename">encryption.xml</code> file accompanying the [=EPUB publication=] (see <a
-							href="#sec-container-metainf-encryption.xml"></a>).</p>
-
-					<p>An <code>EncryptedData</code> element MUST be specified for each obfuscated font. Each
-							<code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
-						element whose <code>Algorithm</code> attribute has the value
-							<code>http://www.idpf.org/2008/embedding</code>. The presence of this attribute signals the
-						use of the algorithm described in this specification.</p>
-
-					<p>The <code>CipherReference</code> child of the <code>CipherData</code> element MUST list the path
-						to the obfuscated font. As the obfuscation algorithm is restricted to fonts, the
-							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a
-							href="#cmt-grp-font">Font core media type resource</a>.</p>
-
-					<aside class="example" title="An entry for an obfuscated font">
-						<pre>&lt;encryption
-    xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
-    xmlns:enc="http://www.w3.org/2001/04/xmlenc#"&gt;
-   &lt;enc:EncryptedData&gt;
-      &lt;enc:EncryptionMethod
-          Algorithm="http://www.idpf.org/2008/embedding"/&gt;
-      &lt;enc:CipherData&gt;
-         &lt;enc:CipherReference
-             URI="EPUB/Fonts/BKANT.TTF"/&gt;
-      &lt;/enc:CipherData&gt;
-   &lt;/enc:EncryptedData&gt;
-&lt;/encryption&gt;</pre>
-					</aside>
-
-					<p>To prevent trivial copying of the embedded font to other EPUB publications, the <a
-							href="#obfus-keygen">obfuscation key</a> MUST NOT be stored in the
-							<code>encryption.xml</code> file.</p>
 				</section>
 			</section>
 		</section>
@@ -3497,7 +3338,9 @@
 					<dt>Element Name:</dt>
 					<dd>
 						<p>
-							<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>package</code></dfn>
+							<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+								<code>package</code>
+							</dfn>
 						</p>
 					</dd>
 
@@ -3582,7 +3425,7 @@
 										<code>guide</code>
 									</a>
 									<code>[0 or 1]</code>
-									<a href="#sec-pkg-legacy-intro" class="legacy">(legacy)</a>
+									<a href="#obsolete-but-conforming" class="legacy">(obsolete but conforming)</a>
 								</p>
 							</li>
 							<li>
@@ -3625,8 +3468,9 @@
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>metadata</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>metadata</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -3672,7 +3516,7 @@
 									<p>
 										<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
 										<code>[0 or more]</code>
-										<a href="#sec-pkg-legacy-intro" class="legacy">(legacy)</a>
+										<a href="#obsolete-but-conforming" class="legacy">(obsolete but conforming)</a>
 									</p>
 								</li>
 								<li>
@@ -3779,8 +3623,9 @@
 								<dt>Element Name:</dt>
 								<dd>
 									<p>
-										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-												><code>dc:identifier</code></dfn>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+											<code>dc:identifier</code>
+										</dfn>
 									</p>
 								</dd>
 
@@ -3886,8 +3731,9 @@
 								<dt>Element Name:</dt>
 								<dd>
 									<p>
-										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-												><code>dc:title</code></dfn>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+											<code>dc:title</code>
+										</dfn>
 									</p>
 								</dd>
 
@@ -4006,8 +3852,9 @@
 								<dt>Element Name:</dt>
 								<dd>
 									<p>
-										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-												><code>dc:language</code></dfn>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+											<code>dc:language</code>
+										</dfn>
 									</p>
 								</dd>
 
@@ -4102,16 +3949,28 @@
 								<dd>
 									<ul class="nomark">
 										<li>
-											<p><a href="#attrdef-dir"><code>dir</code></a>
-												<code>[optional]</code></p>
+											<p>
+												<a href="#attrdef-dir">
+													<code>dir</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code></p>
+											<p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-												<code>[optional]</code></p>
+											<p>
+												<a href="#attrdef-xml-lang">
+													<code>xml:lang</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -4346,7 +4205,9 @@
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>meta</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>meta</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -4545,7 +4406,9 @@
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>link</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>link</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -4818,8 +4681,9 @@ XHTML:
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>manifest</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>manifest</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -4876,7 +4740,9 @@ XHTML:
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>item</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>item</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -4993,11 +4859,21 @@ XHTML:
 							element matches their respective definitions:</p>
 
 						<ul>
-							<li><a href="#sec-mathml">mathml</a></li>
-							<li><a href="#sec-remote-resources">remote-resources</a></li>
-							<li><a href="#sec-scripted">scripted</a></li>
-							<li><a href="#sec-svg">svg</a></li>
-							<li><a href="#sec-switch">switch</a></li>
+							<li>
+								<a href="#sec-mathml">mathml</a>
+							</li>
+							<li>
+								<a href="#sec-remote-resources">remote-resources</a>
+							</li>
+							<li>
+								<a href="#sec-scripted">scripted</a>
+							</li>
+							<li>
+								<a href="#sec-svg">svg</a>
+							</li>
+							<li>
+								<a href="#sec-switch">switch</a>
+							</li>
 						</ul>
 
 						<aside class="example" id="example-item-properties-scripted-mathml"
@@ -5329,8 +5205,9 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>spine</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>spine</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -5364,7 +5241,7 @@ No Entry</pre>
 											<code>toc</code>
 										</a>
 										<code>[optional]</code>
-										<a href="#sec-pkg-legacy-intro" class="legacy">(legacy)</a>
+										<a href="#obsolete-but-conforming" class="legacy">(obsolete but conforming)</a>
 									</p>
 								</li>
 							</ul>
@@ -5414,7 +5291,7 @@ No Entry</pre>
 						mechanisms to override the default direction (e.g., buttons or settings that allow the
 						application of alternate style sheets).</p>
 
-					<p>The <a href="#sec-pkg-legacy-intro">legacy</a>
+					<p>The <a href="#obsolete-but-conforming">obsolete but conforming</a>
 						<code>toc</code> attribute takes an <a data-cite="xml#idref">IDREF</a> [[xml]] that identifies
 						the manifest item that represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
 				</section>
@@ -5430,8 +5307,9 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>itemref</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>itemref</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -5581,8 +5459,9 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>collection</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>collection</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -5665,94 +5544,6 @@ No Entry</pre>
    &lt;link href="subjectIndex03.xhtml"/&gt;
 &lt;/collection&gt;</pre>
 					</aside>
-				</section>
-			</section>
-
-			<section id="sec-pkg-legacy">
-				<h3>Legacy features</h3>
-
-				<section id="sec-pkg-legacy-intro">
-					<h4>Introduction</h4>
-
-					<p>The package document <strong>legacy</strong> features are retained from EPUB 2 only to allow the
-						authoring of content that can function, to some degree, in [=reading systems=] that only support
-						EPUB 2 publications.</p>
-
-					<p>These features were added primarily to address the overlap period as EPUB 3 reading systems were
-						developed, as there was still a high probability at that time that users would be opening EPUB 3
-						publications on EPUB 2 reading systems.</p>
-
-					<p>As reading systems that only handle EPUB 2 publications are now rare, consider how likely it is
-						that EPUB publications will still be opened on these types of older devices before making the
-						effort to add these legacy features.</p>
-				</section>
-
-				<section id="pkg-legacy-support">
-					<h4>Support</h4>
-
-					<p>[=EPUB publications=] MAY include the legacy features defined in this section for compatibility
-						purposes with EPUB 2 reading systems.</p>
-
-					<p>EPUB 3 reading systems will not use these features when presenting publications to users.</p>
-
-					<div class="note">
-						<p>The Working Group advises that [=EPUB conformance checkers=] not issue alerts about the
-							presence of legacy features in [=EPUB publications=], as their inclusion is valid for
-							backwards compatibility. Only issue alerts if a legacy feature does not conform to its
-							definition or otherwise breaks a usage requirement.</p>
-					</div>
-				</section>
-
-				<section id="sec-opf2-meta">
-					<h4>The <code>meta</code> element</h4>
-
-					<p>The <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
-							element</a> [[opf-201]] provides a means of including generic metadata for EPUB 2 [=reading
-						systems=].</p>
-
-					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-								><code>meta</code> element definition</a> in&#160;[[opf-201]] for more information.</p>
-
-					<div class="note">
-						<p>The EPUB 3 [^meta^] element, which uses different attributes and requires text content,
-							provides metadata capabilities for EPUB 3 reading systems.</p>
-
-						<p>The [[opf-201]] <code>meta</code> element also allows a cover image to be specified for EPUB
-							2 reading systems. In EPUB 3, the cover image has to be identified using the <a
-								href="#sec-cover-image"><code>cover-image</code> property</a> on the manifest [^item^]
-							for the image.</p>
-					</div>
-				</section>
-
-				<section id="sec-opf2-guide">
-					<h4>The <code>guide</code> element</h4>
-
-					<p>The <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
-							element</a>&#160;[[opf-201]] provides machine-processable navigation to key structures in
-						EPUB 2 [=reading systems=].</p>
-
-					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-								><code>guide</code> element definition</a> in&#160;[[opf-201]] for more information.</p>
-
-					<div class="note">
-						<p>The <a href="#sec-nav-landmarks">landmarks nav</a> in the [=EPUB navigation document=]
-							provides this functionality in EPUB 3 reading systems.</p>
-					</div>
-				</section>
-
-				<section id="sec-opf2-ncx">
-					<h4>NCX</h4>
-
-					<p>The <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a> [[opf-201]]
-						provides a table of contents for EPUB 2 [=reading systems=].</p>
-
-					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
-							definition</a> in&#160;[[opf-201]] for more information.</p>
-
-					<div class="note">
-						<p>The <a href="#sec-nav">EPUB navigation document</a> replaces the NCX for EPUB 3 reading
-							systems.</p>
-					</div>
 				</section>
 			</section>
 		</section>
@@ -5895,8 +5686,12 @@ No Entry</pre>
 							URL does not include either of the following strings in its [=domain=] [[url]]:</p>
 
 						<ul>
-							<li><code>w3.org</code></li>
-							<li><code>idpf.org</code></li>
+							<li>
+								<code>w3.org</code>
+							</li>
+							<li>
+								<code>idpf.org</code>
+							</li>
 						</ul>
 
 						<p>When using custom attributes, the content MUST remain consumable by a user without any
@@ -7502,7 +7297,8 @@ No Entry</pre>
 
 						<dl>
 							<dt id="page-spread-center">
-								<code>rendition:page-spread-center</code></dt>
+								<code>rendition:page-spread-center</code>
+							</dt>
 							<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a
 									href="#spread-none"><code>spread-none</code> property</a> for centering a spine
 								item.</dd>
@@ -8008,8 +7804,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>smil</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>smil</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8081,8 +7878,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>head</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>head</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8154,8 +7952,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>body</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>body</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8231,8 +8030,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>seq</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>seq</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8309,8 +8109,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>par</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>par</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8376,8 +8177,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>text</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>text</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8442,8 +8244,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>audio</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>audio</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -9411,26 +9214,34 @@ html.my-document-playing * {
 			<p>Some of the key standards for authoring accessible web content include:</p>
 
 			<dl>
-				<dt><a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a>
+				</dt>
 				<dd>
 					<p>The requirements and practices for creating accessible web content are documented in the
 						[[wcag2]].</p>
 				</dd>
 
-				<dt><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a>
+				</dt>
 				<dd>
 					<p>The [[wai-aria]] specification defines roles, states, and properties for making dynamic content
 						that does not use native HTML elements and attributes accessible. It also provides a set of
 						landmarks for navigating web pages.</p>
 				</dd>
 
-				<dt><a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a>
+				</dt>
 				<dd>
 					<p>The [[dpub-aria]] specification is an extension of [[wai-aria]] that provides additional roles
 						specific to identifying common publishing structures.</p>
 				</dd>
 
-				<dt><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
+				</dt>
 				<dd>
 					<p>[[html-aria]] specifies how the roles, states, and properties defined ARIA and DPUB-ARIA can be
 						used in HTML documents.</p>
@@ -9714,6 +9525,65 @@ html.my-document-playing * {
 				</div>
 			</section>
 
+			<section id="obsolete-but-conforming">
+				<h3>Obsolete but conforming features</h3>
+
+				<p>An <dfn>obsolete but conforming</dfn> feature is one that is not deprecated but that is also either
+					not designed for use in EPUB 3 [=reading systems=] or that would ideally be deprecated except that
+					it would invalidate a significant base of existing [=EPUB publications=].</p>
+
+				<p>[=EPUB publications=] MAY include the obsolete but conforming features defined in this section.</p>
+
+				<div class="note">
+					<p>The Working Group advises that [=EPUB conformance checkers=] not issue alerts about the presence
+						of obsolete but conforming features in [=EPUB publications=]. Only issue alerts if a feature
+						does not conform to its definition or otherwise breaks a usage requirement.</p>
+				</div>
+
+				<dl>
+					<dt>OCF</dt>
+					<dd>
+						<p id="sec-font-obfuscation">This specification previously defined an <a
+								data-cite="epub-33#sec-font-obfuscation">algorithm for obfuscating fonts</a>
+							[[epub-33]]. Due to its weak encryption capabilities and its reliance on SHA-1, which will
+							be deprecated as of 2030, the use of font obfuscation is no longer advised even though it
+							remains conforming. Better methods of protecting fonts exist. Both [[woff]] and [[woff2]]
+							fonts, for example, allow the embedding of licensing information and provide some protection
+							through font table compression. The use of remotely hosted fonts also allows for font
+							subsetting.</p>
+					</dd>
+
+					<dt>Package document</dt>
+					<dd>
+						<p>The following features are retained only to provide a measure of backwards compatibility with
+							reading systems that only support EPUB 2 publications. They are ignored by EPUB 3 reading
+							systems. As reading systems that only handle EPUB 2 publications are now rare, including
+							these features has limited value.</p>
+						<ul>
+							<li id="sec-opf2-meta">
+								<p>OPF 2 <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
+											><code>meta</code> element</a> [[opf-201]] &#8212; EPUB 3 reading systems
+									only recognize the EPUB 3 [^meta^] element for metadata. For cover images, EPUB 3
+									reading systems only recognize the the <a href="#sec-cover-image"
+											><code>cover-image</code> property</a>.</p>
+							</li>
+
+							<li id="sec-opf2-guide">
+								<p>OPF 2 <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
+											><code>guide</code> element</a>&#160;[[opf-201]] &#8212; EPUB 3 reading
+									systems only recognize the <a href="#sec-nav-landmarks">landmarks nav</a>.</p>
+							</li>
+
+							<li id="sec-opf2-ncx">
+								<p>OPF 2 <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1"
+										>NCX</a> [[opf-201]] &#8212; EPUB 3 reading systems only recognize the <a
+										href="#sec-nav">EPUB navigation document</a>.</p>
+							</li>
+						</ul>
+					</dd>
+				</dl>
+			</section>
+
 			<section id="deprecated">
 				<h3>Deprecated features</h3>
 
@@ -9971,8 +9841,9 @@ html.my-document-playing * {
 							<dt>Attribute Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr"
-											><code>epub:type</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+										<code>epub:type</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -10005,8 +9876,9 @@ html.my-document-playing * {
 							<dt>Attribute Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr"
-											><code>epub-type</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+										<code>epub-type</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -10419,8 +10291,9 @@ html.my-document-playing * {
 					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for example, will often reject new prefixes until they update their [=EPUB
-							conformance checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
+						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for
+							example, will often reject new prefixes until they update their [=EPUB conformance
+							checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
 					</div>
 
 					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"
@@ -10590,7 +10463,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-orientation</code></td>
+								<td>
+									<code>-epub-text-orientation</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10613,16 +10488,28 @@ html.my-document-playing * {
 						</thead>
 						<tbody>
 							<tr>
-								<td><code>vertical-right</code></td>
-								<td><code>mixed</code></td>
+								<td>
+									<code>vertical-right</code>
+								</td>
+								<td>
+									<code>mixed</code>
+								</td>
 							</tr>
 							<tr>
-								<td><code>rotate-right</code></td>
-								<td><code>sideways</code></td>
+								<td>
+									<code>rotate-right</code>
+								</td>
+								<td>
+									<code>sideways</code>
+								</td>
 							</tr>
 							<tr>
-								<td><code>rotate-normal</code></td>
-								<td><code>sideways</code></td>
+								<td>
+									<code>rotate-normal</code>
+								</td>
+								<td>
+									<code>sideways</code>
+								</td>
 							</tr>
 						</tbody>
 					</table>
@@ -10639,7 +10526,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-writing-mode</code></td>
+								<td>
+									<code>-epub-writing-mode</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10660,7 +10549,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-combine-horizontal</code></td>
+								<td>
+									<code>-epub-text-combine-horizontal</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10682,12 +10573,20 @@ html.my-document-playing * {
 						</thead>
 						<tbody>
 							<tr>
-								<td><code>-epub-text-combine-horizontal: none</code></td>
-								<td><code>text-combine-upright: none</code></td>
+								<td>
+									<code>-epub-text-combine-horizontal: none</code>
+								</td>
+								<td>
+									<code>text-combine-upright: none</code>
+								</td>
 							</tr>
 							<tr>
-								<td><code>-epub-text-combine-horizontal: all</code></td>
-								<td><code>text-combine-upright: all</code></td>
+								<td>
+									<code>-epub-text-combine-horizontal: all</code>
+								</td>
+								<td>
+									<code>text-combine-upright: all</code>
+								</td>
 							</tr>
 						</tbody>
 					</table>
@@ -10710,7 +10609,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-hyphens</code></td>
+								<td>
+									<code>-epub-hyphens</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10734,7 +10635,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-line-break</code></td>
+								<td>
+									<code>-epub-line-break</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10754,7 +10657,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-align-last</code></td>
+								<td>
+									<code>-epub-text-align-last</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10774,7 +10679,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-word-break</code></td>
+								<td>
+									<code>-epub-word-break</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10794,7 +10701,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>text-transform</code></td>
+								<td>
+									<code>text-transform</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10825,7 +10734,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-emphasis-color</code></td>
+								<td>
+									<code>-epub-text-emphasis-color</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10846,7 +10757,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-emphasis-position</code></td>
+								<td>
+									<code>-epub-text-emphasis-position</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10867,7 +10780,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-emphasis-style</code></td>
+								<td>
+									<code>-epub-text-emphasis-style</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10890,7 +10805,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-underline-position</code></td>
+								<td>
+									<code>-epub-text-underline-position</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -11215,7 +11132,9 @@ html.my-document-playing * {
 						href="#sec-publication-resources"></a> for more information about these categories.)</p>
 
 				<dl>
-					<dt><code>meta/data.xml</code></dt>
+					<dt>
+						<code>meta/data.xml</code>
+					</dt>
 					<dd>
 						<p>The resource is a metadata record, stored in the [=EPUB container=]. It is linked via a
 							[^link^] element in the package document metadata. It is therefore a [=linked resource=] on
@@ -11223,14 +11142,18 @@ html.my-document-playing * {
 							part on any other planes. </p>
 					</dd>
 
-					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
+					<dt>
+						<code>https://www.example.org/meta/data2.xml</code>
+					</dt>
 					<dd>
 						<p>The resource is a metadata record, stored remotely. It is linked via a [^link^] element in
 							the package document metadata. It is therefore a linked resource on the manifest plane,
 							(i.e., it is not listed in the manifest). It is not part on any other planes.</p>
 					</dd>
 
-					<dt><code>page.xhtml</code></dt>
+					<dt>
+						<code>page.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is an XHTML document. It is listed in the [=EPUB spine | spine=]. It is a
 							[=publication resource=] on the manifest plane, a [=container resource=], an [=EPUB content
@@ -11238,14 +11161,18 @@ html.my-document-playing * {
 							is necessary.</p>
 					</dd>
 
-					<dt><code>nav.xhtml</code></dt>
+					<dt>
+						<code>nav.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is the [=EPUB navigation document=]. It is not listed in the spine. It is a
 							publication resource on the manifest plane, a container resource, and is not present on
 							either the spine plane or the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>style.css</code></dt>
+					<dt>
+						<code>style.css</code>
+					</dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[html]]
 								<a data-cite="html#the-link-element"><code>link</code></a> element. It is a publication
@@ -11253,7 +11180,9 @@ html.my-document-playing * {
 							is a [=core media type resource=] on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>font/font-file.otf</code></dt>
+					<dt>
+						<code>font/font-file.otf</code>
+					</dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
 							CSS file. It is a publication resource on the manifest plane, is a container resource, is
@@ -11261,7 +11190,9 @@ html.my-document-playing * {
 							fallback is necessary.</p>
 					</dd>
 
-					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
+					<dt>
+						<code>https://www.example.org/fonts/font-file2.otf</code>
+					</dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
 							CSS file. It is a publication resource on the manifest plane, is a [=remote resource=], is
@@ -11269,7 +11200,9 @@ html.my-document-playing * {
 							fallback is necessary.</p>
 					</dd>
 
-					<dt><code>font/font-file.cff</code></dt>
+					<dt>
+						<code>font/font-file.cff</code>
+					</dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
 							referenced from a CSS file. Its media type is not listed as a <a
@@ -11278,7 +11211,9 @@ html.my-document-playing * {
 							resource=] on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>speech/cmn.pls</code></dt>
+					<dt>
+						<code>speech/cmn.pls</code>
+					</dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
 							from an [[html]] <a data-cite="html#the-link-element"><code>link</code></a> element. It is a
@@ -11286,7 +11221,9 @@ html.my-document-playing * {
 							plane, and is an exempt resource on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>image/image_1.png</code></dt>
+					<dt>
+						<code>image/image_1.png</code>
+					</dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[html]] [^img^] element. It is a publication resource on the manifest plane, a container
@@ -11294,7 +11231,9 @@ html.my-document-playing * {
 							content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>image/image_2.png</code></dt>
+					<dt>
+						<code>image/image_2.png</code>
+					</dt>
 					<dd>
 						<p>The resource is a PNG image file. It is referenced via an [[html]] [^a^] element. Because it
 							is referenced from a hyperlink, it <em>has to</em> be listed in the spine. It is a
@@ -11304,7 +11243,9 @@ html.my-document-playing * {
 								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
-					<dt><code>image_desc.xhtml</code></dt>
+					<dt>
+						<code>image_desc.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not
 							explicitly listed in the spine (but it "replaces" the existing spine item when needed). It
@@ -11313,7 +11254,9 @@ html.my-document-playing * {
 							document, it is not present on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>image/image_3.heic</code></dt>
+					<dt>
+						<code>image/image_3.heic</code>
+					</dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
 							referenced from an [[html]] [^source^] element. Its media type is not listed as a <a
@@ -11323,7 +11266,9 @@ html.my-document-playing * {
 							provided via the sibling [[html]] [^img^] element in an [[html]] [^picture^] element.</p>
 					</dd>
 
-					<dt><code>image/image_3.png</code></dt>
+					<dt>
+						<code>image/image_3.png</code>
+					</dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[html]] [^img^] element that is used as an intrinsic fallback of the [[html]] [^picture^]
@@ -11332,7 +11277,9 @@ html.my-document-playing * {
 							fallback is necessary.</p>
 					</dd>
 
-					<dt><code>widget.xhtml</code></dt>
+					<dt>
+						<code>widget.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
 							[[html]] [^iframe^] element. It is a publication resource on the manifest plane, a container
@@ -11341,7 +11288,9 @@ html.my-document-playing * {
 							necessary.</p>
 					</dd>
 
-					<dt><code>https://www.example.org/some_content</code></dt>
+					<dt>
+						<code>https://www.example.org/some_content</code>
+					</dt>
 					<dd>
 						<p>The resource is referenced via an [[html]] [^a^] element and is not stored in the EPUB
 							container. Reading systems will normally open this link via a separate browser instance. It

--- a/epub34/authoring/vocab/link.html
+++ b/epub34/authoring/vocab/link.html
@@ -34,7 +34,8 @@
 								<li>If an alternate link is included in the [=package document=] metadata, it
 									identifies an alternate representation of the package document in the format
 									specified in the <code>media-type</code> attribute.</li>
-								<li>If an alternate link is included in a [^collection^] element's
+								<li>If an alternate link is included in a 
+									<a href="#sec-collection-elem"><code>collection</code></a> element's
 									metadata, it identifies an alternate representation of the <code>collection</code>
 									in the format specified in the <code>media-type</code> attribute.</li>
 								<li>[=Reading systems=] do not have to generate hyperlinks for alternate links.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -750,9 +750,19 @@
 			<section id="sec-container-fobfus">
 				<h3>Font obfuscation</h3>
 
+				<div class="caution">
+					<p>NIST is advising that use of the SHA-1 algorithm [[fips-180-4]] be phased out by the end of 2030.
+						The Publishing Maintenance Working Group does not intend to support font obfuscation in EPUB
+						publications past that date due to its reliance on SHA-1 &#8212; the feature is now marked as
+						obsolete but conforming to not invalidate existing EPUB publications. Reading system developers
+						will have to consider continuing to support deobfuscation to fully support all EPUB publications
+						that have used the feature. As CSS provides font fallbacks, however, ending support will only
+						affect the appearance of some text content.</p>
+				</div>
+
 				<p id="confreq-ocf-fobfus" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">Reading systems
-					SHOULD support deobfuscation of fonts as defined in <a data-cite="epub-34#sec-font-obfuscation">Font
-						obfuscation</a> [[epub-34]].</p>
+					SHOULD support deobfuscation of fonts as defined in <a data-cite="epub-33#sec-font-obfuscation">Font
+						obfuscation</a> [[epub-33]].</p>
 
 				<p>To restore the original data, reading systems can simply reverse the process: the source file becomes
 					the obfuscated data, and the destination file contains the raw data.</p>
@@ -2158,9 +2168,9 @@
 						<summary>Explanation</summary>
 						<p>The path-relative-scheme-less-URL string definition has a number of restrictions that apply
 							to the reference whether it has a prefix or not.</p>
-						<p>For example, the reference is not allowed to begin with a [=URL-scheme string=] followed by a colon.
-							This restriction means that the following is not a valid <code>property</code> value as the
-							second colon could represent a scheme: <code>foo:bar:baz/qux</code>.</p>
+						<p>For example, the reference is not allowed to begin with a [=URL-scheme string=] followed by a
+							colon. This restriction means that the following is not a valid <code>property</code> value
+							as the second colon could represent a scheme: <code>foo:bar:baz/qux</code>.</p>
 						<p>There are also restrictions on what characters have to be percent encoded.</p>
 					</details>
 				</li>


### PR DESCRIPTION
We don't have to use this, but it's easier to see what we'd be getting into by mocking up what a new section would look like with the legacy features and font obfuscation.

(If this is okay, we'd still need to update the RS specification.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2814.html" title="Last updated on Oct 13, 2025, 12:25 AM UTC (763db48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2814/660f70d...763db48.html" title="Last updated on Oct 13, 2025, 12:25 AM UTC (763db48)">Diff</a>