### PR TITLE
Mostly editorial change proposals on the annotation draft

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1033,7 +1033,7 @@
 			<h1 id="5-json-schema"> JSON Schema </h1>
 		</section>
 
-		<section>
+		<section class="appendix">
 			<h1 id="6-references">Further readings </h1>
 			<p> Open Annotation in EPUB, 2015: <a href="https://idpf.org/epub/oa/">
 					https://idpf.org/epub/oa/ </a>
@@ -1059,5 +1059,6 @@
 					https://www.w3.org/TR/epub-33/ </a>
 			</p>
 		</section>
+        <section id="index"></section>
 	</body>
 </html>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -36,15 +36,24 @@
                     profile: "web-platform",
                     specs:[ "epub-34"]
                 },
+                localBiblio: {
+                    "epub-ann-ucr": {
+                        "authors": [
+                            "Laurent Le Meur"
+                        ],
+                            "title": "EPUB Annotations Use Cases and Requirements",
+                                "href": "https://w3c.github.io/epub-specs/wg-notes/annotations-ucr/",
+                                    "date": "26 November 2025",
+                                        "publisher": "W3C"
+                    },
+                }
             };</script>
 	</head>
 	<body>
 		<section id="abstract">
-			<p> This document defines a profile of the <a
-					href="https://www.w3.org/TR/annotation-model/"> W3C Web Annotation Data Model
-				</a> by specifying a subset of the properties allowed in this model, and adding
-				properties deemed useful to satisfy the <a href="./../wg-notes/annotations-ucr/">
-					Use Cases and Requirements for EPUB Annotations</a>.
+			<p> This document defines a profile of the [[[annotation-model]]] [[annotation-model]]
+                by specifying a subset of the properties allowed in this model, and adding
+				properties deemed useful to satisfy the [[[epub-ann-ucr]]] [[epub-ann-ucr]].
 			</p>
 		</section>
 		<section id="sotd"></section>
@@ -52,45 +61,53 @@
             <!-- <p>All algorithm explanations are <em>non-normative</em>.</p> -->
         </section>
 
-		<section id="1-profile-of-the-w3c-annotation-data-model">
+		<section id="1-profile-of-the-w3c-annotation-data-model" class="informative">
 			<h1> Subset of the Web Annotation Data Model </h1>
 			<p> This section defines a profile of the [[[annotation-model]]] [[annotation-model]], as used for EPUB
-				Annotations. In the Web Annotation model, the core structure is the
+				Annotations.</p>
+            <p> In the Web Annotation model, the core structure is the
                 <a data-cite="annotation-model#annotations">Annotation object</a>,
                 which contains properties defining the annotation's
                 <a data-cite="annotation-model#bodies-and-targets">Body and Target</a>.
-                EPUB Annotations reuse the <a href="#1-1-annotation-object">same model</a> with some restrictions, listed below.
+                EPUB Annotations reuse the <a href="#1-1-annotation-object">same model</a> with some restrictions listed below.
                 Subsequent sections provide more formal definitions for the terms used by this
                 specification.
             </p>
            <ul>
-                 <li> Web Annotations have 0 or more Bodies, whereas this document requires to have a single <a href="#1-4-body">Body</a>
+                 <li> Web Annotations may have 0 or more Bodies, whereas this document requires to have a single <a href="#1-4-body">Body</a>
                     per annotation. Furthermore, in the [[annotation-model]], such Body can be remote or embedded,
                     whereas only embedded Bodies are used in EPUB Annotation
-                    for textual comments (the inclusion mechanism is to be defined for audiovisual comments). </li>
-                <li> Web Annotations have 1 or more Targets, while only a single <a href="#1-3-target">Target</a> is allowed per
-                    EPUB Annotations.  The Target of an EPUB Annotation is the content being annotated, which is
-                    a specific segment in a document within the EPUB package defined by its relative <a href="#1-3-1-source">Source</a> URL and a <a href="#1-3-2-selector">Selector</a>. </li>
+                    for textual comments .
+
+                    <p class="issue">The inclusion mechanism is to be defined for audiovisual comments</p>
+
+                </li>
+                <li> Web Annotations have 1 or more Targets, while only a single <a href="#1-3-target">Target</a> is allowed for an
+                    EPUB Annotation.  The Target of an EPUB Annotation is the content being annotated, which is
+                    a specific segment in a document within the EPUB package defined by its relative
+                    <a href="#1-3-1-source">Source</a> URL and a <a href="#1-3-2-selector">Selector</a>. </li>
                 <li> Web Annotations may have multiple motivations, while only a single motivation is allowed for EPUB annotations. </li>
-                <li> Web Annotations may have multiple creators, while only a single creator is allowed for EPUB annotations</li>
-                <li> Web Annotations may have additional properties not accepted for EPUB Annotations. For example,
+                <li> Web Annotations may have multiple creators, while only a single creator is allowed for EPUB annotations.</li>
+                <li> Web Annotations may have additional properties that are not accepted for EPUB Annotations (see the
+                    definitions of the properties in later sections). For example,
                     a specific generator application and generated date may exist for a Web Annotation,
                     whereas this document only defines these properties for <a href="#2-annotation-set">Annotation Sets</a>.
                     Web Annotations also define additional property values and types than are not usable for EPUB Annotations. </li>
                 <li> Web Annotations define an <code>AnnotationCollection</code> structure to handle paginated requests, whereas this document
                     defines an <code>AnnotationSet</code> structure to group multiple annotations for sharing purposes.
-                    Implementers MUST support <code>AnnotationSet</code> and MAY support both structures for maximum compatibility. </li>
+                    Implementers MUST support <code>AnnotationSet</code> and MAY support both structures for maximum compatibility.
+                </li>
             </ul>
 			<p class="note">This document does not define how annotations are created, stored, or
 				synchronized in a reading system. </p>
 		</section>
         <section>
 			<h2 id="1-annotation"> Annotation </h2>
-
             <section>
 			<h3 id="1-1-annotation-object"> Annotation Object </h3>
-			<p> This document retains the following annotation properties from the Web Annotation
-				Data Model: </p>
+			<p> This document retains the following annotation properties from the
+                <a data-cite="annotation-model#annotations">Annotation object</a> [[annotation-model]]:
+             </p>
 			<table class="zebra">
 				<thead>
 					<tr>
@@ -107,7 +124,11 @@
 						</td>
 						<td>The context that determines the meaning of the JSON as an Annotation.
 							It MUST be <a href="http://www.w3.org/ns/anno.jsonld">
-								http://www.w3.org/ns/anno.jsonld”</a>.</td>
+								http://www.w3.org/ns/anno.jsonld”</a>.
+
+                            <p class="issue">That is probably not true; we define additional classes, eg, Body, that is not defined in that context.</p>
+
+                            </td>
 						<td>string</td>
 						<td>Yes</td>
 					</tr>
@@ -115,7 +136,7 @@
 						<td>
 							<code> id </code>
 						</td>
-						<td>The identity of the annotation. A uuid formatted as a URN is recommended.</td>
+						<td>The identity of the annotation. A uuid formatted as a URN is RECOMMENDED.</td>
 						<td>URI</td>
 						<td>Yes</td>
 					</tr>
@@ -156,8 +177,8 @@
 							<code> creator </code>
 						</td>
 						<td>The creator of the annotation. This may be either a human or an
-							organization.</td>
-						<td> Creator </td>
+							organization.<br></td>
+						<td> <a href="#1-2-creator"></a> </td>
 						<td> No </td>
 					</tr>
 					<tr>
@@ -165,7 +186,7 @@
 							<code> target </code>
 						</td>
 						<td>The target content of the annotation.</td>
-						<td> Target </td>
+						<td> <a href="#1-3-target"></a> </td>
 						<td> Yes </td>
 					</tr>
 					<tr>
@@ -173,11 +194,16 @@
 							<code> body </code>
 						</td>
 						<td>The annotation body.</td>
-						<td> Body </td>
+						<td> <a href="#1-4-body"></a> </td>
 						<td> No </td>
 					</tr>
 				</tbody>
 			</table>
+
+            <p class="note">The [[annotation-model]] specification is fairly open ended as for the value of, for example, the
+                <code>body</code> property. This specification restricts the value by defining specific classes that must be used, see the
+                <a href="#1-2-creator"></a>, <a href="#1-3-target"></a>, and <a href="#1-4-body"></a> below.
+            </p>
 
 			<p class="note">The type of annotation should be considered when determining the value of the <code>motivation</code> property.
 				An annotation with a Body structure corresponds to a "comment".
@@ -186,9 +212,13 @@
 
 			<p class="issue">Question: should we add a "replying" motivation for annotations that are replies to other annotations?</p>
 
-            <aside class="example" title="Core structure of an EPUB annotation">
+            <p class="ednote">We should specify whether a property may appear at most once (body, target) because that is also part of
+                the profile definition. This can be a separate column ("cardinality") or be added to the description. This remark may be valid
+                for all the tables in the document.
+            </p>
 
-			<!-- <p> Sample 1: Core structure of an EPUB annotation </p> -->
+
+            <aside class="example" title="Core structure of an EPUB annotation">
 			<pre>
                 {
                     "@context": "http://www.w3.org/ns/anno.jsonld",
@@ -197,8 +227,10 @@
                     "created": "2023-10-14T15:13:28Z",
                     "modified": "2024-01-29T09:00:00Z",
                     "target": {
+                        …
                     },
                     "body": {
+                        …
                     }
                 }
 			</pre>
@@ -208,7 +240,7 @@
             <section>
 			<h3 id="1-2-creator"> Creator </h3>
 			<p> The creator of an annotation is a person or an organisation. </p>
-			<p> This document defines the following creator properties: </p>
+ 			<p> This document defines the following creator properties: </p>
 			<table class="zebra">
 				<thead>
 					<tr>
@@ -231,7 +263,7 @@
 						<td>
 							<code> type </code>
 						</td>
-						<td> The RDF structure type. It MUST be "Person" or
+						<td> Type of the creator. It MUST be "Person" or
 							"Organization". </td>
 						<td> string </td>
 						<td> Yes </td>
@@ -294,8 +326,8 @@
             <section>
 			<h4 id="1-3-1-source"> Source </h4>
 			<p> The target resource MUST be identified by the URL of an existing resource in the
-				EPUB package. It MUST be one of the item/@href values of the
-				<a href="https://www.w3.org/TR/epub-33/#sec-manifest-elem"> manifest element </a>.</p>
+				EPUB package. It MUST be one of the `item/@href` values of the [^manifest^] element as
+                defined in [[epub-34]].</p>
 
             <aside class="example" title=" the source of the annotation is the relative URL identifying an HTML document in an EPUB">
 			<pre>
@@ -305,8 +337,10 @@
 					  "target": {
 					    "source": "OEBPS/text/chapter1.html",
 					    "selector": [
+                            …
 					    ],
 					    "meta": {
+                            …
 					    }
 					  }
 					}
@@ -316,12 +350,12 @@
             <section>
 			<h4 id="1-3-2-selector"> Selector </h4>
 			<p> An annotation refers to a segment of a resource, which is identified by one or more
-				Selectors. The nature of the Selectors and methods to describe segments depend on
+                <a data-cite="annotation-model#selectors">Selectors</a>. The nature of the Selectors and methods to describe segments depend on
 				the resource type. Providing more than one Selector allows an annotation software to
 				choose the most accurate selector from those it can handle and helps accommodate
 				evolutions on the annotated resource. </p>
 			<p> Annotation selectors are specified in <a data-cite="annotation-model#selectors">Web
-					Annotation Data Model, section on Selectors </a>. This specification retains
+					Annotation Data Model</a>. This specification retains
 				selectors deemed useful for annotating publications and details on how to use these
 				selectors. </p>
 			<p class="note">New selectors will undoubtedly be defined in the coming months after
@@ -536,7 +570,7 @@
 
 			<h3 id="1-4-body"> Body </h3>
 			<p>The body of an annotation contains plain text, style, and an optional keyword.</p>
-			<p>The body property contains:</p>
+			<p>This document specifies the following sub-properties:</p>
 			<table class="zebra">
 				<thead>
 					<tr>
@@ -593,7 +627,7 @@
 							<code> language </code>
 						</td>
 						<td> The language of the annotation. </td>
-						<td> BCP47 </td>
+						<td> [[BCP47]] </td>
 						<td> No </td>
 					</tr>
 					<tr>
@@ -639,13 +673,14 @@
 		<section>
 			<h2 id="2-annotation-set"> Annotation Set </h2>
 			<p>An Annotation does not contain information about its associated publication. If a
-				set of annotations is shared as a detached file, it is mandatory to export with them
+				set of annotations is shared as a detached file, it is mandatory to also export
 				information that will help find the associated publication even if the publication
 				is not adequately identified.</p>
-			<p>Note: the AnnotationCollection defined by the W3C does not provide an adequate
+			<p class="note">The <a data-cite="annotation-model#annotation-collection"><code>AnnotationCollection</code></a> defined
+                in the [[[annotation-model]]] does not provide an adequate
 				structure for sharing annotations either as a detached file or as a file embedded in
-				a Zip package. The AnnotationCollection is intrinsically paginated and provides a
-				way to retrieve annotations via a REST API.</p>
+				a Zip package. The <code>AnnotationCollection</code> meant to provide a
+				way to retrieve annotations via a REST API and is, therefore, intrinsically paginated.</p>
 
 			<p> The AnnotationSet object contains: </p>
 			<table class="zebra">
@@ -664,7 +699,9 @@
 						</td>
 						<td> The context that determines the meaning of the JSON as an annotation
 							set. It MUST be “ <a href="http://www.w3.org/ns/anno.jsonld”">
-								http://www.w3.org/ns/anno.jsonld” </a> . </td>
+								http://www.w3.org/ns/anno.jsonld” </a> .
+                                <p class="issue">we will have to define our own vocabulary an context files to cover these.</p>
+                        </td>
 						<td> string </td>
 						<td> Yes </td>
 					</tr>
@@ -673,7 +710,7 @@
 							<code> id </code>
 						</td>
 						<td> The identity of the annotation set. A uuid formatted as a URN is
-							recommended. </td>
+							RECOMMENDED. </td>
 						<td> URI </td>
 						<td> Yes </td>
 					</tr>
@@ -681,7 +718,7 @@
 						<td>
 							<code> type </code>
 						</td>
-						<td> The RDF structure type. It MUST be "AnnotationSet". </td>
+						<td> It MUST be <code>AnnotationSet</code>. </td>
 						<td> string </td>
 						<td> Yes </td>
 					</tr>
@@ -690,7 +727,7 @@
 							<code> generator </code>
 						</td>
 						<td> The agent responsible for the generation of the object serialization. </td>
-						<td> Generator </td>
+						<td> <a href="#2-1-generator"></a> </td>
 						<td> No </td>
 					</tr>
 					<tr>
@@ -698,7 +735,7 @@
 							<code> about </code>
 						</td>
 						<td> Information relative to the publication. </td>
-						<td> About object </td>
+						<td> <a href="#2-2-about"></a> </td>
 						<td> Yes </td>
 					</tr>
 					<tr>
@@ -755,7 +792,7 @@
 						<td>
 							<code> type </code>
 						</td>
-						<td> The RDF structure type. It MUST be "Software". </td>
+						<td> The RDF type. It MUST be "Software". </td>
 						<td> string </td>
 						<td> Yes </td>
 					</tr>
@@ -842,8 +879,8 @@
 					</tr>
 				</tbody>
 			</table>
-			<p class="note"> All properties defined above are from the Dublin Core vocabulary, referenced
-				in the Web Annotation Data Model. </p>
+			<p class="note"> All properties are from the Dublin Core Vocabulary [[dcterms]], also referenced
+				in the [[[annotation-model]]] as well as in the EPUB <a data-cite="epub-34#sec-pkg-metadata">package document metadata</a>. </p>
 
 			<aside class="example" title="An AnnotationSet containing one annotation">
 			<pre>
@@ -885,6 +922,13 @@
 			<p> The examples throughout the document are serialized as [[JSON-LD]] using the Context given in Appendix A
 				of the [[[annotation-vocab]]] [[annotation-vocab]], which is the preferred serialization format.
 				The media type of this format is <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>.</p>
+
+            <div class="issue"><p>As noted elsewhere, there is an additional work to be done here: (a) create/define a proper (RDF) vocabulary for all
+                terms, classes, etc, that have been defined in this spec, and an accompanying context file that must be used with the core annotation context.
+                </p>
+                <p>The experience of the VC Working Group will come in handy to make that relatively straightforward.</p>
+            </div>
+
 			<p> This specification introduces a dedicated file extension for serialized
 				<code>AnnotationSet</code>s: <code> .annotation </code>.</p>
         </section>
@@ -898,6 +942,11 @@
 				AnnotationSet. </p>
             <section class="informative">
 			<h1 id="4-best-practices-for-reading-systems"> Best Practices for Reading Systems </h1>
+
+            <p class="ednote">This section being informative, the MUST, SHOULD, etc, keyword are not appropriate here. At the minimum, they should be
+                turned into lower case.
+            </p>
+
             <section>
     			<h2 id="4-1-displaying-filtered-annotations"> Displaying filtered annotations </h2>
     			<p> Reading systems should enable filtering by motivation, color, highlight mode, keyword and

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -751,7 +751,7 @@
 						<td>
 							<code>title</code>
 						</td>
-						<td> A title helping on the identification of the set. </td>
+						<td> A title to help identifying the set. </td>
 						<td> string </td>
 						<td> No </td>
 					</tr>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -321,7 +321,7 @@
 					</tr>
 				</tbody>
 			</table>
-			<p> A Target with no Selector indicates that the annotation is targeting the entire
+			<p> A Target with no Selector indicates that the annotation applies to the entire
 				target resource. </p>
             <section>
 			<h4 id="1-3-1-source"> Source </h4>
@@ -817,7 +817,7 @@
             </section>
             <section>
 			<h3 id="2-2-about"> About </h3>
-			<p> The About object contains information relative to the publication. Such metadata in
+			<p> The About object contains information relative to the publication. Such metadata is
 				intended to help associate an annotation set with a publication: </p>
 			<table class="zebra">
 				<thead>
@@ -991,14 +991,14 @@
     			<h2 id="4-4-exporting-annotations-in-a-publication"> Exporting annotations in a
     				publication </h2>
     			<p> When a user decides to export a publication from the Reading System, he SHOULD be
-    				proposed to embed the annotations associated with the publication. </p>
-    			<p> If the user decides to embed annotations in a publication, he SHOULD be proposed to
+    				prompted to embed the annotations associated with the publication. </p>
+    			<p> If the user decides to embed annotations in a publication, he SHOULD be prompted to
     				filter the annotations by keywords (multiple choice). </p>
 
             </section>
             <section>
     			<h2 id="4-5-importing-annotations"> Importing annotations </h2>
-    			<p> To simplify the association of annotations with a publication, a Reading System MUST
+    			<p> To simplify associating annotations with a publication, a Reading System MUST
     				offer a way to select a publication before selecting an annotation set. The drag and
     				drop of an annotation set into a Reading System MAY also be proposed, but
     				identifying the proper publication from the metadata in the annotation set is more

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -239,7 +239,7 @@
             </section>
             <section>
 			<h3 id="1-2-creator"> Creator </h3>
-			<p> The creator of an annotation is a person or an organisation. </p>
+			<p> The creator of an annotation is a person or an organization. </p>
  			<p> This document defines the following creator properties: </p>
 			<table class="zebra">
 				<thead>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -94,8 +94,8 @@
                     whereas this document only defines these properties for <a href="#2-annotation-set">Annotation Sets</a>.
                     Web Annotations also define additional property values and types than are not usable for EPUB Annotations. </li>
                 <li> Web Annotations define an <code>AnnotationCollection</code> structure to handle paginated requests, whereas this document
-                    defines an <code>AnnotationSet</code> structure to group multiple annotations for sharing purposes.
-                    Implementers MUST support <code>AnnotationSet</code> and MAY support both structures for maximum compatibility.
+                    defines an [=AnnotationSet=] structure to group multiple annotations for sharing purposes.
+                    Implementers MUST support [=AnnotationSet=] and MAY support both structures for maximum compatibility.
                 </li>
             </ul>
 			<p class="note">This document does not define how annotations are created, stored, or
@@ -178,7 +178,7 @@
 						</td>
 						<td>The creator of the annotation. This may be either a human or an
 							organization.<br></td>
-						<td> <a href="#1-2-creator"></a> </td>
+						<td> [=Creator=] </td>
 						<td> No </td>
 					</tr>
 					<tr>
@@ -186,7 +186,7 @@
 							<code> target </code>
 						</td>
 						<td>The target content of the annotation.</td>
-						<td> <a href="#1-3-target"></a> </td>
+						<td> [=Target=] </td>
 						<td> Yes </td>
 					</tr>
 					<tr>
@@ -194,15 +194,15 @@
 							<code> body </code>
 						</td>
 						<td>The annotation body.</td>
-						<td> <a href="#1-4-body"></a> </td>
+						<td> [=Body=] </td>
 						<td> No </td>
 					</tr>
 				</tbody>
 			</table>
 
             <p class="note">The [[annotation-model]] specification is fairly open ended as for the value of, for example, the
-                <code>body</code> property. This specification restricts the value by defining specific classes that must be used, see the
-                <a href="#1-2-creator"></a>, <a href="#1-3-target"></a>, and <a href="#1-4-body"></a> below.
+                <code>body</code> property. This specification restricts the value by defining specific classes that must be used, see the definitions for
+                [=Creator=], [=Target=], and [=Body=] below.
             </p>
 
 			<p class="note">The type of annotation should be considered when determining the value of the <code>motivation</code> property.
@@ -239,7 +239,7 @@
             </section>
             <section>
 			<h3 id="1-2-creator"> Creator </h3>
-			<p> The creator of an annotation is a person or an organization. </p>
+			<p> The <dfn>Creator</dfn> of an annotation is a person or an organization. </p>
  			<p> This document defines the following creator properties: </p>
 			<table class="zebra">
 				<thead>
@@ -282,7 +282,7 @@
 
             <section>
 			<h3 id="1-3-target"> Target </h3>
-			<p>The target of an annotation associates the annotation with a specific segment of a
+			<p>The <dfn>Target</dfn> of an annotation associates the annotation with a specific segment of a
 				resource in the current publication.</p>
 			<p> This document defines three target sub-properties: </p>
 			<table class="zebra">
@@ -569,7 +569,7 @@
             <section>
 
 			<h3 id="1-4-body"> Body </h3>
-			<p>The body of an annotation contains plain text, style, and an optional keyword.</p>
+			<p>The <dfn>Body</dfn> of an annotation contains plain text, style, and an optional keyword.</p>
 			<p>This document specifies the following sub-properties:</p>
 			<table class="zebra">
 				<thead>
@@ -676,13 +676,14 @@
 				set of annotations is shared as a detached file, it is mandatory to also export
 				information that will help find the associated publication even if the publication
 				is not adequately identified.</p>
+
 			<p class="note">The <a data-cite="annotation-model#annotation-collection"><code>AnnotationCollection</code></a> defined
                 in the [[[annotation-model]]] does not provide an adequate
 				structure for sharing annotations either as a detached file or as a file embedded in
 				a Zip package. The <code>AnnotationCollection</code> meant to provide a
 				way to retrieve annotations via a REST API and is, therefore, intrinsically paginated.</p>
 
-			<p> The AnnotationSet object contains: </p>
+			<p> The <dfn>AnnotationSet</dfn> object contains: </p>
 			<table class="zebra">
 				<thead>
 					<tr>
@@ -724,23 +725,23 @@
 					</tr>
 					<tr>
 						<td>
-							<code> generator </code>
+							<code>generator</code>
 						</td>
 						<td> The agent responsible for the generation of the object serialization. </td>
-						<td> <a href="#2-1-generator"></a> </td>
+						<td> [=Generator=] </td>
 						<td> No </td>
 					</tr>
 					<tr>
 						<td>
-							<code> about </code>
+							<code>about</code>
 						</td>
 						<td> Information relative to the publication. </td>
-						<td> <a href="#2-2-about"></a> </td>
+						<td> [=About=] </td>
 						<td> Yes </td>
 					</tr>
 					<tr>
 						<td>
-							<code> generated </code>
+							<code>generated</code>
 						</td>
 						<td> The time when the set was generated. </td>
 						<td> ISO 8601 datetime </td>
@@ -748,7 +749,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> title </code>
+							<code>title</code>
 						</td>
 						<td> A title helping on the identification of the set. </td>
 						<td> string </td>
@@ -756,7 +757,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> items </code>
+							<code>items</code>
 						</td>
 						<td> The annotations of the set. </td>
 						<td> Array of Annotation objects </td>
@@ -767,7 +768,7 @@
 
             <section>
 			<h3 id="2-1-generator"> Generator </h3>
-			<p>The Generator object contains information relative to the software from which the
+			<p>The <dfn>Generator</dfn> object contains information relative to the software from which the
 				serialized annotation has been produced.</p>
 			<table class="zebra">
 				<thead>
@@ -817,7 +818,7 @@
             </section>
             <section>
 			<h3 id="2-2-about"> About </h3>
-			<p> The About object contains information relative to the publication. Such metadata is
+			<p> The <dfn>About</dfn> object contains information relative to the publication. Such metadata is
 				intended to help associate an annotation set with a publication: </p>
 			<table class="zebra">
 				<thead>
@@ -930,7 +931,7 @@
             </div>
 
 			<p> This specification introduces a dedicated file extension for serialized
-				<code>AnnotationSet</code>s: <code> .annotation </code>.</p>
+				[=AnnotationSets=]: <code> .annotation </code>.</p>
         </section>
 		</section>
 
@@ -939,7 +940,7 @@
 				EPUB </h1>
 
 			<p> The OPTIONAL <code> my.annotation </code> file in the META-INF directory holds an
-				AnnotationSet. </p>
+				[=AnnotationSet=]. </p>
             <section class="informative">
 			<h1 id="4-best-practices-for-reading-systems"> Best Practices for Reading Systems </h1>
 

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -919,7 +919,7 @@
             <section>
 
 			<h3 id="2-3-serialization"> Serialization </h3>
-			<p> The examples throughout the document are serialized as [[JSON-LD]] using the Context given in Appendix A
+			<p> The examples throughout the document are serialized as [[JSON-LD11]] using the Context given in Appendix A
 				of the [[[annotation-vocab]]] [[annotation-vocab]], which is the preferred serialization format.
 				The media type of this format is <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>.</p>
 

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -16,7 +16,7 @@
                 shortName: "epub-ann",
                 noRecTrack: false,
                 edDraftURI: "https://w3c.github.io/epub-specs/epub34/annotations/",
-                copyrightStart: "2025",
+                copyrightStart: "2026",
                 editors:[ {
                     name: "Laurent Le Meur",
                     company: "EDRLab",
@@ -31,6 +31,7 @@
                     branch: "main"
                 },
                 preProcess:[inlineCustomCSS],
+                testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
                 xref: {
                     profile: "web-platform",
                     specs:[ "epub-34"]
@@ -47,36 +48,50 @@
 			</p>
 		</section>
 		<section id="sotd"></section>
+        <section id="conformance">
+            <!-- <p>All algorithm explanations are <em>non-normative</em>.</p> -->
+        </section>
+
 		<section id="1-profile-of-the-w3c-annotation-data-model">
-			<h1> Subset of the W3C Annotation Data Model </h1>
-			<p> This section defines the profile of the W3C Annotation Data Model used for EPUB
-				annotations. </p>
-			<p> In the W3C Annotation Data Model, the core structure is the Annotation object,
-				which contains properties defining the annotation's target and body. </p>
-			<p> W3C Annotations have 0 or more Bodies, whereas this document only defines a single Body
-				per annotation. Such Body can be remote or embedded, whereas this document defines embedded Bodies only 
-				for textual comments (the inclusion mechanism is to be defined for audiovisual comments). </p> 
-			<p> W3C Annotations have 1 or more Targets, whereas this document only defines a single Target
-				per annotation. The Target of an EPUB Annotation is the content being annotated, which is  
-				a specific segment in a document within the EPUB package, defined by its relative Source URL and a Selector. </p>
-			<p> W3C Annotations can have multiple motivations, whereas this document only defines a single motivation
-				per annotation. </p>
-			<p> W3C Annotations can have multiple creators, whereas this document only defines a single creator
-				per annotation. </p>
-			<p> W3C Annotations can have additional properties not defined in this document, like a specific generator application
-				and generated date per Annotation, whereas this document only defines these properties at the Annotation Set level. 
-				W3C Annotations also handle more property values and types than defined in this document. </p>
-			<p> W3C Annotations define an AnnotationCollection structure to handle paginated requests, whereas this document
-				defines an AnnotationSet structure to group multiple annotations for sharing purposes.
-				Implementers MUST support AnnotationSet and MAY support both structures for maximum compatibility. </p>
-			<p> Note: This document does not define how annotations are created, stored, or
+			<h1> Subset of the Web Annotation Data Model </h1>
+			<p> This section defines a profile of the [[[annotation-model]]] [[annotation-model]], as used for EPUB
+				Annotations. In the Web Annotation model, the core structure is the
+                <a data-cite="annotation-model#annotations">Annotation object</a>,
+                which contains properties defining the annotation's
+                <a data-cite="annotation-model#bodies-and-targets">Body and Target</a>.
+                EPUB Annotations reuse the <a href="#1-1-annotation-object">same model</a> with some restrictions, listed below.
+                Subsequent sections provide more formal definitions for the terms used by this
+                specification.
+            </p>
+           <ul>
+                 <li> Web Annotations have 0 or more Bodies, whereas this document requires to have a single <a href="#1-4-body">Body</a>
+                    per annotation. Furthermore, in the [[annotation-model]], such Body can be remote or embedded,
+                    whereas only embedded Bodies are used in EPUB Annotation
+                    for textual comments (the inclusion mechanism is to be defined for audiovisual comments). </li>
+                <li> Web Annotations have 1 or more Targets, while only a single <a href="#1-3-target">Target</a> is allowed per
+                    EPUB Annotations.  The Target of an EPUB Annotation is the content being annotated, which is
+                    a specific segment in a document within the EPUB package defined by its relative <a href="#1-3-1-source">Source</a> URL and a <a href="#1-3-2-selector">Selector</a>. </li>
+                <li> Web Annotations may have multiple motivations, while only a single motivation is allowed for EPUB annotations. </li>
+                <li> Web Annotations may have multiple creators, while only a single creator is allowed for EPUB annotations</li>
+                <li> Web Annotations may have additional properties not accepted for EPUB Annotations. For example,
+                    a specific generator application and generated date may exist for a Web Annotation,
+                    whereas this document only defines these properties for <a href="#2-annotation-set">Annotation Sets</a>.
+                    Web Annotations also define additional property values and types than are not usable for EPUB Annotations. </li>
+                <li> Web Annotations define an <code>AnnotationCollection</code> structure to handle paginated requests, whereas this document
+                    defines an <code>AnnotationSet</code> structure to group multiple annotations for sharing purposes.
+                    Implementers MUST support <code>AnnotationSet</code> and MAY support both structures for maximum compatibility. </li>
+            </ul>
+			<p class="note">This document does not define how annotations are created, stored, or
 				synchronized in a reading system. </p>
 		</section>
+        <section>
 			<h2 id="1-annotation"> Annotation </h2>
+
+            <section>
 			<h3 id="1-1-annotation-object"> Annotation Object </h3>
-			<p> This document retains the following annotation properties from the W3C Annotation
+			<p> This document retains the following annotation properties from the Web Annotation
 				Data Model: </p>
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th> Name </th>
@@ -164,33 +179,37 @@
 				</tbody>
 			</table>
 
-			<p>Note: The type of annotation should be considered when determining the value of the <code>motivation</code> property. 
-				An annotation with a Body structure corresponds to a "comment". 
-				An annotation without Body structure corresponds to a "highlight" if its Selector defines a range of characters, a space in an image 
+			<p class="note">The type of annotation should be considered when determining the value of the <code>motivation</code> property.
+				An annotation with a Body structure corresponds to a "comment".
+				An annotation without Body structure corresponds to a "highlight" if its Selector defines a range of characters, a space in an image
 				or a time period, and a "bookmark" if it does not.</p>
-			<p>Question: should we add a "replying" motivation for annotations that are replies to other annotations?</p>
-			
-			<p> Sample 1: Core structure of an EPUB annotation </p>
+
+			<p class="issue">Question: should we add a "replying" motivation for annotations that are replies to other annotations?</p>
+
+            <aside class="example" title="Core structure of an EPUB annotation">
+
+			<!-- <p> Sample 1: Core structure of an EPUB annotation </p> -->
 			<pre>
-				<code class="lang-json">
-					{
-					  "@context": "http://www.w3.org/ns/anno.jsonld",
-					  "id": "urn:uuid:123-123-123-123",
-					  "type": "Annotation",
-					  "created": "2023-10-14T15:13:28Z",
-					  "modified": "2024-01-29T09:00:00Z",
-					  "target": {
-					   },
-					  "body": {
-					  }
-					}
-				</code>
+                {
+                    "@context": "http://www.w3.org/ns/anno.jsonld",
+                    "id": "urn:uuid:123-123-123-123",
+                    "type": "Annotation",
+                    "created": "2023-10-14T15:13:28Z",
+                    "modified": "2024-01-29T09:00:00Z",
+                    "target": {
+                    },
+                    "body": {
+                    }
+                }
 			</pre>
-			
+            </aside>
+
+            </section>
+            <section>
 			<h3 id="1-2-creator"> Creator </h3>
 			<p> The creator of an annotation is a person or an organisation. </p>
 			<p> This document defines the following creator properties: </p>
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th> Name </th>
@@ -227,12 +246,14 @@
 					</tr>
 				</tbody>
 			</table>
-			
+            </section>
+
+            <section>
 			<h3 id="1-3-target"> Target </h3>
 			<p>The target of an annotation associates the annotation with a specific segment of a
 				resource in the current publication.</p>
 			<p> This document defines three target sub-properties: </p>
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th> Name </th>
@@ -270,16 +291,14 @@
 			</table>
 			<p> A Target with no Selector indicates that the annotation is targeting the entire
 				target resource. </p>
-			
+            <section>
 			<h4 id="1-3-1-source"> Source </h4>
 			<p> The target resource MUST be identified by the URL of an existing resource in the
 				EPUB package. It MUST be one of the item/@href values of the
 				<a href="https://www.w3.org/TR/epub-33/#sec-manifest-elem"> manifest element </a>.</p>
 
-			<p> Sample 2: the source of the annotation is the relative URL identifying an HTML
-				document in an EPUB. </p>
+            <aside class="example" title=" the source of the annotation is the relative URL identifying an HTML document in an EPUB">
 			<pre>
-				<code class="lang-json">
 					{
 					  "@context": "http://www.w3.org/ns/anno.jsonld",
 					  "type": "Annotation",
@@ -291,23 +310,23 @@
 					    }
 					  }
 					}
-				</code>
 			</pre>
-			
+            </aside>
+            </section>
+            <section>
 			<h4 id="1-3-2-selector"> Selector </h4>
 			<p> An annotation refers to a segment of a resource, which is identified by one or more
 				Selectors. The nature of the Selectors and methods to describe segments depend on
 				the resource type. Providing more than one Selector allows an annotation software to
 				choose the most accurate selector from those it can handle and helps accommodate
 				evolutions on the annotated resource. </p>
-			<p> Annotation selectors are specified in <a
-					href="https://www.w3.org/TR/2017/REC-annotation-model-20170223/#selectors"> W3C
-					Annotation Data Model, section Selectors </a>. This specification filters
-				selectors deemed useful for annotating publications and details the use of these
+			<p> Annotation selectors are specified in <a data-cite="annotation-model#selectors">Web
+					Annotation Data Model, section on Selectors </a>. This specification retains
+				selectors deemed useful for annotating publications and details on how to use these
 				selectors. </p>
-			<p> Note: New selectors will undoubtedly be defined in the coming months after
+			<p class="note">New selectors will undoubtedly be defined in the coming months after
 				discussion with members of the W3C Publishing Maintenance Working Group.</p>
-			
+
 			<!--
 			<h5 id="1-3-2-1-text-quote-selector"> Text Quote Selector </h5>
 			<p> This Selector describes a range of text by copying it and including some of the
@@ -339,7 +358,7 @@
 			</pre>
 			<h5 id="1-3-2-2-cssselector-textpositionselector"> CssSelector +
 				TextPositionSelector </h5>
-			<p>References in the W3C Annotation Data Model: <a
+			<p>References in the Web Annotation Data Model: <a
 					href="https://www.w3.org/TR/annotation-model/#css-selector"> CSS Selector </a> ,
 					<a href="https://www.w3.org/TR/annotation-model/#text-position-selector"> Text
 					Position Selector </a> , <a
@@ -350,7 +369,7 @@
 				positions of the selection in the stream. Position 0 would be immediately before the
 				first character, position 1 would be immediately before the second character, and so
 				on. The start character is thus included in the list, but the end character is not.
-				The W3C Annotation Data Model specifies that the selection of the text MUST be in
+				The Web Annotation Data Model specifies that the selection of the text MUST be in
 				terms of <strong> unicode code points </strong> (the &quot;character number&quot;),
 				not in terms of code units (that number expressed using a selected data type).
 				Selections SHOULD NOT start or end in the middle of a grapheme cluster. The
@@ -372,7 +391,7 @@
 					      "type": "CssSelector",
 					      "value": "#intro > p:nth-child(2)",
 					      "refinedBy": {
-					        "type": "TextPositionSelector",	 
+					        "type": "TextPositionSelector",
 					        "start": 4,
 					        "end": 19
 					      }
@@ -393,14 +412,14 @@
 					</div>
 				</code>
 			</pre>
-			
+
 			<h5 id="1-3-2-3-progressionselector"> ProgressionSelector </h5>
 			<p>A ProgressionSelector contains a decimal value representing the annotation's
 				position as a percentage of the total size of the resource.</p>
 			<p>While such positioning is imprecise and does not correctly identify a fragment, it
 				is helpful to order annotations in a list and help position the annotation near the
 				corresponding fragment if other selectors fail.</p>
-				
+
 			<p>Sample 5: This ProgressionSelector indicates that the annotation is positioned just
 				after the middle of the resource:</p>
 			<pre>
@@ -408,7 +427,7 @@
 					{
 					  "selector": [
 					    {
-					    "type": "ProgressionSelector",	 
+					    "type": "ProgressionSelector",
 					    "value": 0.534234255
 					    }
 					  ]
@@ -416,7 +435,7 @@
 				</code>
 			</pre>
 			-->
-			
+
 			<!--
 			<h4 id="1-3-3-meta"> Meta </h4>
 			<p>Meta information MAY be added to an annotation as “breadcrumbs”, to ease the display
@@ -504,18 +523,21 @@
 					        "txt": "Sub Section 1"
 					        }
 					      ],
-					      "page": "XI"       
+					      "page": "XI"
 					    }
 					  }
 					}
 				</code>
 			</pre>
 			-->
-			
+            </section>
+            </section>
+            <section>
+
 			<h3 id="1-4-body"> Body </h3>
 			<p>The body of an annotation contains plain text, style, and an optional keyword.</p>
 			<p>The body property contains:</p>
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th> Name </th>
@@ -547,14 +569,14 @@
 						</td>
 						<td> The media-type of the annotation value; "text/plain" by
 							default; "text/markdown" is recommended. </td>
-						<td> rfc6838, rfc7763 </td>
+						<td> [[RFC6838]], [[RFC7763]] </td>
 						<td> No </td>
 					</tr>
 					<tr>
 						<td>
 							<code> color </code>
 						</td>
-						<td> The colour of the annotation; yellow by default. </td>
+						<td> The color of the annotation; yellow by default. </td>
 						<td> "pink" | "orange" | "yellow" | "green" | "blue" | "purple" </td>
 						<td> No </td>
 					</tr>
@@ -586,34 +608,34 @@
 						<td>
 							<code> keyword </code>
 						</td>
-						<td> Free text categorising the annotation. </td>
+						<td> Free text categorizing the annotation. </td>
 						<td> string </td>
 						<td> No </td>
 					</tr>
 				</tbody>
 			</table>
-			<p> Note: Read “Best practices for Reading Systems” about using a keyword in an
+			<p class="note">Read “Best practices for Reading Systems” about using a keyword in an
 				annotation. </p>
-			
-			<p> Sample 7: An annotation Body. </p>
+
+            <aside class="example" title="An annotation Body">
 			<pre>
-				<code class="lang-json">
 					{
 					  "@context": "http://www.w3.org/ns/anno.jsonld",
 					  "type": "Annotation",
 					  "body": {
 					    "type": "TextualBody",
 					    "value": "j'adore !",
-					    "keyword": "teacher",   
+					    "keyword": "teacher",
 					    "color": "blue",
 					    "language": "fr",
 					    "textDirection": "ltr"
 					  }
 					}
-				</code>
 			</pre>
+            </aside>
+            </section>
 		</section>
-		
+
 		<section>
 			<h2 id="2-annotation-set"> Annotation Set </h2>
 			<p>An Annotation does not contain information about its associated publication. If a
@@ -624,9 +646,9 @@
 				structure for sharing annotations either as a detached file or as a file embedded in
 				a Zip package. The AnnotationCollection is intrinsically paginated and provides a
 				way to retrieve annotations via a REST API.</p>
-			
+
 			<p> The AnnotationSet object contains: </p>
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th> Name </th>
@@ -667,7 +689,7 @@
 						<td>
 							<code> generator </code>
 						</td>
-						<td> The agent responsible for the generation of the object serialisation. </td>
+						<td> The agent responsible for the generation of the object serialization. </td>
 						<td> Generator </td>
 						<td> No </td>
 					</tr>
@@ -705,11 +727,12 @@
 					</tr>
 				</tbody>
 			</table>
-			
+
+            <section>
 			<h3 id="2-1-generator"> Generator </h3>
 			<p>The Generator object contains information relative to the software from which the
 				serialized annotation has been produced.</p>
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th> Name </th>
@@ -754,10 +777,12 @@
 					</tr>
 				</tbody>
 			</table>
+            </section>
+            <section>
 			<h3 id="2-2-about"> About </h3>
 			<p> The About object contains information relative to the publication. Such metadata in
 				intended to help associate an annotation set with a publication: </p>
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th> Name </th>
@@ -817,12 +842,11 @@
 					</tr>
 				</tbody>
 			</table>
-			<p> Note: all properties defined above are from the Dublin Core vocabulary, referenced
+			<p class="note"> All properties defined above are from the Dublin Core vocabulary, referenced
 				in the Web Annotation Data Model. </p>
-			
-			<p> Sample 8: An AnnotationSet containing one annotation. </p>
+
+			<aside class="example" title="An AnnotationSet containing one annotation">
 			<pre>
-				<code class="lang-json">
 					{
 					  "@context": "http://www.w3.org/ns/anno.jsonld",
 					  "id": "urn:uuid:123-123-123-123",
@@ -852,99 +876,115 @@
 					    }
 					  ]
 					}
-				</code>
 			</pre>
-			
+            </aside>
+            </section>
+            <section>
+
 			<h3 id="2-3-serialization"> Serialization </h3>
-			<p> The examples throughout the document are serialized as [JSON-LD] using the Context given in Appendix A 
-				of the Annotation Vocabulary [annotation-vocab], which is the preferred serialization format. 
-				The media type of this format is "application/ld+json;profile="http://www.w3.org/ns/anno.jsonld".</p>
+			<p> The examples throughout the document are serialized as [[JSON-LD]] using the Context given in Appendix A
+				of the [[[annotation-vocab]]] [[annotation-vocab]], which is the preferred serialization format.
+				The media type of this format is <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>.</p>
 			<p> This specification introduces a dedicated file extension for serialized
-				AnnotationSets: <code> .annotation </code>.</p>
+				<code>AnnotationSet</code>s: <code> .annotation </code>.</p>
+        </section>
 		</section>
-		
+
 		<section>
 			<h1 id="3-embedding-annotations-in-publications"> Embedding annotations in
 				EPUB </h1>
-			
+
 			<p> The OPTIONAL <code> my.annotation </code> file in the META-INF directory holds an
 				AnnotationSet. </p>
-			
+            <section class="informative">
 			<h1 id="4-best-practices-for-reading-systems"> Best Practices for Reading Systems </h1>
-			<p>
-				<em> This section is non-normative. </em>
-			</p>
-			<h2 id="4-1-displaying-filtered-annotations"> Displaying filtered annotations </h2>
-			<p> Reading systems should enable filtering by motivation, colour, highlight mode, keyword and
-				creator. For instance, a user can display &quot;blue&quot; annotations only or
-				“teacher” annotations only. Filtering on multiple criteria is a plus. </p>
+            <section>
+    			<h2 id="4-1-displaying-filtered-annotations"> Displaying filtered annotations </h2>
+    			<p> Reading systems should enable filtering by motivation, color, highlight mode, keyword and
+    				creator. For instance, a user can display &quot;blue&quot; annotations only or
+    				“teacher” annotations only. Filtering on multiple criteria is a plus. </p>
 
-			<h2 id="4-2-using-multiple-selectors"> Using multiple selectors </h2>
-			<p> It is recommended that Reading Systems export multiple selectors, including at least
-				one precise selector (e.g. CssSelector + TextPositionSelector)
-				and one selector resistant to content modifications (e.g. ProgressionSelector). </p>
-			<p> When displaying an annotation, a Reading System is free to use the most precise
-				Selector available. It will select an alternative Selector as a fallback in case the
-				preferred one does not return a correct position in the publication: this can happen
-				if the publication has been modified after the annotation has been created. </p>
-			<p> Not all selectors are equally easy to implement. Reading Systems MAY choose to
-				support only a subset of the selectors defined in this specification. </p>
-			<p> The W3C Publishing Maintenance Working Group is expected to define one or more selectors 
-				reading systems are required to implement, as a <i>lingua franca</i>. </p> 
-			
-			<h2 id="4-3-exporting-annotations-as-a-detached-file"> Exporting annotations as a
-				detached file </h2>
-			<p> When a user decides to export an annotation set from a reading system, he SHOULD be
-				proposed to filter the annotations by keywords (multiple choice). “Annotations with
-				no keyword” and “All annotations” SHOULD be proposed as options. The advantage of
-				this practice is that, for instance, a user can export personal annotations (usually
-				with no keyword) and leave “teacher” annotations unexported. </p>
-			<p> They MAY enter a title for the annotation set (empty by default). Such a title SHOULD
-				become the exported filename. </p>
-			<p> They MUST be able to choose the directory in which the annotation set will be stored. </p>
-			<p> The file extension MUST be <code> .annotation </code> . </p>
-			<p> The application may propose alternative formats at export time: an HTML or markdown format 
-				with human-friendly references to the location of each annotation may be handy. </p>
-			
-			<h2 id="4-4-exporting-annotations-in-a-publication"> Exporting annotations in a
-				publication </h2>
-			<p> When a user decides to export a publication from the Reading System, he SHOULD be
-				proposed to embed the annotations associated with the publication. </p>
-			<p> If the user decides to embed annotations in a publication, he SHOULD be proposed to
-				filter the annotations by keywords (multiple choice). </p>
+            </section>
 
-			<h2 id="4-5-importing-annotations"> Importing annotations </h2>
-			<p> To simplify the association of annotations with a publication, a Reading System MUST
-				offer a way to select a publication before selecting an annotation set. The drag and
-				drop of an annotation set into a Reading System MAY also be proposed, but
-				identifying the proper publication from the metadata in the annotation set is more
-				complicated. </p>
-			<p> When importing an annotation set, a Reading System SHOULD display a message with the
-				title of the annotation set and the number of annotations in the set. The Reading
-				System MUST offer the user the choice to abort the import. </p>
-			<p> Each annotation is uniquely identified. If during the import of an annotation set,
-				one or more annotations are re-imported, the Reading System MUST offer to the user
-				the choice to override existing annotations or abort the import of the annotation
-				set. </p>
+            <section>
+    			<h2 id="4-2-using-multiple-selectors"> Using multiple selectors </h2>
+    			<p> It is recommended that Reading Systems export multiple selectors, including at least
+    				one precise selector (e.g. CssSelector + TextPositionSelector)
+    				and one selector resistant to content modifications (e.g. ProgressionSelector). </p>
+    			<p> When displaying an annotation, a Reading System is free to use the most precise
+    				Selector available. It will select an alternative Selector as a fallback in case the
+    				preferred one does not return a correct position in the publication: this can happen
+    				if the publication has been modified after the annotation has been created. </p>
+    			<p> Not all selectors are equally easy to implement. Reading Systems MAY choose to
+    				support only a subset of the selectors defined in this specification. </p>
+    			<p> The W3C Publishing Maintenance Working Group is expected to define one or more selectors
+    				reading systems are required to implement, as a <i>lingua franca</i>. </p>
 
-			<h2 id="4-6-dealing-with-colours"> Dealing with colours </h2>
-			<p> This document specifies a closed set of six colours chosen because of their
-				extensive support in well-known reading systems. However, most existing reading apps
-				offer a smaller set to their users. </p>
-			<p> If an application imports annotations with a colour it does not support, it should
-				display them with a neutral colour. The recommended neutral colour is grey. </p>
-			<p> Some applications may support colours not in the set defined by this specification
-				(e.g. brown). In this case, a 1-to-1 substitution at export time is required (e.g.
-				brown to orange). </p>
-			<p> Note: we didn't spot applications with more than six annotation colours. </p>
-		</section>
-		
+            </section>
+
+            <section>
+    			<h2 id="4-3-exporting-annotations-as-a-detached-file"> Exporting annotations as a
+    				detached file </h2>
+    			<p> When a user decides to export an annotation set from a reading system, he SHOULD be
+    				proposed to filter the annotations by keywords (multiple choice). “Annotations with
+    				no keyword” and “All annotations” SHOULD be proposed as options. The advantage of
+    				this practice is that, for instance, a user can export personal annotations (usually
+    				with no keyword) and leave “teacher” annotations unexported. </p>
+    			<p> They MAY enter a title for the annotation set (empty by default). Such a title SHOULD
+    				become the exported filename. </p>
+    			<p> They MUST be able to choose the directory in which the annotation set will be stored. </p>
+    			<p> The file extension MUST be <code> .annotation </code> . </p>
+    			<p> The application may propose alternative formats at export time: an HTML or markdown format
+    				with human-friendly references to the location of each annotation may be handy. </p>
+
+            </section>
+            <section>
+    			<h2 id="4-4-exporting-annotations-in-a-publication"> Exporting annotations in a
+    				publication </h2>
+    			<p> When a user decides to export a publication from the Reading System, he SHOULD be
+    				proposed to embed the annotations associated with the publication. </p>
+    			<p> If the user decides to embed annotations in a publication, he SHOULD be proposed to
+    				filter the annotations by keywords (multiple choice). </p>
+
+            </section>
+            <section>
+    			<h2 id="4-5-importing-annotations"> Importing annotations </h2>
+    			<p> To simplify the association of annotations with a publication, a Reading System MUST
+    				offer a way to select a publication before selecting an annotation set. The drag and
+    				drop of an annotation set into a Reading System MAY also be proposed, but
+    				identifying the proper publication from the metadata in the annotation set is more
+    				complicated. </p>
+    			<p> When importing an annotation set, a Reading System SHOULD display a message with the
+    				title of the annotation set and the number of annotations in the set. The Reading
+    				System MUST offer the user the choice to abort the import. </p>
+    			<p> Each annotation is uniquely identified. If during the import of an annotation set,
+    				one or more annotations are re-imported, the Reading System MUST offer to the user
+    				the choice to override existing annotations or abort the import of the annotation
+    				set. </p>
+
+            </section>
+            <section>
+    			<h2 id="4-6-dealing-with-colors"> Dealing with colors </h2>
+    			<p> This document specifies a closed set of six colors chosen because of their
+    				extensive support in well-known reading systems. However, most existing reading apps
+    				offer a smaller set to their users. </p>
+    			<p> If an application imports annotations with a color it does not support, it should
+    				display them with a neutral color. The recommended neutral color is grey. </p>
+    			<p> Some applications may support colors not in the set defined by this specification
+    				(e.g. brown). In this case, a 1-to-1 substitution at export time is required (e.g.
+    				brown to orange). </p>
+    			<p> Note: we didn't spot applications with more than six annotation colors. </p>
+
+            </section>
+            </section>
+        </section>
+
 		<section>
 			<h1 id="5-json-schema"> JSON Schema </h1>
 		</section>
-		
+
 		<section>
-			<h1 id="6-references"> References </h1>
+			<h1 id="6-references">Further readings </h1>
 			<p> Open Annotation in EPUB, 2015: <a href="https://idpf.org/epub/oa/">
 					https://idpf.org/epub/oa/ </a>
 			</p>


### PR DESCRIPTION
I did an, essentially, editorial pass through the document. "Essentially" because I tried to avoid making any kind of technical changes, I hope I have changed, inadvertently, something.

The overall changes are (1) harmonize with our other documents and (2) make respec happier. Some of the changes I made

- I systematically added html sectioning with `<section>` elements; I believe respec's formatting with header formatting, CSS rules, etc, rely on those
- I added classes to table to make them more readable, along the lines of tables in our other specs
- Used the respec idioms as well as specref for references, which made respec generate proper reference lists, both formal and informal
- I used the `<aside>` structure for all the examples, much as it is done in the authoring spec
- Use `note` and `ednote` classes for notes and editorial notes. I also added issues here and there; some of those may have to be moved to GitHub
- I added some cross references within the document as well as to the Web Annotation spec. As an aside: the document systematically referred to the "W3C Annotation Model", but the right title is "Web Annotation Model". After all, this document will, eventually, become a W3C document as well...

One thing I did not change: there are explicit section id setting (more exactly `<hx>` id settings) which reflect, I presume, the section numbering of the original document. This is inherently brittle, if ever we want to add a new section or, God Forbid! reorganize a document. Would be better to use a different scheme or, maybe even better, let respec do it (it automatically generates id values based on the section title).

I realize this PR is difficult to preview, sorry about that...

----

See:

* For EPUB 3 Annotations:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/1st-anno-draft-comments/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/annotations/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/1st-anno-draft-comments/epub34/annotations/index.html)
