### PR TITLE
Reorganization of appendixes

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11,7 +11,7 @@
 		<script src="../../common/js/add-caution-hd.js" class="remove"></script>
 		<script src="../../common/js/data-test-display.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
-		<script class="remove"> //<![CDATA[
+		<script class="remove">
             var respecConfig = {
                 group: "pm",
                 wgPublicList: "public-pm-wg",
@@ -70,7 +70,7 @@
 						]
 					}
 				] */
-            };//]]>
+            };
 		</script>
 		<style>
 			pre {
@@ -78,8 +78,7 @@
 			}
 			#app-unsupported dt {
 				margin-top: 2rem;
-				margin-bottom: 
-				1rem;
+				margin-bottom: 1rem;
 			}</style>
 	</head>
 	<body>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -9394,1205 +9394,6 @@ html.my-document-playing * {
 					privacy and security.</p>
 			</section>
 		</section>
-		<section id="app-obsolete" class="appendix">
-			<h2>Obsolete features</h2>
-
-			<section id="sec-obs-conform">
-				<h3>Obsolete but conforming features</h3>
-
-				<p>An <dfn id="obsolete-but-conforming">obsolete but conforming</dfn> feature is one that is not
-					deprecated but that is also either not designed for use in EPUB 3 [=reading systems=] or that would
-					ideally be [=deprecated=] except that it would invalidate a significant base of existing [=EPUB
-					publications=].</p>
-
-				<p>[=EPUB publications=] MAY include the obsolete but conforming features defined in this section. Their
-					usage MUST conform to their referenced definitions.</p>
-
-				<dl>
-					<dt>Open Container Format (OCF)</dt>
-					<dd>
-						<ul>
-							<li id="sec-font-obfuscation">
-								<p><a data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]]</p>
-								<div class="caution">
-									<p>NIST is advising that use of the SHA-1 algorithm [[fips-180-4]] be phased out by
-										the end of 2030. The Publishing Maintenance Working Group does not intend to
-										support font obfuscation in EPUB publications past that date due to its reliance
-										on SHA-1, although reading systems will have to continue to support
-										deobfuscation for existing EPUB publications.</p>
-									<p>Better methods of protecting fonts exist. Both [[woff]] and [[woff2]] fonts, for
-										example, allow the embedding of licensing information and provide some
-										protection through font table compression. The use of remotely hosted fonts also
-										allows for font subsetting.</p>
-								</div>
-							</li>
-						</ul>
-					</dd>
-
-					<dt id="sec-pkg-collections">Collections</dt>
-					<dd>
-						<ul>
-							<li id="sec-collection-elem">
-								<a data-cite="epub-33#sec-collection-elem"><code>collection</code> element</a>
-								[[epub-33]] </li>
-						</ul>
-						<div class="caution">
-							<p>When EPUB 3 was maintained by IDPF, a number of specifications were developed that relied
-								on the <code>collection</code> element. Due to a lack of adoption and implementation in
-								reading systems, these specifications are no longer maintained and use of the element is
-								no longer advised.</p>
-						</div>
-					</dd>
-
-					<dt id="sec-pkg-legacy">Legacy features</dt>
-					<dd>
-						<ul>
-							<li id="sec-opf2-meta">
-								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2">OPF 2
-											<code>meta</code> element</a> [[opf-201]]</p>
-							</li>
-
-							<li id="sec-opf2-guide">
-								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">OPF 2
-											<code>guide</code> element</a>&#160;[[opf-201]]</p>
-							</li>
-
-							<li id="sec-opf2-ncx">
-								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">OPF 2
-										NCX</a> [[opf-201]]</p>
-							</li>
-						</ul>
-						<div class="note">
-							<p>EPUB 3 reading systems ignore these features. They are replaced by the [^meta^] element,
-								the <a href="#sec-nav-landmarks">landmarks nav</a>, and the <a href="#sec-nav-toc">toc
-									nav</a>, respectively.</p>
-							<p>The features are retained only to provide a measure of backwards compatibility with
-								reading systems that only support EPUB 2. As such reading systems are now rare,
-								including these features has limited value.</p>
-						</div>
-					</dd>
-
-					<dt id="css-prefixes">Prefixed CSS properties</dt>
-					<dd>
-						<ul>
-							<li id="sec-css-prefixed-writing-modes-text-orientation">
-								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-orientation"
-										><code>-epub-text-orientation</code></a> [[epub-33]]</li>
-							<li id="sec-css-prefixed-writing-modes-writing-mode">
-								<a data-cite="epub-33#sec-css-prefixed-writing-modes-writing-mode"
-										><code>-epub-writing-mode</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-writing-modes-text-combine">
-								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
-										><code>-epub-text-combine-horizontal</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-text-epub-hyphens">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-hyphens"><code>-epub-hyphens</code></a>
-								[[epub-33]] </li>
-							<li id="sec-css-prefixed-text-epub-line-break">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-line-break"
-										><code>-epub-line-break</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-text-epub-text-align-last">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-align-last"
-										><code>-epub-text-align-last</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-text-epub-word-break">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-word-break"
-										><code>-epub-word-break</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-text-text-transform"><code>text-transform</code> value <a
-									data-cite="epub-33#sec-css-prefixed-text-text-transform"
-										><code>-epub-fullwidth</code></a> [[epub-33]]</li>
-							<li id="sec-css-prefixed-text-epub-text-emphasis-color">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-color"
-										><code>-epub-text-emphasis-color</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-text-epub-text-emphasis-position">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-position"
-										><code>-epub-text-emphasis-position</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-text-epub-text-emphasis-style">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-style"
-										><code>-epub-text-emphasis-style</code></a> [[epub-33]] </li>
-							<li id="sec-css-prefixed-text-epub-text-underline-position">
-								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-underline-position"
-										><code>-epub-text-underline-position</code></a> [[epub-33]] </li>
-						</ul>
-						<div class="caution">
-							<p>EPUB 3 originally included these prefixed properties as many CSS features related to
-								world languages were not yet mature. They are only retained now to ensure backwards
-								compatibility for content authored using these prefixes. The Working Group recommends
-								switching to the unprefixed versions as soon as CSS support allows as these prefixed
-								properties are not expected to be maintained in the next major version of EPUB.</p>
-						</div>
-					</dd>
-				</dl>
-
-				<div class="note">
-					<p>The Working Group advises that [=EPUB conformance checkers=] not issue alerts about the presence
-						of obsolete but conforming features in [=EPUB publications=]. Only issue alerts if a feature
-						does not conform to its definition or otherwise breaks a usage requirement.</p>
-				</div>
-			</section>
-
-			<section id="sec-obs-deprecated">
-				<h3>Deprecated features</h3>
-
-				<p>A <dfn id="deprecated">deprecated</dfn> feature is one that has limited or no support in [=reading
-					systems=] and/or usage in [=EPUB publications=].</p>
-
-				<p>The following deprecated features SHOULD NOT be used. When used, their usage MUST conform to their
-					referenced definitions.</p>
-
-				<dl>
-					<dt>Package document</dt>
-					<dd>
-						<ul>
-							<li>
-								<p id="sec-opf-bindings"><a
-										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
-											><code>bindings</code> element</a> [[epubpublications-301]]</p>
-							</li>
-
-							<li>
-								<p id="sec-defining-collection-types"><a
-										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
-										>new collection types</a> [[epubpackages-32]]</p>
-							</li>
-						</ul>
-					</dd>
-
-					<dt>XHTML content documents</dt>
-					<dd>
-						<ul>
-							<li id="sec-xhtml-content-switch">
-								<p><a
-										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
-											><code>switch</code> element</a> [[epubcontentdocs-301]]</p>
-							</li>
-
-							<li>
-								<p id="sec-xhtml-epub-trigger"><a
-										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
-											><code>epub:trigger</code> element</a> [[epubcontentdocs-301]]</p>
-							</li>
-						</ul>
-					</dd>
-
-					<dt>Fixed layouts</dt>
-					<dd>
-						<ul>
-							<li>
-								<p><a href="https://idpf.org/epub/301/spec/epub-publications.html#fxl-property-spread"
-											><code>rendition:spread</code> property with the value
-										<code>portrait</code></a> [[epubpublications-301]] &#8212; use the value
-										"<code>both</code>" instead.</p>
-							</li>
-							<li>
-								<p id="spread-portrait"><a
-										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
-											><code>spread-portrait</code> property</a> [[epubpublications-301]] &#8212;
-									use the property "<code>rendition:spread-both</code>" instead.</p>
-							</li>
-							<li>
-								<p id="viewport" data-epubcheck="true"
-									data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L187"
-										><a
-										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
-											><code>rendition:viewport</code> property</a> [[epubpublications-301]]</p>
-							</li>
-						</ul>
-					</dd>
-
-					<dt>Vocabulary association mechanisms</dt>
-					<dd>
-						<ul>
-							<li>
-								<p><a data-cite="epub-33#tbl-pkg-reserved-prefixes"><code>xsd</code> reserved prefix</a>
-									[[epub-33]] for package metadata.</p>
-							</li>
-							<li>
-								<p><a data-cite="epub-33#tbl-reserved-prefixes"><code>msv</code> and <code>prism</code>
-										reserved prefixes</a> [[epub-33]] for structural semantics.</p>
-							</li>
-						</ul>
-					</dd>
-
-					<dt>Meta properties vocabulary</dt>
-					<dd>
-						<ul>
-							<li>
-								<p id="sec-meta-auth"><a
-										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
-											><code>meta-auth</code> property</a> [[!epubpublications-30]]</p>
-							</li>
-						</ul>
-					</dd>
-
-					<dt>Link relationships vocabulary</dt>
-					<dd>
-						<ul>
-							<li>
-								<p id="sec-marc21xml-record"><a
-										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"
-											><code>marc21xml-record</code> property</a> [[!epubpublications-30]] &#8212;
-									It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
-										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-										"<code>application/marcxml+xml</code>".</p>
-							</li>
-
-							<li>
-								<p id="sec-mods-record"><a
-										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"
-											><code>mods-record</code> property</a> [[!epubpublications-30]] &#8212; It
-									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
-										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-										"<code>application/mods+xml</code>".</p>
-							</li>
-
-							<li>
-								<p id="sec-onix-record"><a
-										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"
-											><code>onix-record</code> property</a> [[!epubpublications-30]] &#8212; It
-									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
-										href="#attrdef-properties">properties attribute</a> value <a href="#onix"
-											><code>onix</code></a>.</p>
-							</li>
-
-							<li>
-								<p id="sec-xml-signature"><a
-										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"
-											><code>xml-signature</code> property</a> [[!epubpublications-30]]</p>
-							</li>
-
-							<li>
-								<p id="sec-xmp-record"><a
-										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"
-											><code>xmp-record</code> property</a> [[!epubpublications-30]]</p>
-							</li>
-						</ul>
-					</dd>
-
-					<dt>Prefixed CSS properties</dt>
-					<dd>
-						<ul>
-							<li>
-								<p><a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
-											><code>-epub-text-combine</code></a> [[epub-33]]</p>
-							</li>
-						</ul>
-					</dd>
-				</dl>
-
-				<div class="note">
-					<p>The Working Group recommends that [=EPUB conformance checkers=] alert about the presence of
-						deprecated features when encountered in EPUB publications.</p>
-				</div>
-			</section>
-		</section>
-		<section id="app-identifiers-allowed" class="appendix" data-epubcheck="true"
-			data-tests="https://w3c.github.io/epub-structural-tests/#B-external-identifiers_external-identifiers.feature_L13,https://w3c.github.io/epub-structural-tests/#B-external-identifiers_external-identifiers.feature_L23">
-			<h2>Allowed external identifiers</h2>
-
-			<p>The following table lists the <a aria-label="public identifiers" data-cite="xml#dt-pubid">public </a> and
-					<a data-cite="xml#dt-sysid">system identifiers</a> [[xml]] allowed in <a data-cite="xml#dt-doctype"
-					>document type declarations</a>. [[xml]]</p>
-
-			<p>These external identifiers MAY be used only in [=publication resources=] with the listed media types
-				[[rfc2046]] specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a
-					href="#sec-xml-constraints"></a> for more information.)</p>
-
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th>Media Type(s)</th>
-						<th>Public Identifier</th>
-						<th>System Identifier</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<ul class="flat">
-								<li>
-									<code>application/mathml+xml</code>
-								</li>
-								<li>
-									<code>application/mathml-presentation+xml</code>
-								</li>
-								<li>
-									<code>application/mathml-content+xml</code>
-								</li>
-							</ul>
-						</td>
-						<td>
-							<code>-//W3C//DTD MathML 3.0//EN</code>
-						</td>
-						<td>
-							<code>http://www.w3.org/Math/DTD/mathml3/mathml3.dtd</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<code>application/x-dtbncx+xml</code>
-						</td>
-						<td>
-							<code>-//NISO//DTD ncx 2005-1//EN</code>
-						</td>
-						<td>
-							<code>http://www.daisy.org/z3986/2005/ncx-2005-1.dtd</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<code>image/svg+xml</code>
-						</td>
-						<td>
-							<code>-//W3C//DTD SVG 1.1//EN</code>
-						</td>
-						<td>
-							<code>http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd</code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-		</section>
-		<section id="app-structural-semantics" class="appendix">
-			<h2>Expressing structural semantics</h2>
-
-			<section id="sec-structural-semantics-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
-					The [^/epub:type^] attribute is used to express domain-specific semantics in [=EPUB content
-					documents=] and [=media overlay documents=], with the structural information it carries
-					complementing the underlying vocabulary.</p>
-
-				<p>The applied semantics refine the meaning of their containing elements without changing their nature
-					for assistive technologies, as happens when using the similar [^/role^] attribute&#160;[[html]]. The
-					attribute does not enhance the accessibility of the content, in other words; it only provides hints
-					about the purpose.</p>
-
-				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
-					It also allows [=reading systems=] to learn more about the structure and content of a document
-					(e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and escapability</a> in media
-					overlays).</p>
-
-				<p>This specification defines a method for adding structural semantics using <em>the attribute
-					axis</em>: instead of adding new elements, the <code>epub:type</code> attribute can be appended to
-					existing elements to add the desired semantics.</p>
-			</section>
-
-			<section id="sec-epub-type-attribute">
-				<h3>The <code>type</code> attribute</h3>
-
-				<dl>
-					<dt>XHTML serialization</dt>
-					<dd>
-						<dl class="elemdef" id="attrdef-epub-type-xhtml">
-							<dt>Attribute Name:</dt>
-							<dd>
-								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
-										<code>epub:type</code>
-									</dfn>
-								</p>
-							</dd>
-
-							<dt>Namespace:</dt>
-							<dd>
-								<p>
-									<code>http://www.idpf.org/2007/ops</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a
-										href="#confreq-svg-structural-semantics">SVG</a>, and <a
-										href="#sec-overlays-def">media overlays</a>.</p>
-							</dd>
-
-							<dt>Value:</dt>
-							<dd>
-								<p>A <a data-cite="xml#NT-S">whitespace-separated</a> [[xml]] list of <a
-										href="#sec-property-datatype">property</a> values, with restrictions as defined
-									in <a href="#sec-vocab-assoc"></a>.</p>
-							</dd>
-						</dl>
-					</dd>
-
-					<dt>HTML serialization</dt>
-					<dd>
-						<dl class="elemdef" id="attrdef-epub-type-html">
-							<dt>Attribute Name:</dt>
-							<dd>
-								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
-										<code>epub-type</code>
-									</dfn>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">HTML</a>.</p>
-							</dd>
-
-							<dt>Value:</dt>
-							<dd>
-								<p>A [=ASCII whitespace|whitespace-separated=] [[infra]] list of values that SHOULD be
-									taken from the EPUB 3 Structural Semantics Vocabulary [[epub-ssv-11]].</p>
-							</dd>
-						</dl>
-					</dd>
-				</dl>
-
-				<div class="ednote">
-					<p>Support for an HTML serialization of the <code>epub:type</code> attribute depends on the addition
-						of support for the <a href="#sec-xhtml">HTML syntax</a> in the EPUB 3.4 revision. It is <b><i>at
-								risk</i></b>, depending on authors' and implementers' feedback.</p>
-
-					<p>The proposed <code>epub-type</code> will provide similar functionality for HTML content documents
-						but with some restrictions (namely, no extensibility through the <code>epub:prefix</code>
-						attribute). The attribute should be read as a replacement for <code>epub:type</code> where this
-						specification and the Reading Systems specification [[epub-rs-34]] refer to that attribute for
-						XHTML content documents. These references will be updated once it is clearer that support will
-						definitely be added in this revision.</p>
-
-					<p>The <code>epub:type</code> attribute will remain the sole means of including semantics in XML
-						grammars in EPUB (i.e., XHTML content documents, SVG content documents, and media overlay
-						documents).</p>
-
-					<p>To provide feedback on this change, please open issues in the <a
-							href="https://github.com/w3c/epub-specs/issues">GitHub tracker for the EPUB
-							specifications</a>.</p>
-				</div>
-
-
-				<div class="caution">
-					<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
-						attribute&#160;[[html]], the attributes serve different purposes. The values of the
-							<code>epub:type</code> attribute do not enhance access through assistive technologies like
-						screen readers as they do not map to the accessibility <abbr
-							title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
-						means that adding <code>epub:type</code> values to semantically neutral elements like [[html]]
-						[^div^] and [^span^] does not make them any more accessible to assistive technologies. Only ARIA
-						roles influence how assistive technologies understand such elements.</p>
-
-					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
-						[=reading system=] enhancements. Reading systems can use <code>epub:type</code> values to
-						provide accessibility enhancements like built-in read aloud or media overlays functionality
-						where interaction with assistive technologies is not essential.</p>
-
-					<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
-						Module</a>&#160;[[?dpub-aria]] for more information about accessible publishing roles.</p>
-				</div>
-
-				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
-					is one or more whitespace-separated terms stemming from external vocabularies associated with the
-					document instance.</p>
-
-				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The prefix URL for
-					referencing its properties is <code>http://idpf.org/epub/vocab/structure/#</code>.</p>
-
-				<p>Unprefixed terms that are not part of this vocabulary MAY be used but the preferred method for adding
-					custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
-						href="#sec-vocab-assoc"></a> for more information.</p>
-
-				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
-					<pre>&lt;html
-    …
-    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-   …
-   &lt;body&gt;
-      …
-      &lt;section epub:type="preamble"&gt;
-         …
-      &lt;/section&gt;
-      …
-   &lt;/body&gt;
-&lt;/html&gt;</pre>
-				</aside>
-
-				<aside class="example" id="ex.epubtype.gloss" title="Identifying a glossary">
-					<pre>&lt;html
-    …
-    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-   …
-   &lt;body&gt;
-      …
-      &lt;dl epub:type="glossary"&gt;
-         …
-      &lt;/dl&gt;
-      …
-   &lt;/body&gt;
-&lt;/html&gt;</pre>
-				</aside>
-
-				<aside class="example" id="ex.epubtype.pg" title="Adding page break semantics">
-					<pre>&lt;html
-    …
-    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-   …
-   &lt;body&gt;
-      …
-      &lt;p&gt;
-         …
-         &lt;span
-            epub:type="pagebreak"
-            id="p234"
-            role="doc-pagebreak"
-            aria-label="234"/&gt;
-         …
-      &lt;/p&gt;
-      …
-   &lt;/body&gt;
-&lt;/html&gt;</pre>
-				</aside>
-			</section>
-		</section>
-		<section id="app-vocabs" class="appendix">
-			<h2>Vocabularies</h2>
-
-			<p>This appendix defines a general set of mechanisms by which attributes in this specification can reference
-				terms from vocabularies. It also defines EPUB-specific vocabularies for use with the attributes.</p>
-
-			<section id="sec-vocab-assoc">
-				<h3>Vocabulary association mechanisms</h3>
-
-				<section id="sec-vocab-assoc-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
-						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
-							<code>epub:type</code> attribute uses this data type in [=EPUB content documents=] and
-						[=media overlay documents=] to add <a href="#app-structural-semantics">structural semantics</a>,
-						for example, while the <code>property</code> and <code>rel</code> attributes use the data type
-						to define properties and relationships in the [=package document=].</p>
-
-					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] — it represents a URL [[url]] in
-						compact form. The expression consists of a prefix and a reference, where the prefix — whether
-						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
-						vocabulary. When a [=reading system=] converts the prefix to its URL representation and combines
-						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
-						that contains human- and/or machine-readable information about the term.</p>
-
-					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
-						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
-						referenced from the default vocabularies do not include a prefix as the mapping reading systems
-						use to map to a URL is predefined.</p>
-
-					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
-						terms and properties, it is only necessary to declare a <a href="#sec-prefix-attr">prefix</a>.
-						In another authoring convenience, this specification also <a
-							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
-						publishing vocabularies (i.e., their declaration is not required).</p>
-
-					<p>The following sections provide additional details on the <var>property</var> data type and
-						vocabulary association mechanism.</p>
-				</section>
-
-				<section id="sec-property-datatype">
-					<h4>The <var>property</var> data type</h4>
-
-					<p>The <var>property</var> data type is a compact means of expressing a URL [[url]] and consists of
-						an OPTIONAL prefix separated from a reference by a colon.</p>
-
-					<table class="productionset">
-						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
-							<code>xsd:</code>.</caption>
-						<tbody>
-							<tr>
-								<td id="property.ebnf.property">
-									<a href="#property.ebnf.property">property</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-										href="#property.ebnf.reference">reference</a>; </td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.prefix">
-									<a href="#property.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.reference">
-									<a href="#property.ebnf.reference">reference</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? [=path-relative-scheme-less-URL string=] [[url]] ? ;</td>
-								<td>/*&#160;as defined in [[url]]&#160;*/<br /></td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
-						[[rdfa-core]]. A <var>property</var> represents a subset of CURIEs.</p>
-
-					<p>There are two key differences from CURIEs, however:</p>
-
-					<ul>
-						<li>
-							<p>an empty <var>reference</var> does not represent a valid <var>property</var> value even
-								though it is valid to the definition above (i.e., a <var>property</var> value that only
-								consists of a prefix and colon is invalid).</p>
-						</li>
-						<li>
-							<p>an empty string does not represent a valid <var>property</var> even though it is valid to
-								the definition above.</p>
-						</li>
-					</ul>
-
-					<aside class="example" title="Expanding a metadata property value">
-						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
-							and the reference <code>modified</code>.</p>
-
-						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
-
-						<p>After <a data-cite="epub-rs-34#sec-property-values">processing</a> [[epub-rs-34]], this
-							property would expand to the following URL:</p>
-
-						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
-						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
-					</aside>
-
-					<p>When a prefix is omitted from a <var>property</var> value, the specified term is taken from the
-							<a href="#sec-default-vocab">default vocabulary</a> for that attribute.</p>
-
-					<aside class="example" title="Expanding a manifest property value">
-						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
-							manifest [^item^] element:</p>
-
-						<pre>&lt;item … properties="mathml"/&gt;</pre>
-
-						<p>This property expands to:</p>
-
-						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-
-						<p>when the prefix URL for the vocabulary is concatenated with the reference.</p>
-					</aside>
-				</section>
-
-				<section id="sec-default-vocab">
-					<h5>Default vocabularies</h5>
-
-					<p>A default vocabulary is one whose terms and properties MUST NOT have a <a href="#sec-prefix-attr"
-							>prefix</a> when a <a href="#sec-property-datatype"><var>property</var> value</a> is
-						expected.</p>
-
-					<p>A prefix MUST NOT be assigned to the URLs associated with these vocabularies using the <a
-							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-
-					<div class="note">
-						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
-									><var>property</var> data type</a> for more information about its default
-							vocabulary.</p>
-					</div>
-				</section>
-
-				<section id="sec-prefix-attr" data-epubcheck="true"
-					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L671,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L694,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L17,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L22,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L28,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L34">
-					<h4>The <code>prefix</code> attribute</h4>
-
-					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
-							href="#sec-property-datatype"><var>property</var> values</a>.</p>
-
-					<p>The value of the <code>prefix</code> attribute is a whitespace-separated list of one or more
-						prefix-to-URL mappings of the form:</p>
-
-					<table class="productionset">
-						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
-							<code>xsd:</code>.</caption>
-						<tbody>
-							<tr>
-								<td id="prefix.ebnf.def">
-									<a href="#prefix.ebnf.def">prefixes</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.mapping">
-									<a href="#prefix.ebnf.mapping">mapping</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
-										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.prefix">
-									<a href="#prefix.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.space">
-									<a href="#prefix.ebnf.space">space</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>#x20 ;</td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.whitespace">
-									<a href="#prefix.ebnf.whitespace">whitespace</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>(#x20 | #x9 | #xD | #xA) ;</td>
-								<td>&#160;</td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, all prefixes used
-						in a document MUST be declared. The <code>prefix</code> attribute MUST be specified only on the
-							<a data-cite="xml#dt-root">root element</a> [[xml]] of the respective format.</p>
-
-					<p>The attribute is not namespaced when used in the [=package document=].</p>
-
-					<aside class="example" title="Declaring prefixes in the package document">
-						<p>In this example, the prefixes for the Friend of a Friend (<code>foaf</code>) and DBPedia
-								(<code>dbp</code>) vocabularies are declared in the <code>prefix</code> attribute.</p>
-
-						<pre>&lt;package
-    …
-    prefix="foaf: http://xmlns.com/foaf/spec/
-            dbp: http://dbpedia.org/ontology/"&gt;
-   …
-&lt;/package&gt;</pre>
-					</aside>
-
-					<p>The attribute MUST be declared in the namespace <code>http://www.idpf.org/2007/ops</code> when
-						used in [=EPUB content documents=] and [=media overlay documents=].</p>
-
-					<aside class="example" title="Declaring prefixes in an XHTML content document">
-						<p>In this example, a prefix is declared for the Z39.98 Structural Semantics Vocabulary.</p>
-
-						<pre>&lt;html …
-      xmlns:epub="http://www.idpf.org/2007/ops"
-      epub:prefix="z3998: https://www.daisy.org/z3998/2012/vocab/structure/"&gt;
-   …
-&lt;/html&gt;</pre>
-					</aside>
-
-					<div class="note">
-						<p>Although the <code>prefix</code> attribute is modeled on the identically named
-								<code>prefix</code> attribute in [[rdfa-core]], the attributes cannot be used
-							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB content
-							documents is the RDFa attribute.</p>
-
-						<p>It is common for both attributes to appear in EPUB content documents that also specify RDFa
-							expressions.</p>
-
-						<pre>&lt;html … prefix="…"
-        xmlns:epub="http://www.idpf.org/2007/ops"
-        epub:prefix="…"&gt;   …
-&lt;/html&gt;</pre>
-					</div>
-
-					<p>Note that for <a href="#sec-xhtml-svg-inclusion">SVG embedded by inclusion</a>, prefixes MUST be
-						declared on the [[html]] root [^html^] element.</p>
-
-					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
-						maps to a <a href="#sec-default-vocab">default vocabulary</a>.</p>
-
-					<p>The prefix '_' MUST NOT be declared as this specification reserves this prefix for future
-						compatibility with RDFa [[rdfa-core]] processing.</p>
-
-					<p>For future compatibility with alternative serializations of the package document, a prefix MUST
-						NOT be declared for the Dublin Core <em>/elements/1.1/</em> namespace [[dcterms]]. Only the
-						[[dcterms]] elements are <a href="#sec-pkg-metadata">allowed in the package document
-							metadata</a>.</p>
-				</section>
-
-				<section id="sec-reserved-prefixes">
-					<h4>Reserved prefixes</h4>
-
-					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for
-							example, will often reject new prefixes until they update their [=EPUB conformance
-							checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
-					</div>
-
-					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"
-								><var>property</var> value</a> without declaring them in a <a href="#sec-prefix-attr"
-								><code>prefix</code> attribute</a>.</p>
-
-
-					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
-							attribute</a>.</p>
-
-					<p>The reserved prefixes that can be used depends on the context:</p>
-
-					<dl class="conformance-list">
-						<dt>Package document</dt>
-						<dd id="sec-metadata-reserved-prefixes">
-							<p>The following prefixes MAY be used in [=package document=] attributes without having to
-								declare them.</p>
-							<table id="tbl-pkg-reserved-prefixes" class="prefix">
-								<thead>
-									<tr>
-										<th>Prefix</th>
-										<th>URL</th>
-										<th>Usage</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>a11y</td>
-										<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
-										<td>To declare properties from them EPUB Accessibility namespace. These are
-											typically defined in <a data-cite="epub-a11y-12#app-a11y-vocab">EPUB
-												Accessibility 1.2</a> [[epub-a11y-12]].</td>
-									</tr>
-									<tr>
-										<td>dcterms</td>
-										<td>http://purl.org/dc/terms/</td>
-										<td>To declare properties from the <a data-cite="dcterms#section-2">Dublin Core
-												/terms/ namespace</a> [[dcterms]].</td>
-									</tr>
-									<tr>
-										<td>marc</td>
-										<td>http://id.loc.gov/vocabulary/</td>
-										<td>Primarily used in the <a href="#attrdef-scheme"><code>scheme</code>
-												attribute</a> to indicate that creator and contributor roles are defined
-											in the the <a href="https://www.loc.gov/marc/relators/relaterm.html">MARC
-												relators code list</a>. Can be used to reference other vocabularies
-											published by the Library of Congress.</td>
-									</tr>
-									<tr>
-										<td>media</td>
-										<td>http://www.idpf.org/epub/vocab/overlays/#</td>
-										<td>To declare properties from the <a href="#app-overlays-vocab">Media Overlays
-												vocabulary</a>.</td>
-									</tr>
-									<tr>
-										<td>onix</td>
-										<td>http://www.editeur.org/ONIX/book/codelists/<wbr />current.html#</td>
-										<td>Used in the <code>scheme</code> attribute to identify the <a
-												href="https://ns.editeur.org/onix/en">ONIX code list</a> a value
-											corresponds to.</td>
-									</tr>
-									<tr>
-										<td>rendition</td>
-										<td>http://www.idpf.org/vocab/rendition/#</td>
-										<td>To declare properties from the <a href="#app-rendering-vocab">Package
-												rendering vocabulary</a>.</td>
-									</tr>
-									<tr>
-										<td>schema</td>
-										<td>http://schema.org/</td>
-										<td>To declare properties from the <a href="https://schema.org">Schema.org
-												vocabulary</a>.</td>
-									</tr>
-								</tbody>
-							</table>
-						</dd>
-					</dl>
-				</section>
-			</section>
-
-			<section id="sec-property-field-definitions">
-				<h3>Property field definitions</h3>
-
-				<p>The fields in the vocabulary definition tables have the following implicit requirements:</p>
-
-				<dl>
-					<dt>Allowed Values</dt>
-					<dd>
-						<p>Specifies the REQUIRED type of value using [[!xmlschema-2]] datatypes. Datatypes are declared
-							using the <code>xsd:</code> prefix.</p>
-					</dd>
-
-					<dt>Applies To</dt>
-					<dd>
-						<p>Specifies which publication resource type(s) that the property MAY be specified on.</p>
-						<p>This field appears for properties used in the <a href="#attrdef-properties"
-									><code>properties</code> attribute</a>.</p>
-					</dd>
-
-					<dt>Cardinality</dt>
-					<dd>
-						<p>Specifies the number of times the property MAY be specified, whether globally or attached to
-							another element or property.</p>
-						<p>Properties with a minimum cardinality of one MUST be specified.</p>
-					</dd>
-
-					<dt>Description</dt>
-					<dd>
-						<p>Describes the purpose of the property and specifies any additional usage requirements that
-							have to be followed.</p>
-					</dd>
-
-					<dt>Example</dt>
-					<dd>
-						<p>Provides non-normative usage examples.</p>
-					</dd>
-
-					<dt>Extends</dt>
-					<dd>
-						<p>Identifies what metadata the property MAY be associated with.</p>
-						<p>This field appears for properties that define <a href="#meta-expr-types">primary expressions
-								and subexpressions</a> and <a href="#attrdef-link-rel">relationships</a>.</p>
-					</dd>
-
-					<dt>Name</dt>
-					<dd>
-						<p>Specifies the name of the property as it MUST appear in the metadata.</p>
-					</dd>
-				</dl>
-			</section>
-
-			<div data-include="vocab/meta-property.html" data-include-replace="true"></div>
-
-			<div data-include="vocab/link.html" data-include-replace="true"></div>
-
-			<div data-include="vocab/rendering.html" data-include-replace="true"></div>
-
-			<div data-include="vocab/item-properties.html" data-include-replace="true"></div>
-
-			<div data-include="vocab/itemref-properties.html" data-include-replace="true"></div>
-
-			<div data-include="vocab/overlays.html" data-include-replace="true"></div>
-		</section>
-		<section id="app-viewport-meta" class="appendix">
-			<h2>The <code>viewport meta</code> tag</h2>
-
-			<section id="app-viewport-meta-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>As the <a
-						href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6"
-						>Safari HTML definition</a> of the <code>viewport meta</code> tag, that was used in earlier
-					versions of EPUB&#160;3, is not an officially recognized standard, this specification defines a
-					basic syntax to allow <a href="#sec-fxl-icb-html">width and height dimensions</a> to be expressed
-					for [=fixed-layout documents=].</p>
-
-				<p>The syntax of this grammar is also influenced by the parsing algorithm for the <code>viewport
-						meta</code> tag, as defined in [[css-viewport-1]].</p>
-
-				<p>The syntax is intentionally left as generic as possible as it is not in this specification's scope to
-					define all the possible properties and values. It only defines the basic requirements for defining a
-					property and value pair as well as the possible separators between expressions.</p>
-			</section>
-
-			<section id="app-viewport-meta-syntax">
-				<h3>Syntax</h3>
-
-				<p>For [=fixed-layout documents=], a <code>viewport</code>
-					<a data-cite="html#the-meta-element"><code>meta</code></a> tag [[html]] MUST have <code>name</code>
-					and <code>content</code> attributes that conform to the following definition:</p>
-
-				<dl>
-					<dt id="viewport-name-attr">name</dt>
-					<dd>The value of the [^meta/name^] attribute [[html]] after <a data-cite="xml#AVNormalize"
-							>whitespace normalization</a>&#160;[[xml]] MUST be <code>viewport</code>.</dd>
-
-					<dt id="viewport-content-attr">content</dt>
-					<dd>
-						<p>The value of the [^meta/content^] attribute [[html]] after <a data-cite="xml#AVNormalize"
-								>whitespace normalization</a>&#160;[[xml]] MUST be of the following form:</p>
-						<table class="productionset">
-							<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-									14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
-								to U+007F).</caption>
-							<tbody>
-								<tr>
-									<td id="viewport.ebnf.def">
-										<a href="#viewport.ebnf.def">viewport</a>
-									</td>
-									<td>=</td>
-									<td><a href="#viewport.ebnf.property">property</a>, { <a href="#viewport.ebnf.sep"
-											>sep</a>, <a href="#viewport.ebnf.property">property</a> } ;</td>
-								</tr>
-								<tr>
-									<td id="viewport.ebnf.property">
-										<a href="#viewport.ebnf.property">property</a>
-									</td>
-									<td>=</td>
-									<td><a href="#viewport.ebnf.name">name</a>, [ <a href="#viewport.ebnf.assign"
-											>assign</a>, <a href="#viewport.ebnf.value">value</a> ] ;</td>
-								</tr>
-								<tr>
-									<td id="viewport.ebnf.name">
-										<a href="#viewport.ebnf.name">name</a>
-									</td>
-									<td>=</td>
-									<td>? character data ? ;</td>
-								</tr>
-								<tr>
-									<td id="viewport.ebnf.value">
-										<a href="#viewport.ebnf.value">value</a>
-									</td>
-									<td>=</td>
-									<td>? character data ? ;</td>
-								</tr>
-								<tr>
-									<td id="viewport.ebnf.sep">
-										<a href="#viewport.ebnf.sep">sep</a>
-									</td>
-									<td>=</td>
-									<td>
-										<a href="#viewport.ebnf.sep-char">sep-char</a>, { <a
-											href="#viewport.ebnf.sep-char">sep-char</a> } ;</td>
-								</tr>
-								<tr>
-									<td id="viewport.ebnf.sep-char">
-										<a href="#viewport.ebnf.sep-char">sep-char</a>
-									</td>
-									<td>=</td>
-									<td>( ";" | "," | <a href="#viewport.ebnf.space">space</a> ) ;</td>
-								</tr>
-								<tr>
-									<td id="viewport.ebnf.assign">
-										<a href="#viewport.ebnf.assign">assign</a>
-									</td>
-									<td>=</td>
-									<td>[ <a href="#viewport.ebnf.space">space</a> ], "=", [ <a
-											href="#viewport.ebnf.space">space</a> ] ;</td>
-								</tr>
-								<tr>
-									<td id="viewport.ebnf.space">
-										<a href="#viewport.ebnf.space">space</a>
-									</td>
-									<td>=</td>
-									<td>#x20 ;</td>
-								</tr>
-							</tbody>
-						</table>
-					</dd>
-				</dl>
-
-				<p>The only restriction on property <a href="#viewport.ebnf.name">names</a> and <a
-						href="#viewport.ebnf.value">values</a> is that they MUST NOT contain <a
-						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
-						>assignment character</a>.</p>
-
-				<p>The authoring requirements in this section apply <em>after</em>
-					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
-					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-					within the attribute to single spaces). Any <a data-cite="xml#NT-S">whitespace characters</a>
-					[[xml]] MAY be included in the authored tag so long as the result is valid to this definition.</p>
-
-				<div class="note">
-					<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
-							data-cite="infra#ascii-whitespace">definition of whitespace</a>, the Form Feed (U+000C)
-						character is not valid whitespace per the [[xml]] definition. It cannot be used in the XML
-						syntax (i.e., in XHTML content documents).</p>
-				</div>
-
-				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
-							><code>meta</code></a> element by the [[html]] grammar.</p>
-
-				<div class="note">
-					<p>For more information about specifying the <code>height</code> and <code>width</code> properties
-						and their expected values, refer to <a href="#sec-fxl-content-dimensions"></a>.</p>
-
-					<p>Although the <code>viewport meta</code> tag allows the use of properties other than
-							<code>height</code> and <code>width</code>, as well as to omit values for the
-							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
-						properties could have unintended consequences on the rendering of fixed-layout documents.</p>
-				</div>
-			</section>
-		</section>
-		<section id="app-schemas" class="appendix informative">
-			<h2>Schemas</h2>
-
-			<section id="app-package-schema">
-				<h3>Package document schema</h3>
-
-				<p>A schema for [=package documents=] is available at <a
-						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
-						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
-
-				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
-					[[isoschematron]] and [[xmlschema-2]].</p>
-
-				<div class="note">
-					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
-						and ISO Schematron schemas alone.</p>
-				</div>
-
-				<div class="note">
-					<p>Updates and corrections to these schemas can occur outside of formal revisions of this
-						specification. As a result, they are subject to change at any time. </p>
-				</div>
-			</section>
-
-			<section id="app-ocf-schema">
-				<h3>OCF schemas</h3>
-
-				<section id="app-schema-container">
-					<h4>Schema for <code>container.xml</code></h4>
-
-					<p>A schema for <a href="#sec-container-metainf-container.xml"><code>container.xml</code> files</a>
-						is available at <a
-							href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
-							<code>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl</code></a>.</p>
-
-					<p>Validation using this schema requires a processor that supports [[relaxng-schema]] and
-						[[xmlschema-2]].</p>
-				</section>
-
-				<section id="app-schema-encryption">
-					<h4>Schema for <code>encryption.xml</code></h4>
-
-					<p>The schema for <a href="#sec-container-metainf-encryption.xml"><code>encryption.xml</code>
-							files</a> is included in [[xmlsec-rngschema-20130411]].</p>
-				</section>
-
-				<section id="app-schema-signatures">
-					<h4>Schema for <code>signatures.xml</code></h4>
-
-					<p>The schema for <a href="#sec-container-metainf-signatures.xml"><code>signatures.xml</code>
-							files</a> is included in [[xmlsec-rngschema-20130411]].</p>
-				</section>
-			</section>
-
-			<section id="app-schema-overlays">
-				<h3>Media overlays schema</h3>
-
-				<p>A schema for [=media overlay documents=] is available at <a
-						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
-						>https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
-
-				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
-					[[isoschematron]] and [[xmlschema-2]].</p>
-
-				<div class="note">
-					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
-						and ISO Schematron schemas alone.</p>
-				</div>
-			</section>
-		</section>
 		<section id="app-examples" class="appendix informative">
 			<h2>Detailed examples</h2>
 
@@ -11253,6 +10054,1205 @@ EPUB/images/cover.png</pre>
 						<p><code>12.345</code> = 12 seconds and 345 milliseconds</p>
 					</li>
 				</ul>
+			</section>
+		</section>
+		<section id="app-identifiers-allowed" class="appendix" data-epubcheck="true"
+			data-tests="https://w3c.github.io/epub-structural-tests/#B-external-identifiers_external-identifiers.feature_L13,https://w3c.github.io/epub-structural-tests/#B-external-identifiers_external-identifiers.feature_L23">
+			<h2>Allowed external identifiers</h2>
+
+			<p>The following table lists the <a aria-label="public identifiers" data-cite="xml#dt-pubid">public </a> and
+					<a data-cite="xml#dt-sysid">system identifiers</a> [[xml]] allowed in <a data-cite="xml#dt-doctype"
+					>document type declarations</a>. [[xml]]</p>
+
+			<p>These external identifiers MAY be used only in [=publication resources=] with the listed media types
+				[[rfc2046]] specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a
+					href="#sec-xml-constraints"></a> for more information.)</p>
+
+			<table class="zebra">
+				<thead>
+					<tr>
+						<th>Media Type(s)</th>
+						<th>Public Identifier</th>
+						<th>System Identifier</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>
+							<ul class="flat">
+								<li>
+									<code>application/mathml+xml</code>
+								</li>
+								<li>
+									<code>application/mathml-presentation+xml</code>
+								</li>
+								<li>
+									<code>application/mathml-content+xml</code>
+								</li>
+							</ul>
+						</td>
+						<td>
+							<code>-//W3C//DTD MathML 3.0//EN</code>
+						</td>
+						<td>
+							<code>http://www.w3.org/Math/DTD/mathml3/mathml3.dtd</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>application/x-dtbncx+xml</code>
+						</td>
+						<td>
+							<code>-//NISO//DTD ncx 2005-1//EN</code>
+						</td>
+						<td>
+							<code>http://www.daisy.org/z3986/2005/ncx-2005-1.dtd</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>image/svg+xml</code>
+						</td>
+						<td>
+							<code>-//W3C//DTD SVG 1.1//EN</code>
+						</td>
+						<td>
+							<code>http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd</code>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</section>
+		<section id="app-viewport-meta" class="appendix">
+			<h2>The <code>viewport meta</code> tag</h2>
+			
+			<section id="app-viewport-meta-intro" class="informative">
+				<h3>Introduction</h3>
+				
+				<p>As the <a
+						href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6"
+						>Safari HTML definition</a> of the <code>viewport meta</code> tag, that was used in earlier
+					versions of EPUB&#160;3, is not an officially recognized standard, this specification defines a
+					basic syntax to allow <a href="#sec-fxl-icb-html">width and height dimensions</a> to be expressed
+					for [=fixed-layout documents=].</p>
+				
+				<p>The syntax of this grammar is also influenced by the parsing algorithm for the <code>viewport
+						meta</code> tag, as defined in [[css-viewport-1]].</p>
+				
+				<p>The syntax is intentionally left as generic as possible as it is not in this specification's scope to
+					define all the possible properties and values. It only defines the basic requirements for defining a
+					property and value pair as well as the possible separators between expressions.</p>
+			</section>
+			
+			<section id="app-viewport-meta-syntax">
+				<h3>Syntax</h3>
+				
+				<p>For [=fixed-layout documents=], a <code>viewport</code>
+					<a data-cite="html#the-meta-element"><code>meta</code></a> tag [[html]] MUST have <code>name</code>
+					and <code>content</code> attributes that conform to the following definition:</p>
+				
+				<dl>
+					<dt id="viewport-name-attr">name</dt>
+					<dd>The value of the [^meta/name^] attribute [[html]] after <a data-cite="xml#AVNormalize"
+							>whitespace normalization</a>&#160;[[xml]] MUST be <code>viewport</code>.</dd>
+					
+					<dt id="viewport-content-attr">content</dt>
+					<dd>
+						<p>The value of the [^meta/content^] attribute [[html]] after <a data-cite="xml#AVNormalize"
+								>whitespace normalization</a>&#160;[[xml]] MUST be of the following form:</p>
+						<table class="productionset">
+							<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+									14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
+								to U+007F).</caption>
+							<tbody>
+								<tr>
+									<td id="viewport.ebnf.def">
+										<a href="#viewport.ebnf.def">viewport</a>
+									</td>
+									<td>=</td>
+									<td><a href="#viewport.ebnf.property">property</a>, { <a href="#viewport.ebnf.sep"
+											>sep</a>, <a href="#viewport.ebnf.property">property</a> } ;</td>
+								</tr>
+								<tr>
+									<td id="viewport.ebnf.property">
+										<a href="#viewport.ebnf.property">property</a>
+									</td>
+									<td>=</td>
+									<td><a href="#viewport.ebnf.name">name</a>, [ <a href="#viewport.ebnf.assign"
+											>assign</a>, <a href="#viewport.ebnf.value">value</a> ] ;</td>
+								</tr>
+								<tr>
+									<td id="viewport.ebnf.name">
+										<a href="#viewport.ebnf.name">name</a>
+									</td>
+									<td>=</td>
+									<td>? character data ? ;</td>
+								</tr>
+								<tr>
+									<td id="viewport.ebnf.value">
+										<a href="#viewport.ebnf.value">value</a>
+									</td>
+									<td>=</td>
+									<td>? character data ? ;</td>
+								</tr>
+								<tr>
+									<td id="viewport.ebnf.sep">
+										<a href="#viewport.ebnf.sep">sep</a>
+									</td>
+									<td>=</td>
+									<td>
+										<a href="#viewport.ebnf.sep-char">sep-char</a>, { <a
+											href="#viewport.ebnf.sep-char">sep-char</a> } ;</td>
+								</tr>
+								<tr>
+									<td id="viewport.ebnf.sep-char">
+										<a href="#viewport.ebnf.sep-char">sep-char</a>
+									</td>
+									<td>=</td>
+									<td>( ";" | "," | <a href="#viewport.ebnf.space">space</a> ) ;</td>
+								</tr>
+								<tr>
+									<td id="viewport.ebnf.assign">
+										<a href="#viewport.ebnf.assign">assign</a>
+									</td>
+									<td>=</td>
+									<td>[ <a href="#viewport.ebnf.space">space</a> ], "=", [ <a
+											href="#viewport.ebnf.space">space</a> ] ;</td>
+								</tr>
+								<tr>
+									<td id="viewport.ebnf.space">
+										<a href="#viewport.ebnf.space">space</a>
+									</td>
+									<td>=</td>
+									<td>#x20 ;</td>
+								</tr>
+							</tbody>
+						</table>
+					</dd>
+				</dl>
+				
+				<p>The only restriction on property <a href="#viewport.ebnf.name">names</a> and <a
+						href="#viewport.ebnf.value">values</a> is that they MUST NOT contain <a
+							href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
+								>assignment character</a>.</p>
+				
+				<p>The authoring requirements in this section apply <em>after</em>
+					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
+					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
+					within the attribute to single spaces). Any <a data-cite="xml#NT-S">whitespace characters</a>
+					[[xml]] MAY be included in the authored tag so long as the result is valid to this definition.</p>
+				
+				<div class="note">
+					<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
+							data-cite="infra#ascii-whitespace">definition of whitespace</a>, the Form Feed (U+000C)
+						character is not valid whitespace per the [[xml]] definition. It cannot be used in the XML
+						syntax (i.e., in XHTML content documents).</p>
+				</div>
+				
+				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
+						><code>meta</code></a> element by the [[html]] grammar.</p>
+				
+				<div class="note">
+					<p>For more information about specifying the <code>height</code> and <code>width</code> properties
+						and their expected values, refer to <a href="#sec-fxl-content-dimensions"></a>.</p>
+					
+					<p>Although the <code>viewport meta</code> tag allows the use of properties other than
+						<code>height</code> and <code>width</code>, as well as to omit values for the
+						<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
+						properties could have unintended consequences on the rendering of fixed-layout documents.</p>
+				</div>
+			</section>
+		</section>
+		<section id="app-structural-semantics" class="appendix">
+			<h2>Expressing structural semantics</h2>
+
+			<section id="sec-structural-semantics-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
+					The [^/epub:type^] attribute is used to express domain-specific semantics in [=EPUB content
+					documents=] and [=media overlay documents=], with the structural information it carries
+					complementing the underlying vocabulary.</p>
+
+				<p>The applied semantics refine the meaning of their containing elements without changing their nature
+					for assistive technologies, as happens when using the similar [^/role^] attribute&#160;[[html]]. The
+					attribute does not enhance the accessibility of the content, in other words; it only provides hints
+					about the purpose.</p>
+
+				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
+					It also allows [=reading systems=] to learn more about the structure and content of a document
+					(e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and escapability</a> in media
+					overlays).</p>
+
+				<p>This specification defines a method for adding structural semantics using <em>the attribute
+					axis</em>: instead of adding new elements, the <code>epub:type</code> attribute can be appended to
+					existing elements to add the desired semantics.</p>
+			</section>
+
+			<section id="sec-epub-type-attribute">
+				<h3>The <code>type</code> attribute</h3>
+
+				<dl>
+					<dt>XHTML serialization</dt>
+					<dd>
+						<dl class="elemdef" id="attrdef-epub-type-xhtml">
+							<dt>Attribute Name:</dt>
+							<dd>
+								<p>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+										<code>epub:type</code>
+									</dfn>
+								</p>
+							</dd>
+
+							<dt>Namespace:</dt>
+							<dd>
+								<p>
+									<code>http://www.idpf.org/2007/ops</code>
+								</p>
+							</dd>
+
+							<dt>Usage:</dt>
+							<dd>
+								<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a
+										href="#confreq-svg-structural-semantics">SVG</a>, and <a
+										href="#sec-overlays-def">media overlays</a>.</p>
+							</dd>
+
+							<dt>Value:</dt>
+							<dd>
+								<p>A <a data-cite="xml#NT-S">whitespace-separated</a> [[xml]] list of <a
+										href="#sec-property-datatype">property</a> values, with restrictions as defined
+									in <a href="#sec-vocab-assoc"></a>.</p>
+							</dd>
+						</dl>
+					</dd>
+
+					<dt>HTML serialization</dt>
+					<dd>
+						<dl class="elemdef" id="attrdef-epub-type-html">
+							<dt>Attribute Name:</dt>
+							<dd>
+								<p>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+										<code>epub-type</code>
+									</dfn>
+								</p>
+							</dd>
+
+							<dt>Usage:</dt>
+							<dd>
+								<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">HTML</a>.</p>
+							</dd>
+
+							<dt>Value:</dt>
+							<dd>
+								<p>A [=ASCII whitespace|whitespace-separated=] [[infra]] list of values that SHOULD be
+									taken from the EPUB 3 Structural Semantics Vocabulary [[epub-ssv-11]].</p>
+							</dd>
+						</dl>
+					</dd>
+				</dl>
+
+				<div class="ednote">
+					<p>Support for an HTML serialization of the <code>epub:type</code> attribute depends on the addition
+						of support for the <a href="#sec-xhtml">HTML syntax</a> in the EPUB 3.4 revision. It is <b><i>at
+								risk</i></b>, depending on authors' and implementers' feedback.</p>
+
+					<p>The proposed <code>epub-type</code> will provide similar functionality for HTML content documents
+						but with some restrictions (namely, no extensibility through the <code>epub:prefix</code>
+						attribute). The attribute should be read as a replacement for <code>epub:type</code> where this
+						specification and the Reading Systems specification [[epub-rs-34]] refer to that attribute for
+						XHTML content documents. These references will be updated once it is clearer that support will
+						definitely be added in this revision.</p>
+
+					<p>The <code>epub:type</code> attribute will remain the sole means of including semantics in XML
+						grammars in EPUB (i.e., XHTML content documents, SVG content documents, and media overlay
+						documents).</p>
+
+					<p>To provide feedback on this change, please open issues in the <a
+							href="https://github.com/w3c/epub-specs/issues">GitHub tracker for the EPUB
+							specifications</a>.</p>
+				</div>
+
+
+				<div class="caution">
+					<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
+						attribute&#160;[[html]], the attributes serve different purposes. The values of the
+							<code>epub:type</code> attribute do not enhance access through assistive technologies like
+						screen readers as they do not map to the accessibility <abbr
+							title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
+						means that adding <code>epub:type</code> values to semantically neutral elements like [[html]]
+						[^div^] and [^span^] does not make them any more accessible to assistive technologies. Only ARIA
+						roles influence how assistive technologies understand such elements.</p>
+
+					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
+						[=reading system=] enhancements. Reading systems can use <code>epub:type</code> values to
+						provide accessibility enhancements like built-in read aloud or media overlays functionality
+						where interaction with assistive technologies is not essential.</p>
+
+					<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
+						Module</a>&#160;[[?dpub-aria]] for more information about accessible publishing roles.</p>
+				</div>
+
+				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
+					is one or more whitespace-separated terms stemming from external vocabularies associated with the
+					document instance.</p>
+
+				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
+					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The prefix URL for
+					referencing its properties is <code>http://idpf.org/epub/vocab/structure/#</code>.</p>
+
+				<p>Unprefixed terms that are not part of this vocabulary MAY be used but the preferred method for adding
+					custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
+						href="#sec-vocab-assoc"></a> for more information.</p>
+
+				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
+					<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+   …
+   &lt;body&gt;
+      …
+      &lt;section epub:type="preamble"&gt;
+         …
+      &lt;/section&gt;
+      …
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
+				</aside>
+
+				<aside class="example" id="ex.epubtype.gloss" title="Identifying a glossary">
+					<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+   …
+   &lt;body&gt;
+      …
+      &lt;dl epub:type="glossary"&gt;
+         …
+      &lt;/dl&gt;
+      …
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
+				</aside>
+
+				<aside class="example" id="ex.epubtype.pg" title="Adding page break semantics">
+					<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+   …
+   &lt;body&gt;
+      …
+      &lt;p&gt;
+         …
+         &lt;span
+            epub:type="pagebreak"
+            id="p234"
+            role="doc-pagebreak"
+            aria-label="234"/&gt;
+         …
+      &lt;/p&gt;
+      …
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
+				</aside>
+			</section>
+		</section>
+		<section id="app-vocabs" class="appendix">
+			<h2>Vocabularies</h2>
+
+			<p>This appendix defines a general set of mechanisms by which attributes in this specification can reference
+				terms from vocabularies. It also defines EPUB-specific vocabularies for use with the attributes.</p>
+
+			<section id="sec-vocab-assoc">
+				<h3>Vocabulary association mechanisms</h3>
+
+				<section id="sec-vocab-assoc-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
+						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
+							<code>epub:type</code> attribute uses this data type in [=EPUB content documents=] and
+						[=media overlay documents=] to add <a href="#app-structural-semantics">structural semantics</a>,
+						for example, while the <code>property</code> and <code>rel</code> attributes use the data type
+						to define properties and relationships in the [=package document=].</p>
+
+					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] — it represents a URL [[url]] in
+						compact form. The expression consists of a prefix and a reference, where the prefix — whether
+						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
+						vocabulary. When a [=reading system=] converts the prefix to its URL representation and combines
+						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
+						that contains human- and/or machine-readable information about the term.</p>
+
+					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
+						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
+						referenced from the default vocabularies do not include a prefix as the mapping reading systems
+						use to map to a URL is predefined.</p>
+
+					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
+						terms and properties, it is only necessary to declare a <a href="#sec-prefix-attr">prefix</a>.
+						In another authoring convenience, this specification also <a
+							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
+						publishing vocabularies (i.e., their declaration is not required).</p>
+
+					<p>The following sections provide additional details on the <var>property</var> data type and
+						vocabulary association mechanism.</p>
+				</section>
+
+				<section id="sec-property-datatype">
+					<h4>The <var>property</var> data type</h4>
+
+					<p>The <var>property</var> data type is a compact means of expressing a URL [[url]] and consists of
+						an OPTIONAL prefix separated from a reference by a colon.</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+							<code>xsd:</code>.</caption>
+						<tbody>
+							<tr>
+								<td id="property.ebnf.property">
+									<a href="#property.ebnf.property">property</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
+										href="#property.ebnf.reference">reference</a>; </td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="property.ebnf.prefix">
+									<a href="#property.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? xsd:NCName ? ;</td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="property.ebnf.reference">
+									<a href="#property.ebnf.reference">reference</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? [=path-relative-scheme-less-URL string=] [[url]] ? ;</td>
+								<td>/*&#160;as defined in [[url]]&#160;*/<br /></td>
+							</tr>
+						</tbody>
+					</table>
+
+					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
+						[[rdfa-core]]. A <var>property</var> represents a subset of CURIEs.</p>
+
+					<p>There are two key differences from CURIEs, however:</p>
+
+					<ul>
+						<li>
+							<p>an empty <var>reference</var> does not represent a valid <var>property</var> value even
+								though it is valid to the definition above (i.e., a <var>property</var> value that only
+								consists of a prefix and colon is invalid).</p>
+						</li>
+						<li>
+							<p>an empty string does not represent a valid <var>property</var> even though it is valid to
+								the definition above.</p>
+						</li>
+					</ul>
+
+					<aside class="example" title="Expanding a metadata property value">
+						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
+							and the reference <code>modified</code>.</p>
+
+						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+
+						<p>After <a data-cite="epub-rs-34#sec-property-values">processing</a> [[epub-rs-34]], this
+							property would expand to the following URL:</p>
+
+						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+
+						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
+					</aside>
+
+					<p>When a prefix is omitted from a <var>property</var> value, the specified term is taken from the
+							<a href="#sec-default-vocab">default vocabulary</a> for that attribute.</p>
+
+					<aside class="example" title="Expanding a manifest property value">
+						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
+							manifest [^item^] element:</p>
+
+						<pre>&lt;item … properties="mathml"/&gt;</pre>
+
+						<p>This property expands to:</p>
+
+						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
+
+						<p>when the prefix URL for the vocabulary is concatenated with the reference.</p>
+					</aside>
+				</section>
+
+				<section id="sec-default-vocab">
+					<h5>Default vocabularies</h5>
+
+					<p>A default vocabulary is one whose terms and properties MUST NOT have a <a href="#sec-prefix-attr"
+							>prefix</a> when a <a href="#sec-property-datatype"><var>property</var> value</a> is
+						expected.</p>
+
+					<p>A prefix MUST NOT be assigned to the URLs associated with these vocabularies using the <a
+							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+
+					<div class="note">
+						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
+									><var>property</var> data type</a> for more information about its default
+							vocabulary.</p>
+					</div>
+				</section>
+
+				<section id="sec-prefix-attr" data-epubcheck="true"
+					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L671,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L694,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L17,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L22,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L28,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L34">
+					<h4>The <code>prefix</code> attribute</h4>
+
+					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
+							href="#sec-property-datatype"><var>property</var> values</a>.</p>
+
+					<p>The value of the <code>prefix</code> attribute is a whitespace-separated list of one or more
+						prefix-to-URL mappings of the form:</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+							<code>xsd:</code>.</caption>
+						<tbody>
+							<tr>
+								<td id="prefix.ebnf.def">
+									<a href="#prefix.ebnf.def">prefixes</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
+										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
+										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.mapping">
+									<a href="#prefix.ebnf.mapping">mapping</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
+										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.prefix">
+									<a href="#prefix.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? xsd:NCName ? ;</td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.space">
+									<a href="#prefix.ebnf.space">space</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>#x20 ;</td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.whitespace">
+									<a href="#prefix.ebnf.whitespace">whitespace</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>(#x20 | #x9 | #xD | #xA) ;</td>
+								<td>&#160;</td>
+							</tr>
+						</tbody>
+					</table>
+
+					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, all prefixes used
+						in a document MUST be declared. The <code>prefix</code> attribute MUST be specified only on the
+							<a data-cite="xml#dt-root">root element</a> [[xml]] of the respective format.</p>
+
+					<p>The attribute is not namespaced when used in the [=package document=].</p>
+
+					<aside class="example" title="Declaring prefixes in the package document">
+						<p>In this example, the prefixes for the Friend of a Friend (<code>foaf</code>) and DBPedia
+								(<code>dbp</code>) vocabularies are declared in the <code>prefix</code> attribute.</p>
+
+						<pre>&lt;package
+    …
+    prefix="foaf: http://xmlns.com/foaf/spec/
+            dbp: http://dbpedia.org/ontology/"&gt;
+   …
+&lt;/package&gt;</pre>
+					</aside>
+
+					<p>The attribute MUST be declared in the namespace <code>http://www.idpf.org/2007/ops</code> when
+						used in [=EPUB content documents=] and [=media overlay documents=].</p>
+
+					<aside class="example" title="Declaring prefixes in an XHTML content document">
+						<p>In this example, a prefix is declared for the Z39.98 Structural Semantics Vocabulary.</p>
+
+						<pre>&lt;html …
+      xmlns:epub="http://www.idpf.org/2007/ops"
+      epub:prefix="z3998: https://www.daisy.org/z3998/2012/vocab/structure/"&gt;
+   …
+&lt;/html&gt;</pre>
+					</aside>
+
+					<div class="note">
+						<p>Although the <code>prefix</code> attribute is modeled on the identically named
+								<code>prefix</code> attribute in [[rdfa-core]], the attributes cannot be used
+							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB content
+							documents is the RDFa attribute.</p>
+
+						<p>It is common for both attributes to appear in EPUB content documents that also specify RDFa
+							expressions.</p>
+
+						<pre>&lt;html … prefix="…"
+        xmlns:epub="http://www.idpf.org/2007/ops"
+        epub:prefix="…"&gt;   …
+&lt;/html&gt;</pre>
+					</div>
+
+					<p>Note that for <a href="#sec-xhtml-svg-inclusion">SVG embedded by inclusion</a>, prefixes MUST be
+						declared on the [[html]] root [^html^] element.</p>
+
+					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
+						maps to a <a href="#sec-default-vocab">default vocabulary</a>.</p>
+
+					<p>The prefix '_' MUST NOT be declared as this specification reserves this prefix for future
+						compatibility with RDFa [[rdfa-core]] processing.</p>
+
+					<p>For future compatibility with alternative serializations of the package document, a prefix MUST
+						NOT be declared for the Dublin Core <em>/elements/1.1/</em> namespace [[dcterms]]. Only the
+						[[dcterms]] elements are <a href="#sec-pkg-metadata">allowed in the package document
+							metadata</a>.</p>
+				</section>
+
+				<section id="sec-reserved-prefixes">
+					<h4>Reserved prefixes</h4>
+
+					<div class="caution">
+						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for
+							example, will often reject new prefixes until they update their [=EPUB conformance
+							checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
+					</div>
+
+					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"
+								><var>property</var> value</a> without declaring them in a <a href="#sec-prefix-attr"
+								><code>prefix</code> attribute</a>.</p>
+
+
+					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
+							attribute</a>.</p>
+
+					<p>The reserved prefixes that can be used depends on the context:</p>
+
+					<dl class="conformance-list">
+						<dt>Package document</dt>
+						<dd id="sec-metadata-reserved-prefixes">
+							<p>The following prefixes MAY be used in [=package document=] attributes without having to
+								declare them.</p>
+							<table id="tbl-pkg-reserved-prefixes" class="prefix">
+								<thead>
+									<tr>
+										<th>Prefix</th>
+										<th>URL</th>
+										<th>Usage</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>a11y</td>
+										<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
+										<td>To declare properties from them EPUB Accessibility namespace. These are
+											typically defined in <a data-cite="epub-a11y-12#app-a11y-vocab">EPUB
+												Accessibility 1.2</a> [[epub-a11y-12]].</td>
+									</tr>
+									<tr>
+										<td>dcterms</td>
+										<td>http://purl.org/dc/terms/</td>
+										<td>To declare properties from the <a data-cite="dcterms#section-2">Dublin Core
+												/terms/ namespace</a> [[dcterms]].</td>
+									</tr>
+									<tr>
+										<td>marc</td>
+										<td>http://id.loc.gov/vocabulary/</td>
+										<td>Primarily used in the <a href="#attrdef-scheme"><code>scheme</code>
+												attribute</a> to indicate that creator and contributor roles are defined
+											in the the <a href="https://www.loc.gov/marc/relators/relaterm.html">MARC
+												relators code list</a>. Can be used to reference other vocabularies
+											published by the Library of Congress.</td>
+									</tr>
+									<tr>
+										<td>media</td>
+										<td>http://www.idpf.org/epub/vocab/overlays/#</td>
+										<td>To declare properties from the <a href="#app-overlays-vocab">Media Overlays
+												vocabulary</a>.</td>
+									</tr>
+									<tr>
+										<td>onix</td>
+										<td>http://www.editeur.org/ONIX/book/codelists/<wbr />current.html#</td>
+										<td>Used in the <code>scheme</code> attribute to identify the <a
+												href="https://ns.editeur.org/onix/en">ONIX code list</a> a value
+											corresponds to.</td>
+									</tr>
+									<tr>
+										<td>rendition</td>
+										<td>http://www.idpf.org/vocab/rendition/#</td>
+										<td>To declare properties from the <a href="#app-rendering-vocab">Package
+												rendering vocabulary</a>.</td>
+									</tr>
+									<tr>
+										<td>schema</td>
+										<td>http://schema.org/</td>
+										<td>To declare properties from the <a href="https://schema.org">Schema.org
+												vocabulary</a>.</td>
+									</tr>
+								</tbody>
+							</table>
+						</dd>
+					</dl>
+				</section>
+			</section>
+
+			<section id="sec-property-field-definitions">
+				<h3>Property field definitions</h3>
+
+				<p>The fields in the vocabulary definition tables have the following implicit requirements:</p>
+
+				<dl>
+					<dt>Allowed Values</dt>
+					<dd>
+						<p>Specifies the REQUIRED type of value using [[!xmlschema-2]] datatypes. Datatypes are declared
+							using the <code>xsd:</code> prefix.</p>
+					</dd>
+
+					<dt>Applies To</dt>
+					<dd>
+						<p>Specifies which publication resource type(s) that the property MAY be specified on.</p>
+						<p>This field appears for properties used in the <a href="#attrdef-properties"
+									><code>properties</code> attribute</a>.</p>
+					</dd>
+
+					<dt>Cardinality</dt>
+					<dd>
+						<p>Specifies the number of times the property MAY be specified, whether globally or attached to
+							another element or property.</p>
+						<p>Properties with a minimum cardinality of one MUST be specified.</p>
+					</dd>
+
+					<dt>Description</dt>
+					<dd>
+						<p>Describes the purpose of the property and specifies any additional usage requirements that
+							have to be followed.</p>
+					</dd>
+
+					<dt>Example</dt>
+					<dd>
+						<p>Provides non-normative usage examples.</p>
+					</dd>
+
+					<dt>Extends</dt>
+					<dd>
+						<p>Identifies what metadata the property MAY be associated with.</p>
+						<p>This field appears for properties that define <a href="#meta-expr-types">primary expressions
+								and subexpressions</a> and <a href="#attrdef-link-rel">relationships</a>.</p>
+					</dd>
+
+					<dt>Name</dt>
+					<dd>
+						<p>Specifies the name of the property as it MUST appear in the metadata.</p>
+					</dd>
+				</dl>
+			</section>
+
+			<div data-include="vocab/meta-property.html" data-include-replace="true"></div>
+
+			<div data-include="vocab/link.html" data-include-replace="true"></div>
+
+			<div data-include="vocab/rendering.html" data-include-replace="true"></div>
+
+			<div data-include="vocab/item-properties.html" data-include-replace="true"></div>
+
+			<div data-include="vocab/itemref-properties.html" data-include-replace="true"></div>
+
+			<div data-include="vocab/overlays.html" data-include-replace="true"></div>
+		</section>
+		<section id="app-obsolete" class="appendix">
+			<h2>Obsolete features</h2>
+			
+			<section id="sec-obs-conform">
+				<h3>Obsolete but conforming features</h3>
+				
+				<p>An <dfn id="obsolete-but-conforming">obsolete but conforming</dfn> feature is one that is not
+					deprecated but that is also either not designed for use in EPUB 3 [=reading systems=] or that would
+					ideally be [=deprecated=] except that it would invalidate a significant base of existing [=EPUB
+					publications=].</p>
+				
+				<p>[=EPUB publications=] MAY include the obsolete but conforming features defined in this section. Their
+					usage MUST conform to their referenced definitions.</p>
+				
+				<dl>
+					<dt>Open Container Format (OCF)</dt>
+					<dd>
+						<ul>
+							<li id="sec-font-obfuscation">
+								<p><a data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]]</p>
+								<div class="caution">
+									<p>NIST is advising that use of the SHA-1 algorithm [[fips-180-4]] be phased out by
+										the end of 2030. The Publishing Maintenance Working Group does not intend to
+										support font obfuscation in EPUB publications past that date due to its reliance
+										on SHA-1, although reading systems will have to continue to support
+										deobfuscation for existing EPUB publications.</p>
+									<p>Better methods of protecting fonts exist. Both [[woff]] and [[woff2]] fonts, for
+										example, allow the embedding of licensing information and provide some
+										protection through font table compression. The use of remotely hosted fonts also
+										allows for font subsetting.</p>
+								</div>
+							</li>
+						</ul>
+					</dd>
+					
+					<dt id="sec-pkg-collections">Collections</dt>
+					<dd>
+						<ul>
+							<li id="sec-collection-elem">
+								<a data-cite="epub-33#sec-collection-elem"><code>collection</code> element</a>
+								[[epub-33]] </li>
+						</ul>
+						<div class="caution">
+							<p>When EPUB 3 was maintained by IDPF, a number of specifications were developed that relied
+								on the <code>collection</code> element. Due to a lack of adoption and implementation in
+								reading systems, these specifications are no longer maintained and use of the element is
+								no longer advised.</p>
+						</div>
+					</dd>
+					
+					<dt id="sec-pkg-legacy">Legacy features</dt>
+					<dd>
+						<ul>
+							<li id="sec-opf2-meta">
+								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2">OPF 2
+										<code>meta</code> element</a> [[opf-201]]</p>
+							</li>
+							
+							<li id="sec-opf2-guide">
+								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">OPF 2
+										<code>guide</code> element</a>&#160;[[opf-201]]</p>
+							</li>
+							
+							<li id="sec-opf2-ncx">
+								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">OPF 2
+										NCX</a> [[opf-201]]</p>
+							</li>
+						</ul>
+						<div class="note">
+							<p>EPUB 3 reading systems ignore these features. They are replaced by the [^meta^] element,
+								the <a href="#sec-nav-landmarks">landmarks nav</a>, and the <a href="#sec-nav-toc">toc
+									nav</a>, respectively.</p>
+							<p>The features are retained only to provide a measure of backwards compatibility with
+								reading systems that only support EPUB 2. As such reading systems are now rare,
+								including these features has limited value.</p>
+						</div>
+					</dd>
+					
+					<dt id="css-prefixes">Prefixed CSS properties</dt>
+					<dd>
+						<ul>
+							<li id="sec-css-prefixed-writing-modes-text-orientation">
+								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-orientation"
+									><code>-epub-text-orientation</code></a> [[epub-33]]</li>
+							<li id="sec-css-prefixed-writing-modes-writing-mode">
+								<a data-cite="epub-33#sec-css-prefixed-writing-modes-writing-mode"
+									><code>-epub-writing-mode</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-writing-modes-text-combine">
+								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
+									><code>-epub-text-combine-horizontal</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-hyphens">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-hyphens"><code>-epub-hyphens</code></a>
+								[[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-line-break">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-line-break"
+									><code>-epub-line-break</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-align-last">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-align-last"
+									><code>-epub-text-align-last</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-word-break">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-word-break"
+									><code>-epub-word-break</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-text-transform"><code>text-transform</code> value <a
+									data-cite="epub-33#sec-css-prefixed-text-text-transform"
+									><code>-epub-fullwidth</code></a> [[epub-33]]</li>
+							<li id="sec-css-prefixed-text-epub-text-emphasis-color">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-color"
+									><code>-epub-text-emphasis-color</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-emphasis-position">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-position"
+									><code>-epub-text-emphasis-position</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-emphasis-style">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-style"
+									><code>-epub-text-emphasis-style</code></a> [[epub-33]] </li>
+							<li id="sec-css-prefixed-text-epub-text-underline-position">
+								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-underline-position"
+									><code>-epub-text-underline-position</code></a> [[epub-33]] </li>
+						</ul>
+						<div class="caution">
+							<p>EPUB 3 originally included these prefixed properties as many CSS features related to
+								world languages were not yet mature. They are only retained now to ensure backwards
+								compatibility for content authored using these prefixes. The Working Group recommends
+								switching to the unprefixed versions as soon as CSS support allows as these prefixed
+								properties are not expected to be maintained in the next major version of EPUB.</p>
+						</div>
+					</dd>
+				</dl>
+				
+				<div class="note">
+					<p>The Working Group advises that [=EPUB conformance checkers=] not issue alerts about the presence
+						of obsolete but conforming features in [=EPUB publications=]. Only issue alerts if a feature
+						does not conform to its definition or otherwise breaks a usage requirement.</p>
+				</div>
+			</section>
+			
+			<section id="sec-obs-deprecated">
+				<h3>Deprecated features</h3>
+				
+				<p>A <dfn id="deprecated">deprecated</dfn> feature is one that has limited or no support in [=reading
+					systems=] and/or usage in [=EPUB publications=].</p>
+				
+				<p>The following deprecated features SHOULD NOT be used. When used, their usage MUST conform to their
+					referenced definitions.</p>
+				
+				<dl>
+					<dt>Package document</dt>
+					<dd>
+						<ul>
+							<li>
+								<p id="sec-opf-bindings"><a
+										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
+										><code>bindings</code> element</a> [[epubpublications-301]]</p>
+							</li>
+							
+							<li>
+								<p id="sec-defining-collection-types"><a
+										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
+										>new collection types</a> [[epubpackages-32]]</p>
+							</li>
+						</ul>
+					</dd>
+					
+					<dt>XHTML content documents</dt>
+					<dd>
+						<ul>
+							<li id="sec-xhtml-content-switch">
+								<p><a
+										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
+										><code>switch</code> element</a> [[epubcontentdocs-301]]</p>
+							</li>
+							
+							<li>
+								<p id="sec-xhtml-epub-trigger"><a
+										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
+										><code>epub:trigger</code> element</a> [[epubcontentdocs-301]]</p>
+							</li>
+						</ul>
+					</dd>
+					
+					<dt>Fixed layouts</dt>
+					<dd>
+						<ul>
+							<li>
+								<p><a href="https://idpf.org/epub/301/spec/epub-publications.html#fxl-property-spread"
+										><code>rendition:spread</code> property with the value
+										<code>portrait</code></a> [[epubpublications-301]] &#8212; use the value
+									"<code>both</code>" instead.</p>
+							</li>
+							<li>
+								<p id="spread-portrait"><a
+										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
+										><code>spread-portrait</code> property</a> [[epubpublications-301]] &#8212;
+									use the property "<code>rendition:spread-both</code>" instead.</p>
+							</li>
+							<li>
+								<p id="viewport" data-epubcheck="true"
+									data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L187"
+									><a
+										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
+										><code>rendition:viewport</code> property</a> [[epubpublications-301]]</p>
+							</li>
+						</ul>
+					</dd>
+					
+					<dt>Vocabulary association mechanisms</dt>
+					<dd>
+						<ul>
+							<li>
+								<p><a data-cite="epub-33#tbl-pkg-reserved-prefixes"><code>xsd</code> reserved prefix</a>
+									[[epub-33]] for package metadata.</p>
+							</li>
+							<li>
+								<p><a data-cite="epub-33#tbl-reserved-prefixes"><code>msv</code> and <code>prism</code>
+										reserved prefixes</a> [[epub-33]] for structural semantics.</p>
+							</li>
+						</ul>
+					</dd>
+					
+					<dt>Meta properties vocabulary</dt>
+					<dd>
+						<ul>
+							<li>
+								<p id="sec-meta-auth"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
+										><code>meta-auth</code> property</a> [[!epubpublications-30]]</p>
+							</li>
+						</ul>
+					</dd>
+					
+					<dt>Link relationships vocabulary</dt>
+					<dd>
+						<ul>
+							<li>
+								<p id="sec-marc21xml-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"
+										><code>marc21xml-record</code> property</a> [[!epubpublications-30]] &#8212;
+									It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+									"<code>application/marcxml+xml</code>".</p>
+							</li>
+							
+							<li>
+								<p id="sec-mods-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"
+										><code>mods-record</code> property</a> [[!epubpublications-30]] &#8212; It
+									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+									"<code>application/mods+xml</code>".</p>
+							</li>
+							
+							<li>
+								<p id="sec-onix-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"
+										><code>onix-record</code> property</a> [[!epubpublications-30]] &#8212; It
+									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+										href="#attrdef-properties">properties attribute</a> value <a href="#onix"
+											><code>onix</code></a>.</p>
+							</li>
+							
+							<li>
+								<p id="sec-xml-signature"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"
+										><code>xml-signature</code> property</a> [[!epubpublications-30]]</p>
+							</li>
+							
+							<li>
+								<p id="sec-xmp-record"><a
+										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"
+										><code>xmp-record</code> property</a> [[!epubpublications-30]]</p>
+							</li>
+						</ul>
+					</dd>
+					
+					<dt>Prefixed CSS properties</dt>
+					<dd>
+						<ul>
+							<li>
+								<p><a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
+										><code>-epub-text-combine</code></a> [[epub-33]]</p>
+							</li>
+						</ul>
+					</dd>
+				</dl>
+				
+				<div class="note">
+					<p>The Working Group recommends that [=EPUB conformance checkers=] alert about the presence of
+						deprecated features when encountered in EPUB publications.</p>
+				</div>
+			</section>
+		</section>
+		<section id="app-schemas" class="appendix informative">
+			<h2>Schemas</h2>
+
+			<section id="app-package-schema">
+				<h3>Package document schema</h3>
+
+				<p>A schema for [=package documents=] is available at <a
+						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
+						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
+
+				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
+					[[isoschematron]] and [[xmlschema-2]].</p>
+
+				<div class="note">
+					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
+						and ISO Schematron schemas alone.</p>
+				</div>
+
+				<div class="note">
+					<p>Updates and corrections to these schemas can occur outside of formal revisions of this
+						specification. As a result, they are subject to change at any time. </p>
+				</div>
+			</section>
+
+			<section id="app-ocf-schema">
+				<h3>OCF schemas</h3>
+
+				<section id="app-schema-container">
+					<h4>Schema for <code>container.xml</code></h4>
+
+					<p>A schema for <a href="#sec-container-metainf-container.xml"><code>container.xml</code> files</a>
+						is available at <a
+							href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
+							<code>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl</code></a>.</p>
+
+					<p>Validation using this schema requires a processor that supports [[relaxng-schema]] and
+						[[xmlschema-2]].</p>
+				</section>
+
+				<section id="app-schema-encryption">
+					<h4>Schema for <code>encryption.xml</code></h4>
+
+					<p>The schema for <a href="#sec-container-metainf-encryption.xml"><code>encryption.xml</code>
+							files</a> is included in [[xmlsec-rngschema-20130411]].</p>
+				</section>
+
+				<section id="app-schema-signatures">
+					<h4>Schema for <code>signatures.xml</code></h4>
+
+					<p>The schema for <a href="#sec-container-metainf-signatures.xml"><code>signatures.xml</code>
+							files</a> is included in [[xmlsec-rngschema-20130411]].</p>
+				</section>
+			</section>
+
+			<section id="app-schema-overlays">
+				<h3>Media overlays schema</h3>
+
+				<p>A schema for [=media overlay documents=] is available at <a
+						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
+						>https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
+
+				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
+					[[isoschematron]] and [[xmlschema-2]].</p>
+
+				<div class="note">
+					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
+						and ISO Schematron schemas alone.</p>
+				</div>
 			</section>
 		</section>
 		<section id="app-media-types" class="appendix">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3122,7 +3122,7 @@
 					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] — it represents a URL [[url]] in
 						compact form. The expression consists of a prefix and a reference, where the prefix — whether
 						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
-						vocabulary. When a [=reading system=] converts the prefix to its URL representation and combines
+						vocabulary. When a [=reading system=] converts the prefix to its URL representation and concatenates
 						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
 						that contains human- and/or machine-readable information about the term.</p>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11,8 +11,7 @@
 		<script src="../../common/js/add-caution-hd.js" class="remove"></script>
 		<script src="../../common/js/data-test-display.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
-		<script class="remove">
-			//<![CDATA[
+		<script class="remove"> //<![CDATA[
             var respecConfig = {
                 group: "pm",
                 wgPublicList: "public-pm-wg",
@@ -23,7 +22,7 @@
                 // previousPublishDate: "2024-10-27",
                 // previousMaturity: "REC",
                 // revisedRecEnd: "2025-03-10",
-				//  errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
+				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
                 copyrightStart: "1999",
                 editors:[
                 {
@@ -79,7 +78,8 @@
 			}
 			#app-unsupported dt {
 				margin-top: 2rem;
-				margin-bottom: 1rem;
+				margin-bottom: 
+				1rem;
 			}</style>
 	</head>
 	<body>
@@ -3109,6 +3109,377 @@
 					document as <var>base</var>.</p>
 			</section>
 
+			<section id="sec-vocab-assoc">
+				<h3>Vocabulary association mechanisms</h3>
+
+				<section id="vocab-assoc-intro">
+					<h3>Introduction</h3>
+
+					<p>EPUB defines a method of referencing terms and properties defined in metadata and semantic
+						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
+							<code>property</code> and <code>rel</code> attributes use the data type, for example, to
+						define properties and relationships in the [=package document=].</p>
+
+					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] — it represents a URL [[url]] in
+						compact form. The expression consists of a prefix and a reference, where the prefix — whether
+						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
+						vocabulary. When a [=reading system=] converts the prefix to its URL representation and combines
+						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
+						that contains human- and/or machine-readable information about the term.</p>
+
+					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
+						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
+						referenced from the default vocabularies do not include a prefix as the mapping reading systems
+						use to map to a URL is predefined.</p>
+
+					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
+						terms and properties, it is only necessary to declare a <a href="#sec-prefix-attr">prefix</a>.
+						In another authoring convenience, this specification also <a
+							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
+						publishing vocabularies (i.e., their declaration is not required).</p>
+
+					<p>The following sections provide additional details on the <var>property</var> data type and
+						vocabulary association mechanism.</p>
+
+					<div class="note">
+						<p>Although vocabularies are primarily used within package document, the mechanims defined in
+							this section also apply to expressing structural semantics using the [^/epub:type^]
+							attribute.</p>
+					</div>
+				</section>
+
+				<section id="sec-property-datatype">
+					<h4>The <var>property</var> data type</h4>
+
+					<p>The <var>property</var> data type is a compact means of expressing a URL [[url]] and consists of
+						an OPTIONAL prefix separated from a reference by a colon.</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+							<code>xsd:</code>.</caption>
+						<tbody>
+							<tr>
+								<td id="property.ebnf.property">
+									<a href="#property.ebnf.property">property</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
+										href="#property.ebnf.reference">reference</a>; </td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="property.ebnf.prefix">
+									<a href="#property.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? xsd:NCName ? ;</td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="property.ebnf.reference">
+									<a href="#property.ebnf.reference">reference</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? [=path-relative-scheme-less-URL string=] [[url]] ? ;</td>
+								<td>/*&#160;as defined in [[url]]&#160;*/<br /></td>
+							</tr>
+						</tbody>
+					</table>
+
+					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
+						[[rdfa-core]]. A <var>property</var> represents a subset of CURIEs.</p>
+
+					<p>There are two key differences from CURIEs, however:</p>
+
+					<ul>
+						<li>
+							<p>an empty <var>reference</var> does not represent a valid <var>property</var> value even
+								though it is valid to the definition above (i.e., a <var>property</var> value that only
+								consists of a prefix and colon is invalid).</p>
+						</li>
+						<li>
+							<p>an empty string does not represent a valid <var>property</var> even though it is valid to
+								the definition above.</p>
+						</li>
+					</ul>
+
+					<aside class="example" title="Expanding a metadata property value">
+						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
+							and the reference <code>modified</code>.</p>
+
+						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+
+						<p>After <a data-cite="epub-rs-34#sec-property-values">processing</a> [[epub-rs-34]], this
+							property would expand to the following URL:</p>
+
+						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+
+						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
+					</aside>
+
+					<p>When a prefix is omitted from a <var>property</var> value, the specified term is taken from the
+							<a href="#sec-default-vocab">default vocabulary</a> for that attribute.</p>
+
+					<aside class="example" title="Expanding a manifest property value">
+						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
+							manifest [^item^] element:</p>
+
+						<pre>&lt;item … properties="mathml"/&gt;</pre>
+
+						<p>This property expands to:</p>
+
+						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
+
+						<p>when the prefix URL for the vocabulary is concatenated with the reference.</p>
+					</aside>
+				</section>
+
+				<section id="sec-default-vocab">
+					<h4>Default vocabularies</h4>
+
+					<p>A default vocabulary is one whose terms and properties MUST NOT have a <a href="#sec-prefix-attr"
+							>prefix</a> when a <a href="#sec-property-datatype"><var>property</var> value</a> is
+						expected.</p>
+
+					<p>A prefix MUST NOT be assigned to the URLs associated with these vocabularies using the <a
+							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+
+					<div class="note">
+						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
+									><var>property</var> data type</a> for more information about its default
+							vocabulary.</p>
+					</div>
+				</section>
+
+				<section id="sec-prefix-attr" data-epubcheck="true"
+					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L671,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L694,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L17,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L22,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L28,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L34">
+					<h4>The <code>prefix</code> attribute</h4>
+
+					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
+							href="#sec-property-datatype"><var>property</var> values</a>.</p>
+
+					<p>The value of the <code>prefix</code> attribute is a whitespace-separated list of one or more
+						prefix-to-URL mappings of the form:</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+							<code>xsd:</code>.</caption>
+						<tbody>
+							<tr>
+								<td id="prefix.ebnf.def">
+									<a href="#prefix.ebnf.def">prefixes</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
+										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
+										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.mapping">
+									<a href="#prefix.ebnf.mapping">mapping</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
+										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.prefix">
+									<a href="#prefix.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? xsd:NCName ? ;</td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.space">
+									<a href="#prefix.ebnf.space">space</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>#x20 ;</td>
+								<td>&#160;</td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.whitespace">
+									<a href="#prefix.ebnf.whitespace">whitespace</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>(#x20 | #x9 | #xD | #xA) ;</td>
+								<td>&#160;</td>
+							</tr>
+						</tbody>
+					</table>
+
+					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, all prefixes used
+						in a document MUST be declared. The <code>prefix</code> attribute MUST be specified only on the
+							<a data-cite="xml#dt-root">root element</a> [[xml]] of the respective format.</p>
+
+					<p>The attribute is not namespaced when used in the [=package document=].</p>
+
+					<aside class="example" title="Declaring prefixes in the package document">
+						<p>In this example, the prefixes for the Friend of a Friend (<code>foaf</code>) and DBPedia
+								(<code>dbp</code>) vocabularies are declared in the <code>prefix</code> attribute.</p>
+
+						<pre>&lt;package
+    …
+    prefix="foaf: http://xmlns.com/foaf/spec/
+            dbp: http://dbpedia.org/ontology/"&gt;
+   …
+&lt;/package&gt;</pre>
+					</aside>
+
+					<p>The attribute MUST be declared in the namespace <code>http://www.idpf.org/2007/ops</code> when
+						used in [=EPUB content documents=] and [=media overlay documents=].</p>
+
+					<aside class="example" title="Declaring prefixes in an XHTML content document">
+						<p>In this example, a prefix is declared for the Z39.98 Structural Semantics Vocabulary.</p>
+
+						<pre>&lt;html …
+      xmlns:epub="http://www.idpf.org/2007/ops"
+      epub:prefix="z3998: https://www.daisy.org/z3998/2012/vocab/structure/"&gt;
+   …
+&lt;/html&gt;</pre>
+					</aside>
+
+					<div class="note">
+						<p>Although the <code>prefix</code> attribute is modeled on the identically named
+								<code>prefix</code> attribute in [[rdfa-core]], the attributes cannot be used
+							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB content
+							documents is the RDFa attribute.</p>
+
+						<p>It is common for both attributes to appear in EPUB content documents that also specify RDFa
+							expressions.</p>
+
+						<pre>&lt;html … prefix="…"
+        xmlns:epub="http://www.idpf.org/2007/ops"
+        epub:prefix="…"&gt;   …
+&lt;/html&gt;</pre>
+					</div>
+
+					<p>Note that for <a href="#sec-xhtml-svg-inclusion">SVG embedded by inclusion</a>, prefixes MUST be
+						declared on the [[html]] root [^html^] element.</p>
+
+					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
+						maps to a <a href="#sec-default-vocab">default vocabulary</a>.</p>
+
+					<p>The prefix '_' MUST NOT be declared as this specification reserves this prefix for future
+						compatibility with RDFa [[rdfa-core]] processing.</p>
+
+					<p>For future compatibility with alternative serializations of the package document, a prefix MUST
+						NOT be declared for the Dublin Core <em>/elements/1.1/</em> namespace [[dcterms]]. Only the
+						[[dcterms]] elements are <a href="#sec-pkg-metadata">allowed in the package document
+							metadata</a>.</p>
+				</section>
+
+				<section id="sec-reserved-prefixes">
+					<h4>Reserved prefixes</h4>
+
+					<div class="caution">
+						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for
+							example, will often reject new prefixes until they update their [=EPUB conformance
+							checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
+					</div>
+
+					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"
+								><var>property</var> value</a> without declaring them in a <a href="#sec-prefix-attr"
+								><code>prefix</code> attribute</a>.</p>
+
+
+					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
+							attribute</a>.</p>
+
+					<p>The reserved prefixes that can be used depends on the context:</p>
+
+					<dl class="conformance-list">
+						<dt>Package document</dt>
+						<dd id="sec-metadata-reserved-prefixes">
+							<p>The following prefixes MAY be used in [=package document=] attributes without having to
+								declare them.</p>
+							<table id="tbl-pkg-reserved-prefixes" class="prefix">
+								<thead>
+									<tr>
+										<th>Prefix</th>
+										<th>URL</th>
+										<th>Usage</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>a11y</td>
+										<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
+										<td>To declare properties from them EPUB Accessibility namespace. These are
+											typically defined in <a data-cite="epub-a11y-12#app-a11y-vocab">EPUB
+												Accessibility 1.2</a> [[epub-a11y-12]].</td>
+									</tr>
+									<tr>
+										<td>dcterms</td>
+										<td>http://purl.org/dc/terms/</td>
+										<td>To declare properties from the <a data-cite="dcterms#section-2">Dublin Core
+												/terms/ namespace</a> [[dcterms]].</td>
+									</tr>
+									<tr>
+										<td>marc</td>
+										<td>http://id.loc.gov/vocabulary/</td>
+										<td>Primarily used in the <a href="#attrdef-scheme"><code>scheme</code>
+												attribute</a> to indicate that creator and contributor roles are defined
+											in the the <a href="https://www.loc.gov/marc/relators/relaterm.html">MARC
+												relators code list</a>. Can be used to reference other vocabularies
+											published by the Library of Congress.</td>
+									</tr>
+									<tr>
+										<td>media</td>
+										<td>http://www.idpf.org/epub/vocab/overlays/#</td>
+										<td>To declare properties from the <a href="#app-overlays-vocab">Media Overlays
+												vocabulary</a>.</td>
+									</tr>
+									<tr>
+										<td>onix</td>
+										<td>http://www.editeur.org/ONIX/book/codelists/<wbr />current.html#</td>
+										<td>Used in the <code>scheme</code> attribute to identify the <a
+												href="https://ns.editeur.org/onix/en">ONIX code list</a> a value
+											corresponds to.</td>
+									</tr>
+									<tr>
+										<td>rendition</td>
+										<td>http://www.idpf.org/vocab/rendition/#</td>
+										<td>To declare properties from the <a href="#app-rendering-vocab">Package
+												rendering vocabulary</a>.</td>
+									</tr>
+									<tr>
+										<td>schema</td>
+										<td>http://schema.org/</td>
+										<td>To declare properties from the <a href="https://schema.org">Schema.org
+												vocabulary</a>.</td>
+									</tr>
+								</tbody>
+							</table>
+						</dd>
+					</dl>
+				</section>
+			</section>
+
 			<section id="sec-shared-attrs">
 				<h3>Shared attributes</h3>
 
@@ -5563,7 +5934,7 @@ No Entry</pre>
 						<h5>Structural semantics</h5>
 
 						<p>The [^/epub:type^] attribute MAY be used in [=XHTML content documents=] to express <a
-								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
+								href="#sec-structural-semantics">structural semantics</a>.</p>
 
 						<p>The attribute MUST NOT be used on the <a data-cite="html#the-head-element"
 								><code>head</code></a> element or [=metadata content=] [[html]].</p>
@@ -6127,6 +6498,215 @@ No Entry</pre>
 
 						<p id="confreq-cd-scripted-foreign-resources">Scripts MUST only generate <a
 								href="#sec-core-media-types">core media type resources</a> or fragments thereof.</p>
+					</section>
+				</section>
+
+				<section id="sec-epub-type-attribute">
+					<h3>The <code>type</code> attribute</h3>
+					
+					<section id="sec-structural-semantics">
+						<h4>Structural semantics</h4>
+						
+						<p>Structural semantics add additional meaning about the specific structural purpose an element
+							plays. The [^/epub:type^] attribute is used to express domain-specific semantics in [=EPUB
+							content documents=], with the structural information it carries complementing the underlying
+							vocabulary.</p>
+						
+						<p>The applied semantics refine the meaning of their containing elements without changing their
+							nature for assistive technologies, as happens when using the similar [^/role^]
+							attribute&#160;[[html]]. The attribute does not enhance the accessibility of the content, in
+							other words; it only provides hints about the purpose.</p>
+						
+						<p>Semantic metadata enriches content for use in publishing workflows and for author-defined
+							purposes. It also allows [=reading systems=] to learn more about the structure and content
+							of a document (e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and
+								escapability</a> in media overlays).</p>
+						
+						<p>This specification defines a method for adding structural semantics using <em>the attribute
+								axis</em>: instead of adding new elements, the <code>epub:type</code> attribute can be
+							appended to existing elements to add the desired semantics.</p>
+						
+						<div class="note">
+							<p>The <code>type</code> attribute is also usable in [=media overlay documents=] to reflect
+								the semantic structure of the content being played back.</p>
+						</div>
+					</section>
+					
+					<section id="type-attr-syntax">
+						<h4>Syntax</h4>
+						<dl>
+							<dt>XHTML serialization</dt>
+							<dd>
+								<dl class="elemdef" id="attrdef-epub-type-xhtml">
+									<dt>Attribute Name:</dt>
+									<dd>
+										<p>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+												<code>epub:type</code>
+											</dfn>
+										</p>
+									</dd>
+									
+									<dt>Namespace:</dt>
+									<dd>
+										<p>
+											<code>http://www.idpf.org/2007/ops</code>
+										</p>
+									</dd>
+									
+									<dt>Usage:</dt>
+									<dd>
+										<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics"
+												>XHTML</a>, <a href="#confreq-svg-structural-semantics">SVG</a>, and <a
+													href="#sec-overlays-def">media overlays</a>.</p>
+									</dd>
+									
+									<dt>Value:</dt>
+									<dd>
+										<p>A <a data-cite="xml#NT-S">whitespace-separated</a> [[xml]] list of <a
+												href="#sec-property-datatype">property</a> values, with restrictions as
+											defined in <a href="#sec-vocab-assoc"></a>.</p>
+									</dd>
+								</dl>
+							</dd>
+							
+							<dt>HTML serialization</dt>
+							<dd>
+								<dl class="elemdef" id="attrdef-epub-type-html">
+									<dt>Attribute Name:</dt>
+									<dd>
+										<p>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+												<code>epub-type</code>
+											</dfn>
+										</p>
+									</dd>
+									
+									<dt>Usage:</dt>
+									<dd>
+										<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics"
+												>HTML</a>.</p>
+									</dd>
+									
+									<dt>Value:</dt>
+									<dd>
+										<p>A [=ASCII whitespace|whitespace-separated=] [[infra]] list of values that
+											SHOULD be taken from the EPUB 3 Structural Semantics Vocabulary
+											[[epub-ssv-11]].</p>
+									</dd>
+								</dl>
+							</dd>
+						</dl>
+						
+						<div class="ednote">
+							<p>Support for an HTML serialization of the <code>epub:type</code> attribute depends on the
+								addition of support for the <a href="#sec-xhtml">HTML syntax</a> in the EPUB 3.4
+								revision. It is <b><i>at risk</i></b>, depending on authors' and implementers'
+								feedback.</p>
+							
+							<p>The proposed <code>epub-type</code> will provide similar functionality for HTML content
+								documents but with some restrictions (namely, no extensibility through the
+								<code>epub:prefix</code> attribute). The attribute should be read as a replacement
+								for <code>epub:type</code> where this specification and the Reading Systems
+								specification [[epub-rs-34]] refer to that attribute for XHTML content documents. These
+								references will be updated once it is clearer that support will definitely be added in
+								this revision.</p>
+							
+							<p>The <code>epub:type</code> attribute will remain the sole means of including semantics in
+								XML grammars in EPUB (i.e., XHTML content documents, SVG content documents, and media
+								overlay documents).</p>
+							
+							<p>To provide feedback on this change, please open issues in the <a
+									href="https://github.com/w3c/epub-specs/issues">GitHub tracker for the EPUB
+									specifications</a>.</p>
+						</div>
+						
+						
+						<div class="caution">
+							<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
+								attribute&#160;[[html]], the attributes serve different purposes. The values of the
+								<code>epub:type</code> attribute do not enhance access through assistive
+								technologies like screen readers as they do not map to the accessibility <abbr
+									title="Application Programming Interfaces">APIs</abbr> used by these technologies.
+								This means that adding <code>epub:type</code> values to semantically neutral elements
+								like [[html]] [^div^] and [^span^] does not make them any more accessible to assistive
+								technologies. Only ARIA roles influence how assistive technologies understand such
+								elements.</p>
+							
+							<p>The <code>epub:type</code> attribute is consequently only intended for publishing
+								semantics and [=reading system=] enhancements. Reading systems can use
+								<code>epub:type</code> values to provide accessibility enhancements like built-in
+								read aloud or media overlays functionality where interaction with assistive technologies
+								is not essential.</p>
+							
+							<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
+									Module</a>&#160;[[?dpub-aria]] for more information about accessible publishing
+								roles.</p>
+						</div>
+						
+						<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears.
+							Its value is one or more whitespace-separated terms stemming from external vocabularies
+							associated with the document instance.</p>
+						
+						<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code>
+							attribute is the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The
+							prefix URL for referencing its properties is
+							<code>http://idpf.org/epub/vocab/structure/#</code>.</p>
+						
+						<p>Unprefixed terms that are not part of this vocabulary MAY be used but the preferred method
+							for adding custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them.
+							Refer to <a href="#sec-vocab-assoc"></a> for more information.</p>
+						
+						<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
+							<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+   …
+   &lt;body&gt;
+      …
+      &lt;section epub:type="preamble"&gt;
+         …
+      &lt;/section&gt;
+      …
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
+						</aside>
+						
+						<aside class="example" id="ex.epubtype.gloss" title="Identifying a glossary">
+							<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+   …
+   &lt;body&gt;
+      …
+      &lt;dl epub:type="glossary"&gt;
+         …
+      &lt;/dl&gt;
+      …
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
+						</aside>
+						
+						<aside class="example" id="ex.epubtype.pg" title="Adding page break semantics">
+							<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+   …
+   &lt;body&gt;
+      …
+      &lt;p&gt;
+         …
+         &lt;span
+            epub:type="pagebreak"
+            id="p234"
+            role="doc-pagebreak"
+            aria-label="234"/&gt;
+         …
+      &lt;/p&gt;
+      …
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
+						</aside>
 					</section>
 				</section>
 			</section>
@@ -8552,7 +9132,7 @@ No Entry</pre>
 				<section id="sec-docs-structural-semantic">
 					<h4>Structural semantics in overlays</h4>
 
-					<p>To express <a href="#app-structural-semantics">structural semantics</a> in [=media overlay
+					<p>To express <a href="#sec-structural-semantics">structural semantics</a> in [=media overlay
 						documents=], the [^/epub:type^] attribute MAY be specified on [^par^], [^seq^], and [^body^]
 						elements.</p>
 
@@ -10125,37 +10705,37 @@ EPUB/images/cover.png</pre>
 		</section>
 		<section id="app-viewport-meta" class="appendix">
 			<h2>The <code>viewport meta</code> tag</h2>
-			
+
 			<section id="app-viewport-meta-intro" class="informative">
 				<h3>Introduction</h3>
-				
+
 				<p>As the <a
 						href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6"
 						>Safari HTML definition</a> of the <code>viewport meta</code> tag, that was used in earlier
 					versions of EPUB&#160;3, is not an officially recognized standard, this specification defines a
 					basic syntax to allow <a href="#sec-fxl-icb-html">width and height dimensions</a> to be expressed
 					for [=fixed-layout documents=].</p>
-				
+
 				<p>The syntax of this grammar is also influenced by the parsing algorithm for the <code>viewport
 						meta</code> tag, as defined in [[css-viewport-1]].</p>
-				
+
 				<p>The syntax is intentionally left as generic as possible as it is not in this specification's scope to
 					define all the possible properties and values. It only defines the basic requirements for defining a
 					property and value pair as well as the possible separators between expressions.</p>
 			</section>
-			
+
 			<section id="app-viewport-meta-syntax">
 				<h3>Syntax</h3>
-				
+
 				<p>For [=fixed-layout documents=], a <code>viewport</code>
 					<a data-cite="html#the-meta-element"><code>meta</code></a> tag [[html]] MUST have <code>name</code>
 					and <code>content</code> attributes that conform to the following definition:</p>
-				
+
 				<dl>
 					<dt id="viewport-name-attr">name</dt>
 					<dd>The value of the [^meta/name^] attribute [[html]] after <a data-cite="xml#AVNormalize"
 							>whitespace normalization</a>&#160;[[xml]] MUST be <code>viewport</code>.</dd>
-					
+
 					<dt id="viewport-content-attr">content</dt>
 					<dd>
 						<p>The value of the [^meta/content^] attribute [[html]] after <a data-cite="xml#AVNormalize"
@@ -10230,233 +10810,37 @@ EPUB/images/cover.png</pre>
 						</table>
 					</dd>
 				</dl>
-				
+
 				<p>The only restriction on property <a href="#viewport.ebnf.name">names</a> and <a
 						href="#viewport.ebnf.value">values</a> is that they MUST NOT contain <a
-							href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
-								>assignment character</a>.</p>
-				
+						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
+						>assignment character</a>.</p>
+
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a>&#160;[[xml]] (i.e., after a reading
 					system strips leading and trailing whitespace and compacts all instances of multiple whitespace
 					within the attribute to single spaces). Any <a data-cite="xml#NT-S">whitespace characters</a>
 					[[xml]] MAY be included in the authored tag so long as the result is valid to this definition.</p>
-				
+
 				<div class="note">
 					<p>Although [[html]] <a data-cite="html#dependencies">depends on</a> the [[infra]] <a
 							data-cite="infra#ascii-whitespace">definition of whitespace</a>, the Form Feed (U+000C)
 						character is not valid whitespace per the [[xml]] definition. It cannot be used in the XML
 						syntax (i.e., in XHTML content documents).</p>
 				</div>
-				
+
 				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
-						><code>meta</code></a> element by the [[html]] grammar.</p>
-				
+							><code>meta</code></a> element by the [[html]] grammar.</p>
+
 				<div class="note">
 					<p>For more information about specifying the <code>height</code> and <code>width</code> properties
 						and their expected values, refer to <a href="#sec-fxl-content-dimensions"></a>.</p>
-					
+
 					<p>Although the <code>viewport meta</code> tag allows the use of properties other than
-						<code>height</code> and <code>width</code>, as well as to omit values for the
-						<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
+							<code>height</code> and <code>width</code>, as well as to omit values for the
+							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
 						properties could have unintended consequences on the rendering of fixed-layout documents.</p>
 				</div>
-			</section>
-		</section>
-		<section id="app-structural-semantics" class="appendix">
-			<h2>Expressing structural semantics</h2>
-
-			<section id="sec-structural-semantics-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
-					The [^/epub:type^] attribute is used to express domain-specific semantics in [=EPUB content
-					documents=] and [=media overlay documents=], with the structural information it carries
-					complementing the underlying vocabulary.</p>
-
-				<p>The applied semantics refine the meaning of their containing elements without changing their nature
-					for assistive technologies, as happens when using the similar [^/role^] attribute&#160;[[html]]. The
-					attribute does not enhance the accessibility of the content, in other words; it only provides hints
-					about the purpose.</p>
-
-				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
-					It also allows [=reading systems=] to learn more about the structure and content of a document
-					(e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and escapability</a> in media
-					overlays).</p>
-
-				<p>This specification defines a method for adding structural semantics using <em>the attribute
-					axis</em>: instead of adding new elements, the <code>epub:type</code> attribute can be appended to
-					existing elements to add the desired semantics.</p>
-			</section>
-
-			<section id="sec-epub-type-attribute">
-				<h3>The <code>type</code> attribute</h3>
-
-				<dl>
-					<dt>XHTML serialization</dt>
-					<dd>
-						<dl class="elemdef" id="attrdef-epub-type-xhtml">
-							<dt>Attribute Name:</dt>
-							<dd>
-								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
-										<code>epub:type</code>
-									</dfn>
-								</p>
-							</dd>
-
-							<dt>Namespace:</dt>
-							<dd>
-								<p>
-									<code>http://www.idpf.org/2007/ops</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a
-										href="#confreq-svg-structural-semantics">SVG</a>, and <a
-										href="#sec-overlays-def">media overlays</a>.</p>
-							</dd>
-
-							<dt>Value:</dt>
-							<dd>
-								<p>A <a data-cite="xml#NT-S">whitespace-separated</a> [[xml]] list of <a
-										href="#sec-property-datatype">property</a> values, with restrictions as defined
-									in <a href="#sec-vocab-assoc"></a>.</p>
-							</dd>
-						</dl>
-					</dd>
-
-					<dt>HTML serialization</dt>
-					<dd>
-						<dl class="elemdef" id="attrdef-epub-type-html">
-							<dt>Attribute Name:</dt>
-							<dd>
-								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
-										<code>epub-type</code>
-									</dfn>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">HTML</a>.</p>
-							</dd>
-
-							<dt>Value:</dt>
-							<dd>
-								<p>A [=ASCII whitespace|whitespace-separated=] [[infra]] list of values that SHOULD be
-									taken from the EPUB 3 Structural Semantics Vocabulary [[epub-ssv-11]].</p>
-							</dd>
-						</dl>
-					</dd>
-				</dl>
-
-				<div class="ednote">
-					<p>Support for an HTML serialization of the <code>epub:type</code> attribute depends on the addition
-						of support for the <a href="#sec-xhtml">HTML syntax</a> in the EPUB 3.4 revision. It is <b><i>at
-								risk</i></b>, depending on authors' and implementers' feedback.</p>
-
-					<p>The proposed <code>epub-type</code> will provide similar functionality for HTML content documents
-						but with some restrictions (namely, no extensibility through the <code>epub:prefix</code>
-						attribute). The attribute should be read as a replacement for <code>epub:type</code> where this
-						specification and the Reading Systems specification [[epub-rs-34]] refer to that attribute for
-						XHTML content documents. These references will be updated once it is clearer that support will
-						definitely be added in this revision.</p>
-
-					<p>The <code>epub:type</code> attribute will remain the sole means of including semantics in XML
-						grammars in EPUB (i.e., XHTML content documents, SVG content documents, and media overlay
-						documents).</p>
-
-					<p>To provide feedback on this change, please open issues in the <a
-							href="https://github.com/w3c/epub-specs/issues">GitHub tracker for the EPUB
-							specifications</a>.</p>
-				</div>
-
-
-				<div class="caution">
-					<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
-						attribute&#160;[[html]], the attributes serve different purposes. The values of the
-							<code>epub:type</code> attribute do not enhance access through assistive technologies like
-						screen readers as they do not map to the accessibility <abbr
-							title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
-						means that adding <code>epub:type</code> values to semantically neutral elements like [[html]]
-						[^div^] and [^span^] does not make them any more accessible to assistive technologies. Only ARIA
-						roles influence how assistive technologies understand such elements.</p>
-
-					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
-						[=reading system=] enhancements. Reading systems can use <code>epub:type</code> values to
-						provide accessibility enhancements like built-in read aloud or media overlays functionality
-						where interaction with assistive technologies is not essential.</p>
-
-					<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
-						Module</a>&#160;[[?dpub-aria]] for more information about accessible publishing roles.</p>
-				</div>
-
-				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
-					is one or more whitespace-separated terms stemming from external vocabularies associated with the
-					document instance.</p>
-
-				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB&#160;3 Structural Semantics Vocabulary&#160;[[?epub-ssv-11]]. The prefix URL for
-					referencing its properties is <code>http://idpf.org/epub/vocab/structure/#</code>.</p>
-
-				<p>Unprefixed terms that are not part of this vocabulary MAY be used but the preferred method for adding
-					custom semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
-						href="#sec-vocab-assoc"></a> for more information.</p>
-
-				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
-					<pre>&lt;html
-    …
-    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-   …
-   &lt;body&gt;
-      …
-      &lt;section epub:type="preamble"&gt;
-         …
-      &lt;/section&gt;
-      …
-   &lt;/body&gt;
-&lt;/html&gt;</pre>
-				</aside>
-
-				<aside class="example" id="ex.epubtype.gloss" title="Identifying a glossary">
-					<pre>&lt;html
-    …
-    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-   …
-   &lt;body&gt;
-      …
-      &lt;dl epub:type="glossary"&gt;
-         …
-      &lt;/dl&gt;
-      …
-   &lt;/body&gt;
-&lt;/html&gt;</pre>
-				</aside>
-
-				<aside class="example" id="ex.epubtype.pg" title="Adding page break semantics">
-					<pre>&lt;html
-    …
-    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-   …
-   &lt;body&gt;
-      …
-      &lt;p&gt;
-         …
-         &lt;span
-            epub:type="pagebreak"
-            id="p234"
-            role="doc-pagebreak"
-            aria-label="234"/&gt;
-         …
-      &lt;/p&gt;
-      …
-   &lt;/body&gt;
-&lt;/html&gt;</pre>
-				</aside>
 			</section>
 		</section>
 		<section id="app-vocabs" class="appendix">
@@ -10464,373 +10848,6 @@ EPUB/images/cover.png</pre>
 
 			<p>This appendix defines a general set of mechanisms by which attributes in this specification can reference
 				terms from vocabularies. It also defines EPUB-specific vocabularies for use with the attributes.</p>
-
-			<section id="sec-vocab-assoc">
-				<h3>Vocabulary association mechanisms</h3>
-
-				<section id="sec-vocab-assoc-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
-						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
-							<code>epub:type</code> attribute uses this data type in [=EPUB content documents=] and
-						[=media overlay documents=] to add <a href="#app-structural-semantics">structural semantics</a>,
-						for example, while the <code>property</code> and <code>rel</code> attributes use the data type
-						to define properties and relationships in the [=package document=].</p>
-
-					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] — it represents a URL [[url]] in
-						compact form. The expression consists of a prefix and a reference, where the prefix — whether
-						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
-						vocabulary. When a [=reading system=] converts the prefix to its URL representation and combines
-						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
-						that contains human- and/or machine-readable information about the term.</p>
-
-					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
-						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
-						referenced from the default vocabularies do not include a prefix as the mapping reading systems
-						use to map to a URL is predefined.</p>
-
-					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
-						terms and properties, it is only necessary to declare a <a href="#sec-prefix-attr">prefix</a>.
-						In another authoring convenience, this specification also <a
-							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
-						publishing vocabularies (i.e., their declaration is not required).</p>
-
-					<p>The following sections provide additional details on the <var>property</var> data type and
-						vocabulary association mechanism.</p>
-				</section>
-
-				<section id="sec-property-datatype">
-					<h4>The <var>property</var> data type</h4>
-
-					<p>The <var>property</var> data type is a compact means of expressing a URL [[url]] and consists of
-						an OPTIONAL prefix separated from a reference by a colon.</p>
-
-					<table class="productionset">
-						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
-							<code>xsd:</code>.</caption>
-						<tbody>
-							<tr>
-								<td id="property.ebnf.property">
-									<a href="#property.ebnf.property">property</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-										href="#property.ebnf.reference">reference</a>; </td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.prefix">
-									<a href="#property.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.reference">
-									<a href="#property.ebnf.reference">reference</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? [=path-relative-scheme-less-URL string=] [[url]] ? ;</td>
-								<td>/*&#160;as defined in [[url]]&#160;*/<br /></td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
-						[[rdfa-core]]. A <var>property</var> represents a subset of CURIEs.</p>
-
-					<p>There are two key differences from CURIEs, however:</p>
-
-					<ul>
-						<li>
-							<p>an empty <var>reference</var> does not represent a valid <var>property</var> value even
-								though it is valid to the definition above (i.e., a <var>property</var> value that only
-								consists of a prefix and colon is invalid).</p>
-						</li>
-						<li>
-							<p>an empty string does not represent a valid <var>property</var> even though it is valid to
-								the definition above.</p>
-						</li>
-					</ul>
-
-					<aside class="example" title="Expanding a metadata property value">
-						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
-							and the reference <code>modified</code>.</p>
-
-						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
-
-						<p>After <a data-cite="epub-rs-34#sec-property-values">processing</a> [[epub-rs-34]], this
-							property would expand to the following URL:</p>
-
-						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
-						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
-					</aside>
-
-					<p>When a prefix is omitted from a <var>property</var> value, the specified term is taken from the
-							<a href="#sec-default-vocab">default vocabulary</a> for that attribute.</p>
-
-					<aside class="example" title="Expanding a manifest property value">
-						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
-							manifest [^item^] element:</p>
-
-						<pre>&lt;item … properties="mathml"/&gt;</pre>
-
-						<p>This property expands to:</p>
-
-						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-
-						<p>when the prefix URL for the vocabulary is concatenated with the reference.</p>
-					</aside>
-				</section>
-
-				<section id="sec-default-vocab">
-					<h5>Default vocabularies</h5>
-
-					<p>A default vocabulary is one whose terms and properties MUST NOT have a <a href="#sec-prefix-attr"
-							>prefix</a> when a <a href="#sec-property-datatype"><var>property</var> value</a> is
-						expected.</p>
-
-					<p>A prefix MUST NOT be assigned to the URLs associated with these vocabularies using the <a
-							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-
-					<div class="note">
-						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
-									><var>property</var> data type</a> for more information about its default
-							vocabulary.</p>
-					</div>
-				</section>
-
-				<section id="sec-prefix-attr" data-epubcheck="true"
-					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L671,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L694,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L17,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L22,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L28,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L34">
-					<h4>The <code>prefix</code> attribute</h4>
-
-					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
-							href="#sec-property-datatype"><var>property</var> values</a>.</p>
-
-					<p>The value of the <code>prefix</code> attribute is a whitespace-separated list of one or more
-						prefix-to-URL mappings of the form:</p>
-
-					<table class="productionset">
-						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
-							<code>xsd:</code>.</caption>
-						<tbody>
-							<tr>
-								<td id="prefix.ebnf.def">
-									<a href="#prefix.ebnf.def">prefixes</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.mapping">
-									<a href="#prefix.ebnf.mapping">mapping</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
-										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.prefix">
-									<a href="#prefix.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.space">
-									<a href="#prefix.ebnf.space">space</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>#x20 ;</td>
-								<td>&#160;</td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.whitespace">
-									<a href="#prefix.ebnf.whitespace">whitespace</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>(#x20 | #x9 | #xD | #xA) ;</td>
-								<td>&#160;</td>
-							</tr>
-						</tbody>
-					</table>
-
-					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, all prefixes used
-						in a document MUST be declared. The <code>prefix</code> attribute MUST be specified only on the
-							<a data-cite="xml#dt-root">root element</a> [[xml]] of the respective format.</p>
-
-					<p>The attribute is not namespaced when used in the [=package document=].</p>
-
-					<aside class="example" title="Declaring prefixes in the package document">
-						<p>In this example, the prefixes for the Friend of a Friend (<code>foaf</code>) and DBPedia
-								(<code>dbp</code>) vocabularies are declared in the <code>prefix</code> attribute.</p>
-
-						<pre>&lt;package
-    …
-    prefix="foaf: http://xmlns.com/foaf/spec/
-            dbp: http://dbpedia.org/ontology/"&gt;
-   …
-&lt;/package&gt;</pre>
-					</aside>
-
-					<p>The attribute MUST be declared in the namespace <code>http://www.idpf.org/2007/ops</code> when
-						used in [=EPUB content documents=] and [=media overlay documents=].</p>
-
-					<aside class="example" title="Declaring prefixes in an XHTML content document">
-						<p>In this example, a prefix is declared for the Z39.98 Structural Semantics Vocabulary.</p>
-
-						<pre>&lt;html …
-      xmlns:epub="http://www.idpf.org/2007/ops"
-      epub:prefix="z3998: https://www.daisy.org/z3998/2012/vocab/structure/"&gt;
-   …
-&lt;/html&gt;</pre>
-					</aside>
-
-					<div class="note">
-						<p>Although the <code>prefix</code> attribute is modeled on the identically named
-								<code>prefix</code> attribute in [[rdfa-core]], the attributes cannot be used
-							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB content
-							documents is the RDFa attribute.</p>
-
-						<p>It is common for both attributes to appear in EPUB content documents that also specify RDFa
-							expressions.</p>
-
-						<pre>&lt;html … prefix="…"
-        xmlns:epub="http://www.idpf.org/2007/ops"
-        epub:prefix="…"&gt;   …
-&lt;/html&gt;</pre>
-					</div>
-
-					<p>Note that for <a href="#sec-xhtml-svg-inclusion">SVG embedded by inclusion</a>, prefixes MUST be
-						declared on the [[html]] root [^html^] element.</p>
-
-					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
-						maps to a <a href="#sec-default-vocab">default vocabulary</a>.</p>
-
-					<p>The prefix '_' MUST NOT be declared as this specification reserves this prefix for future
-						compatibility with RDFa [[rdfa-core]] processing.</p>
-
-					<p>For future compatibility with alternative serializations of the package document, a prefix MUST
-						NOT be declared for the Dublin Core <em>/elements/1.1/</em> namespace [[dcterms]]. Only the
-						[[dcterms]] elements are <a href="#sec-pkg-metadata">allowed in the package document
-							metadata</a>.</p>
-				</section>
-
-				<section id="sec-reserved-prefixes">
-					<h4>Reserved prefixes</h4>
-
-					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, they can cause issues. Vendors, for
-							example, will often reject new prefixes until they update their [=EPUB conformance
-							checkers=]. It is advised to declare all prefixes to avoid any issues.</p>
-					</div>
-
-					<p>Reserved prefixes MAY be used in attributes that expect a <a href="#sec-property-datatype"
-								><var>property</var> value</a> without declaring them in a <a href="#sec-prefix-attr"
-								><code>prefix</code> attribute</a>.</p>
-
-
-					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
-							attribute</a>.</p>
-
-					<p>The reserved prefixes that can be used depends on the context:</p>
-
-					<dl class="conformance-list">
-						<dt>Package document</dt>
-						<dd id="sec-metadata-reserved-prefixes">
-							<p>The following prefixes MAY be used in [=package document=] attributes without having to
-								declare them.</p>
-							<table id="tbl-pkg-reserved-prefixes" class="prefix">
-								<thead>
-									<tr>
-										<th>Prefix</th>
-										<th>URL</th>
-										<th>Usage</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td>a11y</td>
-										<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
-										<td>To declare properties from them EPUB Accessibility namespace. These are
-											typically defined in <a data-cite="epub-a11y-12#app-a11y-vocab">EPUB
-												Accessibility 1.2</a> [[epub-a11y-12]].</td>
-									</tr>
-									<tr>
-										<td>dcterms</td>
-										<td>http://purl.org/dc/terms/</td>
-										<td>To declare properties from the <a data-cite="dcterms#section-2">Dublin Core
-												/terms/ namespace</a> [[dcterms]].</td>
-									</tr>
-									<tr>
-										<td>marc</td>
-										<td>http://id.loc.gov/vocabulary/</td>
-										<td>Primarily used in the <a href="#attrdef-scheme"><code>scheme</code>
-												attribute</a> to indicate that creator and contributor roles are defined
-											in the the <a href="https://www.loc.gov/marc/relators/relaterm.html">MARC
-												relators code list</a>. Can be used to reference other vocabularies
-											published by the Library of Congress.</td>
-									</tr>
-									<tr>
-										<td>media</td>
-										<td>http://www.idpf.org/epub/vocab/overlays/#</td>
-										<td>To declare properties from the <a href="#app-overlays-vocab">Media Overlays
-												vocabulary</a>.</td>
-									</tr>
-									<tr>
-										<td>onix</td>
-										<td>http://www.editeur.org/ONIX/book/codelists/<wbr />current.html#</td>
-										<td>Used in the <code>scheme</code> attribute to identify the <a
-												href="https://ns.editeur.org/onix/en">ONIX code list</a> a value
-											corresponds to.</td>
-									</tr>
-									<tr>
-										<td>rendition</td>
-										<td>http://www.idpf.org/vocab/rendition/#</td>
-										<td>To declare properties from the <a href="#app-rendering-vocab">Package
-												rendering vocabulary</a>.</td>
-									</tr>
-									<tr>
-										<td>schema</td>
-										<td>http://schema.org/</td>
-										<td>To declare properties from the <a href="https://schema.org">Schema.org
-												vocabulary</a>.</td>
-									</tr>
-								</tbody>
-							</table>
-						</dd>
-					</dl>
-				</section>
-			</section>
 
 			<section id="sec-property-field-definitions">
 				<h3>Property field definitions</h3>
@@ -10897,18 +10914,18 @@ EPUB/images/cover.png</pre>
 		</section>
 		<section id="app-obsolete" class="appendix">
 			<h2>Obsolete features</h2>
-			
+
 			<section id="sec-obs-conform">
 				<h3>Obsolete but conforming features</h3>
-				
+
 				<p>An <dfn id="obsolete-but-conforming">obsolete but conforming</dfn> feature is one that is not
 					deprecated but that is also either not designed for use in EPUB 3 [=reading systems=] or that would
 					ideally be [=deprecated=] except that it would invalidate a significant base of existing [=EPUB
 					publications=].</p>
-				
+
 				<p>[=EPUB publications=] MAY include the obsolete but conforming features defined in this section. Their
 					usage MUST conform to their referenced definitions.</p>
-				
+
 				<dl>
 					<dt>Open Container Format (OCF)</dt>
 					<dd>
@@ -10929,7 +10946,7 @@ EPUB/images/cover.png</pre>
 							</li>
 						</ul>
 					</dd>
-					
+
 					<dt id="sec-pkg-collections">Collections</dt>
 					<dd>
 						<ul>
@@ -10944,20 +10961,20 @@ EPUB/images/cover.png</pre>
 								no longer advised.</p>
 						</div>
 					</dd>
-					
+
 					<dt id="sec-pkg-legacy">Legacy features</dt>
 					<dd>
 						<ul>
 							<li id="sec-opf2-meta">
 								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2">OPF 2
-										<code>meta</code> element</a> [[opf-201]]</p>
+											<code>meta</code> element</a> [[opf-201]]</p>
 							</li>
-							
+
 							<li id="sec-opf2-guide">
 								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">OPF 2
-										<code>guide</code> element</a>&#160;[[opf-201]]</p>
+											<code>guide</code> element</a>&#160;[[opf-201]]</p>
 							</li>
-							
+
 							<li id="sec-opf2-ncx">
 								<p><a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">OPF 2
 										NCX</a> [[opf-201]]</p>
@@ -10972,46 +10989,46 @@ EPUB/images/cover.png</pre>
 								including these features has limited value.</p>
 						</div>
 					</dd>
-					
+
 					<dt id="css-prefixes">Prefixed CSS properties</dt>
 					<dd>
 						<ul>
 							<li id="sec-css-prefixed-writing-modes-text-orientation">
 								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-orientation"
-									><code>-epub-text-orientation</code></a> [[epub-33]]</li>
+										><code>-epub-text-orientation</code></a> [[epub-33]]</li>
 							<li id="sec-css-prefixed-writing-modes-writing-mode">
 								<a data-cite="epub-33#sec-css-prefixed-writing-modes-writing-mode"
-									><code>-epub-writing-mode</code></a> [[epub-33]] </li>
+										><code>-epub-writing-mode</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-writing-modes-text-combine">
 								<a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
-									><code>-epub-text-combine-horizontal</code></a> [[epub-33]] </li>
+										><code>-epub-text-combine-horizontal</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-text-epub-hyphens">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-hyphens"><code>-epub-hyphens</code></a>
 								[[epub-33]] </li>
 							<li id="sec-css-prefixed-text-epub-line-break">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-line-break"
-									><code>-epub-line-break</code></a> [[epub-33]] </li>
+										><code>-epub-line-break</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-text-epub-text-align-last">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-align-last"
-									><code>-epub-text-align-last</code></a> [[epub-33]] </li>
+										><code>-epub-text-align-last</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-text-epub-word-break">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-word-break"
-									><code>-epub-word-break</code></a> [[epub-33]] </li>
+										><code>-epub-word-break</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-text-text-transform"><code>text-transform</code> value <a
 									data-cite="epub-33#sec-css-prefixed-text-text-transform"
-									><code>-epub-fullwidth</code></a> [[epub-33]]</li>
+										><code>-epub-fullwidth</code></a> [[epub-33]]</li>
 							<li id="sec-css-prefixed-text-epub-text-emphasis-color">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-color"
-									><code>-epub-text-emphasis-color</code></a> [[epub-33]] </li>
+										><code>-epub-text-emphasis-color</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-text-epub-text-emphasis-position">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-position"
-									><code>-epub-text-emphasis-position</code></a> [[epub-33]] </li>
+										><code>-epub-text-emphasis-position</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-text-epub-text-emphasis-style">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-emphasis-style"
-									><code>-epub-text-emphasis-style</code></a> [[epub-33]] </li>
+										><code>-epub-text-emphasis-style</code></a> [[epub-33]] </li>
 							<li id="sec-css-prefixed-text-epub-text-underline-position">
 								<a data-cite="epub-33#sec-css-prefixed-text-epub-text-underline-position"
-									><code>-epub-text-underline-position</code></a> [[epub-33]] </li>
+										><code>-epub-text-underline-position</code></a> [[epub-33]] </li>
 						</ul>
 						<div class="caution">
 							<p>EPUB 3 originally included these prefixed properties as many CSS features related to
@@ -11022,23 +11039,23 @@ EPUB/images/cover.png</pre>
 						</div>
 					</dd>
 				</dl>
-				
+
 				<div class="note">
 					<p>The Working Group advises that [=EPUB conformance checkers=] not issue alerts about the presence
 						of obsolete but conforming features in [=EPUB publications=]. Only issue alerts if a feature
 						does not conform to its definition or otherwise breaks a usage requirement.</p>
 				</div>
 			</section>
-			
+
 			<section id="sec-obs-deprecated">
 				<h3>Deprecated features</h3>
-				
+
 				<p>A <dfn id="deprecated">deprecated</dfn> feature is one that has limited or no support in [=reading
 					systems=] and/or usage in [=EPUB publications=].</p>
-				
+
 				<p>The following deprecated features SHOULD NOT be used. When used, their usage MUST conform to their
 					referenced definitions.</p>
-				
+
 				<dl>
 					<dt>Package document</dt>
 					<dd>
@@ -11046,9 +11063,9 @@ EPUB/images/cover.png</pre>
 							<li>
 								<p id="sec-opf-bindings"><a
 										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
-										><code>bindings</code> element</a> [[epubpublications-301]]</p>
+											><code>bindings</code> element</a> [[epubpublications-301]]</p>
 							</li>
-							
+
 							<li>
 								<p id="sec-defining-collection-types"><a
 										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
@@ -11056,49 +11073,49 @@ EPUB/images/cover.png</pre>
 							</li>
 						</ul>
 					</dd>
-					
+
 					<dt>XHTML content documents</dt>
 					<dd>
 						<ul>
 							<li id="sec-xhtml-content-switch">
 								<p><a
 										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
-										><code>switch</code> element</a> [[epubcontentdocs-301]]</p>
+											><code>switch</code> element</a> [[epubcontentdocs-301]]</p>
 							</li>
-							
+
 							<li>
 								<p id="sec-xhtml-epub-trigger"><a
 										href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
-										><code>epub:trigger</code> element</a> [[epubcontentdocs-301]]</p>
+											><code>epub:trigger</code> element</a> [[epubcontentdocs-301]]</p>
 							</li>
 						</ul>
 					</dd>
-					
+
 					<dt>Fixed layouts</dt>
 					<dd>
 						<ul>
 							<li>
 								<p><a href="https://idpf.org/epub/301/spec/epub-publications.html#fxl-property-spread"
-										><code>rendition:spread</code> property with the value
+											><code>rendition:spread</code> property with the value
 										<code>portrait</code></a> [[epubpublications-301]] &#8212; use the value
-									"<code>both</code>" instead.</p>
+										"<code>both</code>" instead.</p>
 							</li>
 							<li>
 								<p id="spread-portrait"><a
 										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
-										><code>spread-portrait</code> property</a> [[epubpublications-301]] &#8212;
+											><code>spread-portrait</code> property</a> [[epubpublications-301]] &#8212;
 									use the property "<code>rendition:spread-both</code>" instead.</p>
 							</li>
 							<li>
 								<p id="viewport" data-epubcheck="true"
 									data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L187"
-									><a
+										><a
 										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
-										><code>rendition:viewport</code> property</a> [[epubpublications-301]]</p>
+											><code>rendition:viewport</code> property</a> [[epubpublications-301]]</p>
 							</li>
 						</ul>
 					</dd>
-					
+
 					<dt>Vocabulary association mechanisms</dt>
 					<dd>
 						<ul>
@@ -11112,73 +11129,73 @@ EPUB/images/cover.png</pre>
 							</li>
 						</ul>
 					</dd>
-					
+
 					<dt>Meta properties vocabulary</dt>
 					<dd>
 						<ul>
 							<li>
 								<p id="sec-meta-auth"><a
 										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
-										><code>meta-auth</code> property</a> [[!epubpublications-30]]</p>
+											><code>meta-auth</code> property</a> [[!epubpublications-30]]</p>
 							</li>
 						</ul>
 					</dd>
-					
+
 					<dt>Link relationships vocabulary</dt>
 					<dd>
 						<ul>
 							<li>
 								<p id="sec-marc21xml-record"><a
 										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"
-										><code>marc21xml-record</code> property</a> [[!epubpublications-30]] &#8212;
+											><code>marc21xml-record</code> property</a> [[!epubpublications-30]] &#8212;
 									It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
 										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-									"<code>application/marcxml+xml</code>".</p>
+										"<code>application/marcxml+xml</code>".</p>
 							</li>
-							
+
 							<li>
 								<p id="sec-mods-record"><a
 										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"
-										><code>mods-record</code> property</a> [[!epubpublications-30]] &#8212; It
+											><code>mods-record</code> property</a> [[!epubpublications-30]] &#8212; It
 									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
 										href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-									"<code>application/mods+xml</code>".</p>
+										"<code>application/mods+xml</code>".</p>
 							</li>
-							
+
 							<li>
 								<p id="sec-onix-record"><a
 										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"
-										><code>onix-record</code> property</a> [[!epubpublications-30]] &#8212; It
+											><code>onix-record</code> property</a> [[!epubpublications-30]] &#8212; It
 									is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
 										href="#attrdef-properties">properties attribute</a> value <a href="#onix"
 											><code>onix</code></a>.</p>
 							</li>
-							
+
 							<li>
 								<p id="sec-xml-signature"><a
 										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"
-										><code>xml-signature</code> property</a> [[!epubpublications-30]]</p>
+											><code>xml-signature</code> property</a> [[!epubpublications-30]]</p>
 							</li>
-							
+
 							<li>
 								<p id="sec-xmp-record"><a
 										href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"
-										><code>xmp-record</code> property</a> [[!epubpublications-30]]</p>
+											><code>xmp-record</code> property</a> [[!epubpublications-30]]</p>
 							</li>
 						</ul>
 					</dd>
-					
+
 					<dt>Prefixed CSS properties</dt>
 					<dd>
 						<ul>
 							<li>
 								<p><a data-cite="epub-33#sec-css-prefixed-writing-modes-text-combine"
-										><code>-epub-text-combine</code></a> [[epub-33]]</p>
+											><code>-epub-text-combine</code></a> [[epub-33]]</p>
 							</li>
 						</ul>
 					</dd>
 				</dl>
-				
+
 				<div class="note">
 					<p>The Working Group recommends that [=EPUB conformance checkers=] alert about the presence of
 						deprecated features when encountered in EPUB publications.</p>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -10,7 +10,6 @@
 		<script src="../../common/js/data-test-display.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
-			//<![CDATA[
 			var respecConfig = {
 				group: "pm",
 				wgPublicList: "public-pm-wg",
@@ -125,7 +124,8 @@
 						]
 					}
 				 ] */
-			};//]]></script>
+			};
+		</script>
 		<style>
 			#change-log > details > p {
 				margin-left: 1rem;


### PR DESCRIPTION
This pull request started from the discussion in https://github.com/w3c/epub-specs/pull/2814#pullrequestreview-3313313766 about where the obsolete features belong in the list of appendixes but I ended up trying to fix a couple of lost sections buried in the appendixes at the same time:

- The "vocabulary association mechanisms" section was buried under the vocabularies appendix even though it's central to the package document. We did this because it's also applies (to a much lesser extent in practice) to the epub:type attribute, but squirreling it away in an appendix means you end up reading the package document section without really understanding anything up front about prefix attribute, default vocabularies, etc. You have to follow links to make your way back to the appendix.
- The "expressing structural semantics" appendix is similar in that it covers epub:type for content documents, but again, because it can be used in media overlays it ended up in an appendix even though the use is the same for each.

To fix these issues, I moved vocabulary association mechanisms under the package document section and added a note to the introduction to highlight that it also applies to structural semantics. And for the type attribute I moved it under the shared technologies in the section on epub content documents (again adding a note to highlight that applies to media overlays). It's not perfect, but at least it gets the definitions into the body and as close to their primary use cases as possible.

The rest of the pull request is just a minor shuffling of the remaining appendixes:

A. Detailed examples
B. Allowed external identifiers
C. The viewport meta tag
D. Vocabularies
E. Obsolete features
F. Schemas
G. Media type registrations

I moved the examples to the front of the list as they get lost and are out of place when squashed between technical details.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2818.html" title="Last updated on Oct 15, 2025, 2:27 PM UTC (abf692e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2818/7d45572...abf692e.html" title="Last updated on Oct 15, 2025, 2:27 PM UTC (abf692e)">Diff</a>