### PR TITLE
Clarify sentence in accessibility specification

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>
@@ -157,10 +157,10 @@
 				</ul>
 
 				<p>The provision of accessibility metadata facilitates informed decisions about the usability of an EPUB
-					publication. Consumers can review the qualities of the content and decide whether an EPUB
-					publication is appropriate for their needs, regardless of whether it meets the bar of accessible
-					certification. At a minimum, all EPUB publications that conform to this specification meet the
-					accessibility metadata requirements described in <a href="#sec-discovery"></a>.</p>
+					publication. It allows consumers to review the accessible qualities of the content and decide
+					whether an EPUB publication is appropriate for their needs, regardless of whether it meets the bar
+					of accessible certification. At a minimum, all EPUB publications that conform to this specification
+					meet the accessibility metadata requirements described in <a href="#sec-discovery"></a>.</p>
 
 				<p>Although creating EPUB publications with a high degree of accessibility has always been possible,
 					this specification sets formal requirements for certifying content accessible. These requirements

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.2</title>
@@ -302,7 +302,7 @@
 				<p>All <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MUST include [[schema-org]]
 					accessibility metadata in the <a data-cite="epub/#dfn-package-document">package document</a> that
 					exposes their accessible properties, regardless of whether the publications also meet the <a
-						href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs">optimization</a>
+						href="#sec-accessible-pubs">accessibility</a> or <a href="#app-optimized-pubs">optimization</a>
 					requirements.</p>
 
 				<p>EPUB publications MUST include the following accessibility metadata:</p>


### PR DESCRIPTION
Implements the fix in https://github.com/w3c/epub-specs/issues/2793#issuecomment-3303415447

Fixes #2793 

***

[Preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2793/epub34/a11y/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/epub34/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2793/epub34/a11y/index.html)