### PR TITLE
Reference to test results was wrong or incorrectly labeled

### DIFF
--- a/epub33/reports/index.html
+++ b/epub33/reports/index.html
@@ -88,7 +88,7 @@
               Each <em>required</em> feature, whose behavior is specified by [[epub-rs-33]], must have at least two, mutually independent implementations.
             </p>
             <p>
-              See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a> document.
+              See the <a href="https://w3c.github.io/epub-tests/epub33/results">EPUB 3.3 Test Results</a> document.
             </p>
           </li>
         </ul>

--- a/epub34/reports/index.html
+++ b/epub34/reports/index.html
@@ -89,7 +89,7 @@
               Each <em>required</em> feature, whose behavior is specified by [[epub-rs-34]], must have at least two, mutually independent implementations.
             </p>
             <p>
-              See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a> document.
+              See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.4 Test Results</a> document.
             </p>
           </li>
         </ul>


### PR DESCRIPTION
The reference to the epub33 test results was wrong. Also, the structure of the historic data on the test repository was inconsistent with other repos. 

1. The test repository has been slightly rearranged (see https://github.com/w3c/epub-tests/commit/35f25c6b4e56aca3db044dec5832d5d682100ab6)
2. The reference to the results was updated (this PR)