### PR TITLE
Generalize the feature support caution

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -207,8 +207,10 @@
 						of EPUB publications is immediate. Others are updated less frequently and the changes might not
 						affect [=EPUB publications=] until EPUB 3 undergoes a new revision.</p>
 					<p>In all cases, it is possible that previously valid features might become obsolete (e.g., due to a
-						lack of support or because of security issues). Consequently, it is advised to only use features
-						without broad support sparingly and keep [=EPUB conformance checkers=] up to date.</p>
+						lack of support or because of security issues). It is also possible that new features become
+						available to use before they are widely supported in [=reading systems=].</p>
+					<p>Consequently, it is advised to only use features with broad support and keep [=EPUB conformance
+						checkers=] up to date.</p>
 				</div>
 
 				<section id="sec-overview-relations-html">
@@ -5743,12 +5745,6 @@ No Entry</pre>
 
 			<section id="sec-svg">
 				<h3>SVG content documents</h3>
-
-				<div class="caution">
-					<p>[=Reading systems=] might not support all the features of [[svg]] or support them across all
-						platforms that reading systems run on. When utilizing such features, consider the risks to
-						interoperability and document longevity.</p>
-				</div>
 
 				<section id="sec-svg-intro" class="informative">
 					<h4>Introduction</h4>


### PR DESCRIPTION
This pull request removes the generic caution box at the start of the SVG content documents section and adds a sentence to the caution box in the relationship to other specifications section to explain that features may become available to use before they are widely supported in reading systems.

Fixes #2803


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2820.html" title="Last updated on Oct 14, 2025, 10:57 PM UTC (20cbde8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2820/042553c...20cbde8.html" title="Last updated on Oct 14, 2025, 10:57 PM UTC (20cbde8)">Diff</a>