### PR TITLE
Remove references to html syntax

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5858,7 +5858,7 @@ No Entry</pre>
 							the use of the XML syntax. XML, however, is integral to many publishing workflows and
 							expected in many vendor ingestion systems and reading systems. It is also not expected that
 							support for XHTML will be dropped from browsers, even if there are additional support
-							differences between the syntax in the future. Support for the HTML syntax will be addressed
+							differences between the syntax in the future. Support for the HTML syntax may be addressed
 							in a successor format to EPUB 3.</p>
 					</div>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3030,10 +3030,10 @@
 			<section id="sec-package-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The [=package document=] is an XML document that consists of a set of elements that each encapsulate
-					information about a particular aspect of an [=EPUB publication=]. These elements serve to centralize
-					metadata, detail the individual resources, and provide the reading order and other information
-					necessary for its rendering.</p>
+				<p>The [=package document=] is an <a href="#sec-xml-constraints">XML document</a> that consists of a set
+					of elements that each encapsulate information about a particular aspect of an [=EPUB publication=].
+					These elements serve to centralize metadata, detail the individual resources, and provide the
+					reading order and other information necessary for its rendering.</p>
 
 				<p>The following list summarizes the information found in the package document:</p>
 
@@ -5838,8 +5838,39 @@ No Entry</pre>
 				<section id="sec-xhtml-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>This section defines a profile of [[html]] for creating [=XHTML content documents=]. An instance
-						of an XML document that conforms to this profile is a [=core media type resource=].</p>
+					<p>An [=XHTML content document=] is an instance of an <a href="#sec-xml-constraints">XML
+							document</a> expressed using the <a data-cite="html#the-xml-syntax">XML syntax</a> of the
+						[[[html]]] [[html]].</p>
+
+					<p>XHTML content documents that conform to this profile are [=core media type resources=] and one of
+						the two formats that constitute [=EPUB content documents=] &#8212; that can be used without
+						fallbacks in the [^spine^].</p>
+
+					<div class="note">
+						<p>EPUB 3 does not support the <a data-cite="html#the-html-syntax">HTML syntax</a> of [[html]]
+							as a core media type. Although both serializations allow the same elements to be expressed,
+							not all JavaScript libraries and APIs are designed to handle the XML syntax, in particular
+							the shadow DOM. This means, for example, that although the [^template^] element [[html]] can
+							be authored in the XML syntax it may not be usable in the same way as in the HTML
+							syntax.</p>
+
+						<p>The Publishing Maintenance Working Group is aware that the HTML Standard no longer recommends
+							the use of the XML syntax. XML, however, is integral to many publishing workflows and
+							expected in many vendor ingestion systems and reading systems. It is also not expected that
+							support for XHTML will be dropped from browsers, even if there are additional support
+							differences between the syntax in the future. Support for the HTML syntax will be addressed
+							in a successor format to EPUB 3.</p>
+					</div>
+
+					<div class="note">
+
+						<p>Earlier versions of EPUB 3 referred to W3C's HTML5 standard to define EPUB content documents,
+							but that standard was largely a snapshot of the HTML Standard maintained by the WHATWG.
+							After reaching an agreement on the development of HTML in 2018, the W3C standard was retired
+							and EPUB 3 now exclusively refers to the HTML Standard. It does not mean that EPUB 3 does
+							not support HTML5 anymore in XHTML content documents, only that HTML5 is now a marketing
+							term that refers to the HTML Standard as the successor to HTML 4.01 and XHTML 1.1.</p>
+					</div>
 				</section>
 
 				<section id="sec-xhtml-req" data-epubcheck="true"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -226,25 +226,15 @@
 
 					<p>The [[html]] standard defines a single content model with rules for expressing a tag set using
 						either the <a data-cite="html#syntax">HTML syntax</a> or the <a
-							data-cite="html#the-xhtml-syntax">XML syntax</a>. EPUB 3 allows authoring of content
-						documents using either of these syntaxes even though the [[html]] standard <a
-							data-cite="html/xhtml.html#the-xhtml-syntax">no longer recommends the use of the XML
-							syntax</a>. The Working Group recognizes that XML remains an integral technology in the
-						publishing ecosystem and will not remove support for the XML syntax from EPUB 3. Regardless,
-						publishers that prefer to keep using the XML syntax will need to monitor future support for it,
-						and might have to adapt to the HTML syntax to gain access to some features of [[html]].</p>
+							data-cite="html#the-xhtml-syntax">XML syntax</a>. EPUB 3, however, only allows authoring of
+						content documents using the XML syntax, in what are referred to as [=XHTML content
+						documents=].</p>
 
-					<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
-						<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. The above paragraph
-							was added to help explain the change, but would be amended if the HTML syntax is not
-							adopted.</p>
-					</div>
-
-					<p>The <a href="#sec-xhtml">HTML profile defined by this specification</a> inherits all definitions
+					<p>The <a href="#sec-xhtml">XHTML profile defined by this specification</a> inherits all definitions
 						of semantics, structure and processing behaviors from [[html]] unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the [[html]] document model that can be included in [=HTML content documents=].</p>
+						to the [[html]] document model that can be included in XHTML content documents.</p>
 				</section>
 
 				<section id="sec-overview-relations-svg">
@@ -499,35 +489,6 @@
 					</dd>
 
 					<dt>
-						<dfn class="export">HTML content document</dfn>
-					</dt>
-					<dt>
-						<small>(formerly <dfn class="export">XHTML content document</dfn>)</small>
-					</dt>
-					<dd>
-						<p>An [=EPUB content document=] that conforms to the profile of [[html]] defined in <a
-								href="#sec-xhtml"></a>.</p>
-						<p>HTML content documents can be expressed in either the <a data-cite="html#syntax">HTML
-								syntax</a> or the <a data-cite="html#the-xhtml-syntax">XML syntax</a> [[html]].</p>
-						<div class="note">
-							<p>EPUB 3 previously supported only the XML syntax of [[html]] via what were called XHTML
-								content documents. The change of name to HTML content documents is not to give priority
-								to the HTML syntax but to better reflect that [[html]] is the common standard for both
-								syntaxes. The term "XHTML" used to refer to [[xhtml11]], but that was replaced by the
-								XML syntax of [[html]] in 2011, which also officially superseded [[xhtml11]] in
-								2018.</p>
-						</div>
-						<div class="issue" data-number="2715" title="Adoption of the HTML syntax">
-							<p>The change to allow both syntaxes of HTML is an open issue in EPUB 3.4. It is important
-								to note that EPUB 3 is already based on [[html]] and this change only makes the HTML
-								syntax valid to use. Because EPUB 2's XHTML content documents were implemented using
-								[[xhtml11]], some authors mistakenly assume EPUB 3's XHTML content documents use the
-								same technology and that this change represents a move to a new standard.</p>
-							<p>This new definition will be amended if the HTML syntax is not adopted.</p>
-						</div>
-					</dd>
-
-					<dt>
 						<dfn class="export">linked resource</dfn>
 					</dt>
 					<dd>
@@ -646,6 +607,23 @@
 						<p>An [=EPUB content document=] or [=foreign content document=] referenced from the [=EPUB spine
 							| spine=], whether directly or via a <a href="#sec-manifest-fallbacks">fallback
 							chain</a>.</p>
+					</dd>
+
+					<dt>
+						<dfn class="export">XHTML content document</dfn>
+					</dt>
+					<dd>
+						<p>An [=EPUB content document=] that conforms to the profile of [[html]] defined in <a
+								href="#sec-xhtml"></a>.</p>
+						<p>XHTML content documents are expressed using the <a data-cite="html#the-xhtml-syntax">XML
+								syntax</a> [[html]].</p>
+						<div class="note">
+							<p>Although the [[html]] standard no longer refers to the XML syntax as "XHTML", the name
+								XHTML was still current at the time EPUB 3.0 was developed. The name "XHTML content
+								document" was also used in EPUB 2, so keeping it unchanged was intended to help ease
+								transition to the new format. Unlike in EPUB 2, XHTML in this document does not refer to
+								[[xhtml11]], which was officially superseded in 2018.</p>
+						</div>
 					</dd>
 
 					<dt>
@@ -988,20 +966,11 @@
 							<th colspan="3" id="cmt-grp-html" class="tbl-group">HTML</th>
 						</tr>
 						<tr>
-							<td id="cmt-html">
-								<code>text/html</code>
-							</td>
-							<td>
-								<a href="#sec-xhtml">HTML content documents</a>
-							</td>
-							<td>HTML documents that use the <a data-cite="html#syntax">HTML syntax</a> [[html]]</td>
-						</tr>
-						<tr>
 							<td id="cmt-xhtml">
 								<code>application/xhtml+xml</code>
 							</td>
 							<td>
-								<a href="#sec-xhtml">HTML content documents</a>
+								<a href="#sec-xhtml">XHTML content documents</a>
 							</td>
 							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
 								[[html]]</td>
@@ -5864,40 +5833,20 @@ No Entry</pre>
 			<h2>EPUB content documents</h2>
 
 			<section id="sec-xhtml">
-				<h3>HTML content documents</h3>
-
-				<div class="ednote">
-					<p>Support for the HTML syntax is still an <a href="https://github.com/w3c/epub-specs/issues/2715"
-							>open issue</a> in the EPUB 3.4 revision. It is <b><i>at risk</i></b>, depending on authors'
-						and implementers' feedback. This specification introduces it as a core media type and also
-						minimally adds requirements for its authoring in this section to begin making readers aware of
-						the proposed change.</p>
-
-					<p>Much of this specification, and the Reading Systems specification [[epub-rs-34]], continues to
-						refer only to XHTML content documents and their authoring requirements, a number of which need
-						resolving (e.g., providing an <a href="#sec-epub-type-attribute">alternative to the
-								<code>epub:type</code> attribute</a>). These references and requirements will be updated
-						once it is clearer that support will definitely be added in this revision. Until then, the
-						specification should be read as also supporting HTML wherever it currently refers to XHTML,
-						despite the support inconsistencies.</p>
-
-					<p>To provide feedback on this change, please add comments to <a
-							href="https://github.com/w3c/epub-specs/issues/2715">issue 2715</a> in the GitHub
-						tracker.</p>
-				</div>
+				<h3>XHTML content documents</h3>
 
 				<section id="sec-xhtml-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>This section defines a profile of [[html]] for creating HTML content documents. An instance of an
-						HTML document that conforms to this profile is a [=core media type resource=].</p>
+					<p>This section defines a profile of [[html]] for creating [=XHTML content documents=]. An instance
+						of an XML document that conforms to this profile is a [=core media type resource=].</p>
 				</section>
 
 				<section id="sec-xhtml-req" data-epubcheck="true"
 					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L21,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L26,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L32,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L529,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L534">
-					<h4>HTML requirements</h4>
+					<h4>XHTML requirements</h4>
 
-					<p>An HTML content document:</p>
+					<p>An XHTML content document:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -5911,25 +5860,17 @@ No Entry</pre>
 								conformance constraints defined therein.</p>
 						</li>
 						<li>
-							<p id="confreq-cd-html-docprops-syntax">MUST either:</p>
-							<ul class="conformance-list">
-								<li id="confreq-cd-html-docprops-syntax-html">conform to the <a data-cite="html#writing"
-										>HTML syntax</a> [[html]] when defined in the [=epub manifest|manifest=] as
-									having the media type <code>text/html</code>; or</li>
-								<li id="confreq-cd-html-docprops-syntax-xml">conform to the <a
-										data-cite="html#writing-xhtml-documents">XML syntax</a> [[html]] when defined in
-									the [=epub manifest|manifest=] as having the media type
-										<code>application/xhtml+xml</code>.</li>
-							</ul>
+							<p id="confreq-cd-html-docprops-syntax-xml">MUST be an [[html]] document that conforms to
+								the <a data-cite="html#writing-xhtml-documents">XML syntax</a>.</p>
 						</li>
 					</ul>
 
-					<p>Unless specified otherwise, HTML content documents inherit all definitions of semantics,
+					<p>Unless specified otherwise, XHTML content documents inherit all definitions of semantics,
 						structure, and processing behaviors from the [[html]] specification.</p>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
-							[[epub-a11y-12]] applies to HTML content documents. See <a href="#confreq-a11y"
+							[[epub-a11y-12]] applies to XHTML content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -6513,7 +6454,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-epub-type-attribute">
-					<h3>The <code>type</code> attribute</h3>
+					<h3>The <code>epub:type</code> attribute</h3>
 
 					<section id="sec-structural-semantics">
 						<h4>Structural semantics</h4>
@@ -6541,92 +6482,37 @@ No Entry</pre>
 
 					<section id="type-attr-syntax">
 						<h4>Syntax</h4>
-						<dl>
-							<dt>XHTML serialization</dt>
+
+						<dl class="elemdef" id="attrdef-epub-type-xhtml">
+							<dt>Attribute Name:</dt>
 							<dd>
-								<dl class="elemdef" id="attrdef-epub-type-xhtml">
-									<dt>Attribute Name:</dt>
-									<dd>
-										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
-												<code>epub:type</code>
-											</dfn>
-										</p>
-									</dd>
-
-									<dt>Namespace:</dt>
-									<dd>
-										<p>
-											<code>http://www.idpf.org/2007/ops</code>
-										</p>
-									</dd>
-
-									<dt>Usage:</dt>
-									<dd>
-										<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics"
-												>XHTML</a>, <a href="#confreq-svg-structural-semantics">SVG</a>, and <a
-												href="#sec-overlays-def">media overlays</a>.</p>
-									</dd>
-
-									<dt>Value:</dt>
-									<dd>
-										<p>A <a data-cite="xml#NT-S">whitespace-separated</a> [[xml]] list of [=compact
-											URLs=], with restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
-									</dd>
-								</dl>
+								<p>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+										<code>epub:type</code>
+									</dfn>
+								</p>
 							</dd>
 
-							<dt>HTML serialization</dt>
+							<dt>Namespace:</dt>
 							<dd>
-								<dl class="elemdef" id="attrdef-epub-type-html">
-									<dt>Attribute Name:</dt>
-									<dd>
-										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
-												<code>epub-type</code>
-											</dfn>
-										</p>
-									</dd>
+								<p>
+									<code>http://www.idpf.org/2007/ops</code>
+								</p>
+							</dd>
 
-									<dt>Usage:</dt>
-									<dd>
-										<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics"
-												>HTML</a>.</p>
-									</dd>
+							<dt>Usage:</dt>
+							<dd>
+								<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a
+										href="#confreq-svg-structural-semantics">SVG</a>, and <a
+										href="#sec-overlays-def">media overlays</a>.</p>
+							</dd>
 
-									<dt>Value:</dt>
-									<dd>
-										<p>A [=ASCII whitespace|whitespace-separated=] [[infra]] list of values that
-											SHOULD be taken from the EPUB 3 Structural Semantics Vocabulary
-											[[epub-ssv-11]].</p>
-									</dd>
-								</dl>
+							<dt>Value:</dt>
+							<dd>
+								<p>A <a data-cite="xml#NT-S">whitespace-separated</a> [[xml]] list of [=compact URLs=],
+									with restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
 							</dd>
 						</dl>
-
-						<div class="ednote">
-							<p>Support for an HTML serialization of the <code>epub:type</code> attribute depends on the
-								addition of support for the <a href="#sec-xhtml">HTML syntax</a> in the EPUB 3.4
-								revision. It is <b><i>at risk</i></b>, depending on authors' and implementers'
-								feedback.</p>
-
-							<p>The proposed <code>epub-type</code> will provide similar functionality for HTML content
-								documents but with some restrictions (namely, no extensibility through the
-									<code>epub:prefix</code> attribute). The attribute should be read as a replacement
-								for <code>epub:type</code> where this specification and the Reading Systems
-								specification [[epub-rs-34]] refer to that attribute for XHTML content documents. These
-								references will be updated once it is clearer that support will definitely be added in
-								this revision.</p>
-
-							<p>The <code>epub:type</code> attribute will remain the sole means of including semantics in
-								XML grammars in EPUB (i.e., XHTML content documents, SVG content documents, and media
-								overlay documents).</p>
-
-							<p>To provide feedback on this change, please open issues in the <a
-									href="https://github.com/w3c/epub-specs/issues">GitHub tracker for the EPUB
-									specifications</a>.</p>
-						</div>
-
 
 						<div class="caution">
 							<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
@@ -11547,6 +11433,7 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>11-Nov-2025: Removed support for the HTML syntax.</li>
 					<li>10-Oct-2025: Added caution that SHA-1 is being phased out so other methods of protecting fonts
 						than the font obfuscation are advised. See <a
 							href="https://github.com/w3c/epub-specs/issues/2807">issue 2807</a>.</li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5866,7 +5866,7 @@ No Entry</pre>
 
 						<p>Earlier versions of EPUB 3 referred to W3C's HTML5 standard to define EPUB content documents,
 							but that standard was largely a snapshot of the HTML Standard maintained by the WHATWG.
-							After reaching an agreement on the development of HTML in 2018, the W3C standard was retired
+							After reaching an <a href="https://www.w3.org/2019/04/WHATWG-W3C-MOU.html">agreement</a> on the development of HTML in 2019, the W3C standard was retired
 							and EPUB 3 now exclusively refers to the HTML Standard. It does not mean that EPUB 3 does
 							not support HTML5 anymore in XHTML content documents, only that HTML5 is now a marketing
 							term that refers to the HTML Standard as the successor to HTML 4.01 and XHTML 1.1.</p>

--- a/epub34/overview/index.html
+++ b/epub34/overview/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Overview</title>
-		<meta name="color-scheme" content="light dark"/>
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../../common/js/add-caution-hd.js" class="remove"></script>
@@ -104,9 +104,7 @@
 					publication:</p>
 
 				<figure>
-					<figcaption>
-						Structure of an EPUB publication.
-					</figcaption>
+					<figcaption> Structure of an EPUB publication. </figcaption>
 					<img src="images/epub.svg" width="600" aria-details="fig-epub-structure-diagram"
 						alt="Visual structure of the main constituents of an EPUB publication"
 						style="background-color: transparent;" />
@@ -115,9 +113,9 @@
 				<details id="fig-epub-structure-diagram" class="desc">
 					<summary style="font-weight: normal; font-style: italic">Image description</summary>
 					<p>'EPUB (OCF) container' as the outer most component which encapsulates the 'EPUB Publication'
-						containing two documents 'Package Document' and 'Navigation Document' along with a
-						inner component labelled 'Publication Resources' which contains multiple 'Content
-						document (XHTML, SVG)', and multiple 'Other resource (CSS, png, mp3, mov,…)'. </p>
+						containing two documents 'Package Document' and 'Navigation Document' along with a inner
+						component labelled 'Publication Resources' which contains multiple 'Content document (XHTML,
+						SVG)', and multiple 'Other resource (CSS, png, mp3, mov,…)'. </p>
 				</details>
 
 				<p>The body of this document explores these resources in greater detail with the goal of providing
@@ -164,9 +162,8 @@
 				<p>That is also why this overview is for "EPUB 3", as it typically does not change significantly from
 					one specification release to the next.</p>
 
-				<p class="note">
-					At this moment, the [[[epub-34]]] [[epub-34]] version is in development; it is based on the stable [[[epub-33]]] [[epub-33]] version, but the Working Group is adding some new features. 
-				</p>
+				<p class="note"> At this moment, the [[[epub-34]]] [[epub-34]] version is in development; it is based on
+					the stable [[[epub-33]]] [[epub-33]] version, but the Working Group is adding some new features. </p>
 
 				<div class="note">
 					<p>For a general overview of the changes made in each revision, refer to <a
@@ -293,30 +290,20 @@
 		<section id="sec-content-docs">
 			<h2>Content documents</h2>
 
-			<p>
-				Each [=EPUB publication=] contains one or more [=EPUB content documents=], as defined in [[epub-34]]. These are HTML or SVG
-				documents that describe the readable content and reference associated media resources (e.g., images,
-				audio, and video clips).
-			</p>
+			<p>Each [=EPUB publication=] contains one or more [=EPUB content documents=], as defined in [[epub-34]].
+				These are HTML or SVG documents that describe the readable content and reference associated media
+				resources (e.g., images, audio, and video clips).</p>
 
-			<p>
-				HTML documents for EPUB are formally defined as a <a data-cite="epub-34#sec-xhtml">profile of HTML</a> [[html]]. 
-				In particular, that profile requires the usage of the 
-				<a data-cite="html#writing-xhtml-documents">XML syntax</a> [[html]], referred to as XHTML in the EPUB specifications.
-			</p>
+			<p>HTML documents for EPUB are formally defined as a <a data-cite="epub-34#sec-xhtml">profile of
+				HTML</a> [[html]]. In particular, that profile requires the usage of the <a
+					data-cite="html#writing-xhtml-documents">XML syntax</a> [[html]], referred to as [=XHTML content
+				documents=] in the EPUB specifications.</p>
 
-			<p class="note">
-				The term "XHTML" should not be confused with an earlier, fully XML based version of HTML denoted as
-				"XHTML 1.1" [xhtml11]. XHTML 1.1 was originally published in 2001 and was officially retired 
-				by the W3C in 2018.
-				See also <a href="#epub30"></a> for further details.
-			</p>
-
-			<p class="issue">
-				It is currently an <a href="https://github.com/w3c/epub-specs/issues/2715">open issue</a> whether EPUB 3.4 
-				would continue to <em>require</em> the XML serialization, or whether 
-				the "usual" HTML serialization would <em>also</em> be accepted. 
-			</p>
+			<div class="note">
+				<p>The term "XHTML" should not be confused with an earlier, fully XML based version of HTML denoted as
+					"XHTML 1.1" [xhtml11]. XHTML 1.1 was originally published in 2001 and was officially retired by the
+					W3C in 2018. See also <a href="#epub30"></a> for further details.</p>
+			</div>
 
 			<section id="sec-rendering">
 				<h2>Rendering and CSS</h2>
@@ -650,14 +637,11 @@
 					<li>EPUB Accessibility Techniques 1.2 [[epub-a11y-tech-12]]: provides guidance on how to meet the
 						EPUB Accessibility 1.2 [[epub-a11y-12]] discovery and accessibility requirements for EPUB
 						publications. </li>
-					<li>
-						[[[epub-a11y-exemption]]] [[epub-a11y-exemption]]: the <code>exemption</code> property is used
+					<li> [[[epub-a11y-exemption]]] [[epub-a11y-exemption]]: the <code>exemption</code> property is used
 						to indicate that an EPUB publication that does not meet accessibility conformance requirements
-						has an exemption under the applicable jurisdiction's laws.
-					</li>
-					<li>
-						[[[epub-fxl-a11y]]] [[epub-fxl-a11y]]: provides guidance on how to make fixed-layout EPUB publications accessible.	
-					</li>
+						has an exemption under the applicable jurisdiction's laws. </li>
+					<li> [[[epub-fxl-a11y]]] [[epub-fxl-a11y]]: provides guidance on how to make fixed-layout EPUB
+						publications accessible. </li>
 					<li>EPUB Multiple-Rendition Publications 1.1 [[epub-multi-rend-11]]: defines the creation and
 						rendering of EPUB publications consisting of more than one Rendition. </li>
 					<li>EPUB 3 Structural Semantics Vocabulary 1.1 [[epub-ssv-11]]: defines a set of properties relating
@@ -693,33 +677,28 @@
 			</section>
 			<section id="epub30">
 				<h3>EPUB 3.0: 2010</h3>
-				<p>
-					Work on a major revision of the EPUB specifications began in 2010, with the goal of aligning EPUB
-					more closely with HTML. As part of that alignment, the reference to HTML was changed: while EPUB 2.0 
-					referred to XHTML 1.1 [[xhtml11]], EPUB 3.0 relies on the XML serialization of HTML [[html]] (referred to
-					as "HTML5" at the time). This resulted in bringing new, native multimedia features, sophisticated
-					CSS layout rendering and font embedding, MathML support, scripted interactivity, vertical writing
-					and other enhanced global language support, and improved accessibility. 
-				</p>
+				<p> Work on a major revision of the EPUB specifications began in 2010, with the goal of aligning EPUB
+					more closely with HTML. As part of that alignment, the reference to HTML was changed: while EPUB 2.0
+					referred to XHTML 1.1 [[xhtml11]], EPUB 3.0 relies on the XML serialization of HTML [[html]]
+					(referred to as "HTML5" at the time). This resulted in bringing new, native multimedia features,
+					sophisticated CSS layout rendering and font embedding, MathML support, scripted interactivity,
+					vertical writing and other enhanced global language support, and improved accessibility. </p>
 
-				<p>
-					A new specification for EPUB Media Overlays was also introduced, allowing for text and audio synchronization 
-					in EPUB publications. To better align the specification names with the standard, the Open Package Format
-					specification was renamed EPUB publications, and the Open Publication Format specification was
-					renamed EPUB Content Documents. The EPUB 3.0 specifications were approved in October 2011.
-					See [[epubpublications-30]] [[epubcontentdocs-30]] [[ocf-30]] [[epubmediaoverlays-30]]
-					[[epubchanges-30]].
-				</p>
+				<p> A new specification for EPUB Media Overlays was also introduced, allowing for text and audio
+					synchronization in EPUB publications. To better align the specification names with the standard, the
+					Open Package Format specification was renamed EPUB publications, and the Open Publication Format
+					specification was renamed EPUB Content Documents. The EPUB 3.0 specifications were approved in
+					October 2011. See [[epubpublications-30]] [[epubcontentdocs-30]] [[ocf-30]] [[epubmediaoverlays-30]]
+					[[epubchanges-30]]. </p>
 			</section>
 
 			<section id="epub301">
 				<h3>EPUB 3.0.1: 2014</h3>
 
 				<p>The EPUB 3.0.1 revision was undertaken in 2013-14. Although introducing mostly minor fixes and
-					updates, it did see the integration of fixed layout documents to provide greater control
-					over the presentation of EPUB publications.
-					See [[epubpublications-301]] [[epubcontentdocs-301]] [[ocf-301]] [[epubmediaoverlays-301]]
-					[[epubchanges-301]].</p>
+					updates, it did see the integration of fixed layout documents to provide greater control over the
+					presentation of EPUB publications. See [[epubpublications-301]] [[epubcontentdocs-301]] [[ocf-301]]
+					[[epubmediaoverlays-301]] [[epubchanges-301]].</p>
 			</section>
 
 			<section id="epub31">
@@ -759,14 +738,13 @@
 
 				<p>The documents themselves have been restructured. The primary motivation for this restructuring, as
 					well as an extensive editorial revision, was to make the documents more readable. Also, as part of
-					the thorough testing regime developed by the <a
-						href="https://www.w3.org/publishing/groups/epub-wg/">W3C EPUB 3 Working Group</a>, this
-					restructuring led to the separation of Recommendations and Working Group Notes (see also <a
-						href="#app-documents">the detailed list of documents</a>). Features specified in the
-					Recommendations were thoroughly tested, were widely implemented in reading systems, and they can be
-					considered as interoperable. On the other hand, features specified in Working Group Notes, although
-					they may have some authoring uptakes, still lacked support in reading systems; as a result, these
-					technologies should not yet be considered stable and interoperable.</p>
+					the thorough testing regime developed by the <a href="https://www.w3.org/publishing/groups/epub-wg/"
+						>W3C EPUB 3 Working Group</a>, this restructuring led to the separation of Recommendations and
+					Working Group Notes (see also <a href="#app-documents">the detailed list of documents</a>). Features
+					specified in the Recommendations were thoroughly tested, were widely implemented in reading systems,
+					and they can be considered as interoperable. On the other hand, features specified in Working Group
+					Notes, although they may have some authoring uptakes, still lacked support in reading systems; as a
+					result, these technologies should not yet be considered stable and interoperable.</p>
 
 				<p>The separate <a data-cite="epub-33#change-log">section</a> in [[epub-33]] provides a more detailed
 					overview of the changes.</p>
@@ -777,11 +755,10 @@
 			<section id="epub34" class="ednote">
 				<h3>EPUB 3.4: 2027</h3>
 
-				<p>The work on EPUB 3.4 [[epub-34]] started in 2025. The goal was to add some new features 
-					to EPUB 3.3, and to clarify some existing features. The new features include the ability to
-					add standard annotating features to EPUB publications, and the ability to include 
-					"webtoons" in EPUB publications. The new features are expected to be published as
-					 a W3C Recommendation in 2027.</p>
+				<p>The work on EPUB 3.4 [[epub-34]] started in 2025. The goal was to add some new features to EPUB 3.3,
+					and to clarify some existing features. The new features include the ability to add standard
+					annotating features to EPUB publications, and the ability to include "webtoons" in EPUB
+					publications. The new features are expected to be published as a W3C Recommendation in 2027.</p>
 			</section>
 		</section>
 		<section id="index" class="appendix"></section>


### PR DESCRIPTION
This should undo all the changes we've made.

I left the note about xhtml not being 1.1 with the xhtml content document definition, as I think it's helpful to have it where people are most likely to land (with some minor adjustments).

I also kept the "html" heading in the core media types section as having xhtml content documents under the "other" heading never seemed quite right.

I'm marking it as final review since I assume we should give anyone not at tpac a week to catch up on the resolutions before merging.

***

Overview: [Preview](https://cdn.statically.io/gh/w3c/epub-specs/chore/revert-html-syntax/epub34/overview/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/overview/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/chore/revert-html-syntax/epub34/overview/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2832.html" title="Last updated on Nov 26, 2025, 2:13 PM UTC (7c42529)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2832/9f042dc...7c42529.html" title="Last updated on Nov 26, 2025, 2:13 PM UTC (7c42529)">Diff</a>