### PR TITLE
deprecated the rendition:orientation property

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -7421,87 +7421,6 @@ No Entry</pre>
 						</section>
 					</section>
 
-					<section id="orientation" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L74,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L79,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L86,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L93">
-						<h5>Orientation</h5>
-
-						<p>The <code>rendition:orientation</code> property specifies which orientation the [=EPUB
-							publication=] is intended to be rendered in. </p>
-
-						<p id="property-orientation-global">When the <a href="#orientation"
-									><code>rendition:orientation</code> property</a> is specified on a [^meta^] element,
-							it indicates that the intended orientation applies globally (i.e., for all [=EPUB spine |
-							spine=] items).</p>
-
-						<p>One of the following values MUST be used with the <code>rendition:orientation</code>
-							property:</p>
-
-						<dl class="variablelist">
-							<dt>landscape</dt>
-							<dd>
-								<p>Render the content in landscape orientation.</p>
-							</dd>
-
-							<dt>portrait</dt>
-							<dd>
-								<p>Render the content in portrait orientation.</p>
-							</dd>
-
-							<dt>auto</dt>
-							<dd>
-								<p>The content is not orientation constrained. Default value.</p>
-							</dd>
-						</dl>
-
-						<p id="fxl-orientation-duplication">The <code>rendition:orientation</code> property MUST NOT be
-							declared more than once. In addition, it MUST NOT be declared using the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a>. Refer to <a
-								href="#orientation-overrides"></a> for setting the property for individual [=EPUB
-							content documents=].</p>
-
-						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
-							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
-
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-
-      &lt;meta
-          property="rendition:orientation"&gt;
-         landscape
-      &lt;/meta&gt;
-   &lt;/metadata&gt;
-   …
-&lt;/package&gt;</pre>
-						</aside>
-
-						<section id="orientation-overrides" data-epubcheck="true"
-							data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L102,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L107">
-							<h6>Orientation overrides</h6>
-
-							<p id="property-orientation-local">The following properties MAY be specified on [=EPUB spine
-								| spine=] [^itemref^] elements to override the <a href="#property-orientation-global"
-									>global value</a>:</p>
-
-							<dl>
-								<dt id="orientation-auto">rendition:orientation-auto</dt>
-								<dd>The [=reading system=] determines the orientation to render the spine item in.</dd>
-
-								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
-								<dd>Render the given spine item in landscape orientation.</dd>
-
-								<dt id="orientation-portrait">rendition:orientation-portrait</dt>
-								<dd>Render the given spine item in portrait orientation.</dd>
-							</dl>
-
-							<p>A spine item MUST NOT declare more than one of these overrides.</p>
-						</section>
-					</section>
-
 					<section id="spread" data-epubcheck="true"
 						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L117,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L122,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L129,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L136,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L143,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L178">
 						<h5>Synthetic spreads</h5>
@@ -11073,6 +10992,13 @@ EPUB/images/cover.png</pre>
 										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
 										>new collection types</a> [[epubpackages-32]]</p>
 							</li>
+
+                            <li>
+                                <p id="orientation"><a href="https://www.w3.org/TR/epub-33/#orientation">
+                                    <code>rendition:orientation</code></a> and
+                                    <a href="https://www.w3.org/TR/epub-33/#orientation-overrides">orientation overrides</a>
+                                    properties [[epub-33]]</p>
+                            </li>
 						</ul>
 					</dd>
 
@@ -11547,6 +11473,10 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+                    <li>10-Nov-2025: Deprecated the <code>rendition:orientation</code> property, as well as
+                    its override equivalents. See <a href="https://github.com/w3c/epub-specs/issues/2751">issue 2751</a>, and
+                    the related <a href="https://w3c.github.io/pm-wg/minutes/2025-11-10-f2f.html#3397">Working Group resolution</a>.
+                    </li>
 					<li>10-Oct-2025: Added caution that SHA-1 is being phased out so other methods of protecting fonts
 						than the font obfuscation are advised. See <a
 							href="https://github.com/w3c/epub-specs/issues/2807">issue 2807</a>.</li>

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -1,22 +1,22 @@
 <section id="app-rendering-vocab">
 	<h3>Package rendering vocabulary</h3>
-	
+
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
-	
+
 	<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
 		use</a> with the package rendering properties and does not have to be declared in the
 		[=package document=].</p>
-	
+
 	<div class="note">
 		<p>Unlike the other vocabularies in this appendix, the properties in the Package Rendering Vocabulary
 			consist of a mix of properties (expressed in [^meta^] elements)
 			and [=EPUB spine | spine=] overrides (expressed on [^itemref^] elements).</p>
-		
+
 		<p>The usage requirements are also defined in <a href="#sec-rendering-control"></a> not in this appendix.
 			The following table provides a map to the properties, overrides, and where they are defined.</p>
 	</div>
-		
+
 	<table class="tabledef">
 		<thead>
 			<tr>
@@ -35,17 +35,6 @@
 					</ul>
 				</td>
 				<td><a href="#layout"></a></td>
-			</tr>
-			<tr>
-				<td><code>rendition:orientation</code></td>
-				<td>
-					<ul>
-						<li><code>rendition:orientation-auto</code></li>
-						<li><code>rendition:orientation-landscape</code></li>
-						<li><code>rendition:orientation-portrait</code></li>
-					</ul>
-				</td>
-				<td><a href="#orientation"></a></td>
 			</tr>
 			<tr>
 				<td><code>rendition:spread</code></td>
@@ -93,20 +82,20 @@
 			</tr>
 		</tbody>
 	</table>
-	
+
 	<section id="sec-rendering-custom-properties" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_package-rendering-vocab.feature_L19">
 		<h4>Custom rendering properties</h4>
-		
-		<p>Custom properties and [=EPUB spine | spine=] overrides can be included in the 
-			[=package document=] to address rendering issues specific to particular 
+
+		<p>Custom properties and [=EPUB spine | spine=] overrides can be included in the
+			[=package document=] to address rendering issues specific to particular
 			[=reading systems=], as defined by the developers of those reading systems.</p>
-		
-		<p>The only restrictions are that such properties MUST NOT be defined with a 
-			<code>rendition:</code> prefix and MUST NOT conflict behaviorally with properties 
+
+		<p>The only restrictions are that such properties MUST NOT be defined with a
+			<code>rendition:</code> prefix and MUST NOT conflict behaviorally with properties
 			in the <a href="app-rendering-vocab">package rendering vocabulary</a>.</p>
-			
-		<p>If extensions are needed for use by multiple independent reading systems, the 
-			preferred method is to extend the package rendering vocabulary through a revision 
+
+		<p>If extensions are needed for use by multiple independent reading systems, the
+			preferred method is to extend the package rendering vocabulary through a revision
 			to this standard.</p>
 	</section>
 </section>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2466,46 +2466,6 @@
 				</div>
 			</section>
 		</section>
-		<section id="app-unsupported" class="appendix">
-			<h2>Unsupported features</h2>
-
-			<p id="confreq-rs-deprecated">[=reading systems=] MAY support <a data-cite="epub-34#deprecated">deprecated
-					authoring features</a> [[epub-34]].</p>
-
-			<p id="sec-embedded-media">In addition, the following reading system features are now deprecated:</p>
-
-			<dl>
-				<dt>Media overlays processing</dt>
-				<dd>
-					<ul>
-						<li>
-							<p><a href="https://www.w3.org/publishing/epub32/epub-mediaoverlays.html#sec-embedded-media"
-									>Automatic playback of embedded audio and video</a> [[epubmediaoverlays-32]]</p>
-						</li>
-					</ul>
-				</dd>
-
-				<dt><code>epubReadingSystem</code> object</dt>
-				<dd>
-					<ul>
-						<li>
-							<p><a href="https://idpf.org/epub/301/spec/epub-contentdocs.html#app-ers-properties"
-										><code>layoutStyle</code> property</a> [[epubcontentdocs-301]]</p>
-						</li>
-						<li>
-							<p><a href="https://www.w3.org/publishing/epub32/epub-contentdocs.html#app-ers-properties"
-										><code>name</code> and <code>version</code> properties</a>
-								[[epubcontentdocs-32]]</p>
-						</li>
-					</ul>
-				</dd>
-			</dl>
-
-			<div class="note">
-				<p>Developers need to consider the unlikelihood of encountering content with deprecated features before
-					adding new support for them.</p>
-			</div>
-		</section>
 		<section id="app-epubReadingSystem" class="appendix">
 			<h2><dfn class="export">epubReadingSystem</dfn> object</h2>
 
@@ -2668,6 +2628,46 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				</section>
 			</section>
 		</section>
+        <section id="app-unsupported" class="appendix">
+            <h2>Unsupported features</h2>
+
+            <p id="confreq-rs-deprecated">[=reading systems=] MAY support <a data-cite="epub-34#deprecated">deprecated
+                    authoring features</a> [[epub-34]].</p>
+
+            <p id="sec-embedded-media">In addition, the following Reading system features are now deprecated:</p>
+
+            <dl>
+                <dt>Media overlays processing</dt>
+                <dd>
+                    <ul>
+                        <li>
+                            <p><a href="https://www.w3.org/publishing/epub32/epub-mediaoverlays.html#sec-embedded-media">Automatic
+                                    playback of embedded audio and video</a> [[epubmediaoverlays-32]]</p>
+                        </li>
+                    </ul>
+                </dd>
+
+                <dt><code>epubReadingSystem</code> object</dt>
+                <dd>
+                    <ul>
+                        <li>
+                            <p><a href="https://idpf.org/epub/301/spec/epub-contentdocs.html#app-ers-properties"><code>layoutStyle</code>
+                                    property</a> [[epubcontentdocs-301]]</p>
+                        </li>
+                        <li>
+                            <p><a href="https://www.w3.org/publishing/epub32/epub-contentdocs.html#app-ers-properties"><code>name</code>
+                                    and <code>version</code> properties</a>
+                                [[epubcontentdocs-32]]</p>
+                        </li>
+                    </ul>
+                </dd>
+            </dl>
+
+            <div class="note">
+                <p>Developers need to consider the unlikelihood of encountering content with deprecated features before
+                    adding new support for them.</p>
+            </div>
+        </section>
 		<section id="index"></section>
 		<section id="change-log" class="appendix informative">
 			<h2>Change log</h2>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -21,7 +21,7 @@
                 // previousMaturity: "REC",
 				// errata: "https://w3c.github.io/epub-specs/epub34/errata.html",
 				copyrightStart: "1999",
-				editors: [ 
+				editors: [
 				{
 					name: "Matt Garrish",
 					company: "DAISY Consortium",
@@ -1525,42 +1525,6 @@
 									rendering.</p>
 							</dd>
 						</dl>
-					</section>
-
-					<section id="orientation">
-						<h5>The <code>rendition:orientation</code> property</h5>
-
-						<p id="fxl-orientation-default" data-tests="#lay-fxl-orientation-default" data-cite="epub-34"
-							>The default value <code>auto</code> MUST be assumed by EPUB reading systems as the global
-							value if no [^meta^] element carrying the <a data-cite="epub-34#orientation"
-									><code>rendition:orientation</code> property</a> occurs in the <a
-								data-cite="epub-34#elemdef-opf-metadata">package document metadata</a> [[epub-34]].</p>
-
-						<p>The <code>rendition:orientation</code> property values have the following processing
-							requirements:</p>
-
-						<dl class="variablelist">
-							<dt id="def-orientation-auto">auto</dt>
-							<dd>
-								<p>The reading system determines the orientation in which to render [=EPUB content
-									documents=].</p>
-							</dd>
-
-							<dt id="def-orientation-landscape" data-tests="#lay-fxl-orientation-landscape"
-								>landscape</dt>
-							<dd>
-								<p>Reading systems that support multiple orientations SHOULD render EPUB content
-									documents in landscape orientation.</p>
-							</dd>
-
-							<dt id="def-orientation-portrait">portrait</dt>
-							<dd>
-								<p>Reading systems that support multiple orientations SHOULD render EPUB content
-									documents in portrait orientation.</p>
-							</dd>
-						</dl>
-
-						<p>The means by which they convey the intent is implementation specific.</p>
 					</section>
 
 					<section id="spread">


### PR DESCRIPTION
This implements the [F2F Resolution on 10th of November](https://w3c.github.io/pm-wg/minutes/2025-11-10-f2f.html#3397). In particular:

- In the authoring spec
    - the corresponding section has been removed, including the subsection on override properties
    - the item has been added to §E.2, referring back to the EPUB 3.3 as a reference definition of the spec
    - change log has been updated
- In RS spec
    - the corresponding section has been removed

See:

* For EPUB 3.4:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/deprecate-orientation-control-issue-2751/epub34/authoring/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/authoring/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/deprecate-orientation-control-issue-2751/epub34/authoring/index.html)
* For EPUB 3.4 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/deprecate-orientation-control-issue-2751/epub34/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/deprecate-orientation-control-issue-2751/epub34/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2831.html" title="Last updated on Nov 11, 2025, 7:26 AM UTC (7838ee0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2831/9f042dc...7838ee0.html" title="Last updated on Nov 11, 2025, 7:26 AM UTC (7838ee0)">Diff</a>