### PR TITLE
Fix the broken html syntax links

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -5839,7 +5839,7 @@ No Entry</pre>
 					<h4>Introduction</h4>
 
 					<p>An [=XHTML content document=] is an instance of an <a href="#sec-xml-constraints">XML
-							document</a> expressed using the <a data-cite="html#the-xml-syntax">XML syntax</a> of the
+							document</a> expressed using the <a data-cite="html#the-xhtml-syntax">XML syntax</a> of the
 						[[[html]]] [[html]].</p>
 
 					<p>XHTML content documents that conform to this profile are [=core media type resources=] and one of
@@ -5847,7 +5847,7 @@ No Entry</pre>
 						fallbacks in the [^spine^].</p>
 
 					<div class="note">
-						<p>EPUB 3 does not support the <a data-cite="html#the-html-syntax">HTML syntax</a> of [[html]]
+						<p>EPUB 3 does not support the <a data-cite="html#syntax">HTML syntax</a> of [[html]]
 							as a core media type. Although both serializations allow the same elements to be expressed,
 							not all JavaScript libraries and APIs are designed to handle the XML syntax, in particular
 							the shadow DOM. This means, for example, that although the [^template^] element [[html]] can
@@ -5866,10 +5866,11 @@ No Entry</pre>
 
 						<p>Earlier versions of EPUB 3 referred to W3C's HTML5 standard to define EPUB content documents,
 							but that standard was largely a snapshot of the HTML Standard maintained by the WHATWG.
-							After reaching an <a href="https://www.w3.org/2019/04/WHATWG-W3C-MOU.html">agreement</a> on the development of HTML in 2019, the W3C standard was retired
-							and EPUB 3 now exclusively refers to the HTML Standard. It does not mean that EPUB 3 does
-							not support HTML5 anymore in XHTML content documents, only that HTML5 is now a marketing
-							term that refers to the HTML Standard as the successor to HTML 4.01 and XHTML 1.1.</p>
+							After reaching an <a href="https://www.w3.org/2019/04/WHATWG-W3C-MOU.html">agreement</a> on
+							the development of HTML in 2019, the W3C standard was retired and EPUB 3 now exclusively
+							refers to the HTML Standard. It does not mean that EPUB 3 does not support HTML5 anymore in
+							XHTML content documents, only that HTML5 is now a marketing term that refers to the HTML
+							Standard as the successor to HTML 4.01 and XHTML 1.1.</p>
 					</div>
 				</section>
 


### PR DESCRIPTION
Fixes #2839 

<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2840.html" title="Last updated on Dec 1, 2025, 1:46 PM UTC (9c4cf09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2840/293685b...9c4cf09.html" title="Last updated on Dec 1, 2025, 1:46 PM UTC (9c4cf09)">Diff</a>