### PR TITLE
Handling broken links in RS

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1205,8 +1205,8 @@
 					<li>
 						<p id="confreq-css-rs-prefixed"
 							data-tests="#css-epub-hyphens, #css-epub-line-break, #css-epub-text-align-last, #css-epub-text-combine-horizontal, #css-epub-text-emphasis, #css-epub-text-orientation, #css-epub-text-transform, #css-epub-text-underline-position, #css-epub-word-break, #css-epub-writing-mode"
-							>SHOULD support all prefixed properties defined in <a data-cite="epub-34#sec-css-prefixed"
-								>CSS Style Sheets — Prefixed properties</a> [[epub-34]].</p>
+							>SHOULD support all prefixed properties defined in <a data-cite="epub-33#sec-css-prefixed"
+								>CSS Style Sheets — Prefixed properties</a> [[epub-33]].</p>
 					</li>
 					<li>
 						<p id="confreq-css-creator-styles">SHOULD apply style sheets referenced from [=EPUB content
@@ -2052,7 +2052,7 @@
 			<h2>Processing structural semantics</h2>
 
 			<p id="confreq-rs-epub-epub-type" class="support" data-tests="#pss-support">[=Reading systems=] MAY support
-					<a data-cite="epub-34#app-structural-semantics">structural semantics</a> [[epub-34]] in <a>EPUB
+					<a data-cite="epub-34#sec-structural-semantics">structural semantics</a> [[epub-34]] in <a>EPUB
 					content documents</a>.</p>
 
 			<p>When processing the [^/epub:type^] attribute, a reading system:</p>


### PR DESCRIPTION
This PR is to fix #2822

I hope these are the right replacements...

See:

* For EPUB 3.4 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/Issue-2822-broken-links/epub34/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/Issue-2822-broken-links/epub34/rs/index.html)

