### PR TITLE
Updated fragment ID-s

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2128,11 +2128,11 @@
 							<li><var>expandedURL</var> will hold the final URL that results from the concatenation of
 								the base URL and property reference.</li>
 							<li><var>propertyPrefix</var> will hold the property's <a
-									data-cite="epub-33#compact-url.ebnf.prefix">prefix</a> [[epub-33]] (i.e., the value
+									data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]] (i.e., the value
 								before the colon). Properties from a default vocabulary will not have a prefix, but all
 								others will.</li>
 							<li><var>propertyReference</var> will hold the property's <a
-									data-cite="epub-33#compact-url.ebnf.reference">reference</a> [[epub-33]] (i.e., the
+									data-cite="epub-33#property.ebnf.reference">reference</a> [[epub-33]] (i.e., the
 								value after the prefix). All valid properties require a reference.</li>
 						</ul>
 					</details>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2128,11 +2128,11 @@
 							<li><var>expandedURL</var> will hold the final URL that results from the concatenation of
 								the base URL and property reference.</li>
 							<li><var>propertyPrefix</var> will hold the property's <a
-									data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]] (i.e., the value
+									data-cite="epub-33#compact-url.ebnf.prefix">prefix</a> [[epub-33]] (i.e., the value
 								before the colon). Properties from a default vocabulary will not have a prefix, but all
 								others will.</li>
 							<li><var>propertyReference</var> will hold the property's <a
-									data-cite="epub-33#property.ebnf.reference">reference</a> [[epub-33]] (i.e., the
+									data-cite="epub-33#compact-url.ebnf.reference">reference</a> [[epub-33]] (i.e., the
 								value after the prefix). All valid properties require a reference.</li>
 						</ul>
 					</details>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2123,11 +2123,11 @@
 							<li><var>expandedURL</var> will hold the final URL that results from the concatenation of
 								the base URL and reference.</li>
 							<li><var>prefix</var> will hold the compact URL's <a
-									data-cite="epub-34#property.ebnf.prefix">prefix</a> [[epub-34]] (i.e., the value
+									data-cite="epub-34#compact-url.ebnf.prefix">prefix</a> [[epub-34]] (i.e., the value
 								before the colon). Properties from a default vocabulary will not have a prefix, but all
 								others will.</li>
 							<li><var>reference</var> will hold the compact URL's <a
-									data-cite="epub-34#property.ebnf.reference">reference</a> [[epub-34]] (i.e., the
+									data-cite="epub-34#compact-url.ebnf.reference">reference</a> [[epub-34]] (i.e., the
 								value after the prefix). All valid properties require a reference.</li>
 						</ul>
 					</details>


### PR DESCRIPTION
Fix #2826 : leftover fragment ID-s from before renaming the property datatype.