### PR TITLE
Reorganized layout section

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
-		<!--<meta name="color-scheme" content="light dark" />-->
+		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
@@ -6131,7 +6131,7 @@ No Entry</pre>
 
 			<section id="sec-spread-placement" data-epubcheck="true"
 				data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L166,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L171">
-				<h3>Spread placement</h3>
+				<h3>Synthetic spreads</h3>
 
 				<p>When a [=reading system=] renders a [=synthetic spread=], the default behavior is to populate the
 					spread by rendering the next [=EPUB content document=] in the next available unpopulated

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -175,7 +175,7 @@
 
 				<p>EPUB publications by default are intended to reflow to fit the available screen space. It is also
 					possible to create publications that have pixel-precise fixed layouts using images and/or CSS
-					positioning. The metadata to control layouts are defined in <a href="#sec-rendering"></a>.</p>
+					positioning. The metadata to control layouts are defined in <a href="#sec-layout"></a>.</p>
 
 				<p>[=Media overlay documents=] complement EPUB content documents. They provide declarative markup for
 					synchronizing the text in EPUB content documents with prerecorded audio. The result is the ability
@@ -3730,7 +3730,7 @@
 						</li>
 						<li>
 							<p>to provide access to all rendering metadata needed to control the layout and display of
-								the content (e.g., <a href="#sec-fxl-package">fixed-layout properties</a>).</p>
+								the content (e.g., <a href="#app-rendering-vocab">package rendering properties</a>).</p>
 						</li>
 					</ol>
 
@@ -5828,7 +5828,7 @@ No Entry</pre>
 				</section>
 			</section>
 		</section>
-		<section id="sec-rendering">
+		<section id="sec-layout">
 			<h2>Layout rendering</h2>
 
 			<section id="sec-general-rendering-intro" class="informative">
@@ -5930,16 +5930,16 @@ No Entry</pre>
 				<section id="sec-pre-paginated">
 					<h4>Pre-paginated layouts</h4>
 
-					<p>In a pre-paginated layout, each [=fixed-layout document=] referenced a the [=EPUB spine | spine=]
-						[^itemref^] represents one page of content. Reading systems are expected to scale the document
-						to fit the viewport or synthetic spread.</p>
-
 					<div class="note">
 						<p>Pre-paginated layouts were commonly referred to as fixed layouts prior to the introduction of
 								<a href="#sec-roll">roll layouts</a>. As both layouts make use of [=fixed-layout
 							documents=], the term "fixed layout" is now used exclusively for describing EPUB content
 							documents with fixed dimensions, not for the layout type they appear in.</p>
 					</div>
+
+					<p>In a pre-paginated layout, each [=fixed-layout document=] referenced by a [=EPUB spine | spine=]
+						[^itemref^] represents one page of content. Reading systems are expected to scale the document
+						to fit the viewport or synthetic spread.</p>
 
 					<p>To declare that an EPUB publication uses a pre-paginated layout, the <a href="#layout"
 								><code>rendition:layout</code> property</a> MUST be declared in a <code>meta</code>
@@ -5984,8 +5984,9 @@ No Entry</pre>
 					</div>
 
 					<p id="fxl-layout-duplication" data-tests="#lay-fxl-layout-duplication">When the property is set to
-							<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as defined
-						in <a href="#sec-content-dimensions"></a>.</p>
+							<code>pre-paginated</code> for a spine item, the [^itemref^] element MUST reference a <a
+							href="#sec-fxl-docs">fixed layout document</a> or there MUST be one in the [=manifest
+						fallback chain=].</p>
 
 					<p>The following properties from the <a href="#app-rendering-vocab">Package rendering vocabulary</a>
 						can be applied to pre-paginated spine items to further control their rendering:</p>
@@ -5997,7 +5998,7 @@ No Entry</pre>
 						<li>the <a href="#spread"><code>rendition:spread</code> property</a> and its <a
 								href="#spread-overrides">spine overrides</a> are used to indicate a preference for how
 							reading systems ...</li>
-						<li>the <a href="#page-spread"><code>rendition:page-spread-*</code> spine override
+						<li>the <a href="#spread-placement"><code>rendition:page-spread-*</code> spine override
 								properties</a> are used to indicate a preference for how to place spine items in a
 							synthetic spread (on the right or left side of a two-page spread, or centered without a
 							spread).</li>
@@ -6140,27 +6141,23 @@ No Entry</pre>
 					particular viewport, this automatic population behavior MAY be overridden by specifying one of the
 					following properties on its spine <code>itemref</code> element:</p>
 
-				<dl>
-					<dt id="page-spread-center">
-						<code>rendition:page-spread-center</code>
-					</dt>
-					<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a href="#spread-none"
-								><code>spread-none</code> property</a> for centering a spine item.</dd>
-
-					<dt id="fxl-page-spread-left">
-						<code>rendition:page-spread-left</code>
-					</dt>
-					<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
-								href="#page-spread-left">page-spread-left</a></code> property for placing a spine item
-						in the left-hand slot of a two-page spread.</dd>
-
-					<dt id="fxl-page-spread-right">
-						<code>rendition:page-spread-right</code>
-					</dt>
-					<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
-								href="#page-spread-right">page-spread-right</a></code> property for placing a spine item
-						in the right-hand slot of a two-page spread.</dd>
-				</dl>
+				<ul>
+					<li id="page-spread-center">
+						<a href="#page-spread-center">
+							<code>rendition:page-spread-center</code>
+						</a>
+					</li>
+					<li id="fxl-page-spread-left">
+						<a href="#page-spread-left">
+							<code>rendition:page-spread-left</code>
+						</a>
+					</li>
+					<li id="fxl-page-spread-right">
+						<a href="#page-spread-right">
+							<code>rendition:page-spread-right</code>
+						</a>
+					</li>
+				</ul>
 
 				<p>The <code>rendition:page-spread-center</code>, <code>rendition:page-spread-left</code>, and
 						<code>rendition:page-spread-right</code> properties apply to both pre-paginated and reflowable
@@ -6196,43 +6193,43 @@ No Entry</pre>
 						other (reflowable) parts has been left undefined, since the global value of
 							<code>rendition:spread</code> initializes to <code>auto</code> by default.</p>
 
-					<pre>&lt;package …&gt;
-…
-&lt;spine page-progression-direction="ltr"&gt;
-…
-&lt;itemref
-idref="center-plate-left"
-properties="rendition:spread-both rendition:page-spread-left"/&gt;
-&lt;itemref
-idref="center-plate-right"
-properties="rendition:spread-both rendition:page-spread-right"/&gt;
-…
-&lt;/spine&gt;
-&lt;/package&gt;</pre>
+					<pre>&lt;package …>
+   …
+   &lt;spine page-progression-direction="ltr">
+      …
+      &lt;itemref
+          idref="center-plate-left"
+          properties="rendition:spread-both rendition:page-spread-left"/>
+      &lt;itemref
+          idref="center-plate-right"
+          properties="rendition:spread-both rendition:page-spread-right"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
 				</aside>
 
 				<aside class="example" id="fxl-ex6" title="Creating a centered layout">
-					<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:layout"&gt;
-pre-paginated
-&lt;/meta&gt;
-&lt;meta
-property="rendition:spread"&gt;
-auto
-&lt;/meta&gt;
-&lt;/metadata&gt;
-&lt;spine&gt;
-…
-&lt;itemref
-idref="center-plate"
-properties="rendition:page-spread-center"/&gt;
-…
-&lt;/spine&gt;
-…
-&lt;/package&gt;</pre>
+					<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         auto
+      &lt;/meta>
+   &lt;/metadata>
+   &lt;spine>
+      …
+      &lt;itemref
+          idref="center-plate"
+          properties="rendition:page-spread-center"/>
+      …
+   &lt;/spine>
+   …
+&lt;/package></pre>
 				</aside>
 			</section>
 		</section>
@@ -6625,9 +6622,11 @@ properties="rendition:page-spread-center"/&gt;
 					or losing all meaning. [=Fixed-layout documents=] give greater control over presentation when a
 					reflowable EPUB is not suitable for the content.</p>
 
-				<p>Fixed layouts are defined using a <a href="#sec-fxl-package">set of package document properties</a>
-					to control the presentation in [=reading systems=] while the <a href="#sec-content-dimensions"
-						>layout dimensions</a> are obtained from each respective [=EPUB content document=].</p>
+				<p>The <a href="#sec-content-dimensions">layout dimensions</a> of a fixed layout document are obtained
+					from each respective [=EPUB content document=]. How the documents are presented in a reading systems
+					depends on the <a href="#sec-layout">layout</a> used &#8212; they can be presented in a
+					pre-paginated fashion (one per viewport or synthetic spread) or can be presented as a roll. It is
+					also possible to override a reflowable layout to inject pre-paginated fixed layout documents.</p>
 
 				<div class="note" id="note-mechanisms">
 					<p>EPUB 3 supports multiple formats for representing fixed-layout content. When fixed-layout content

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3.4</title>
-		<meta name="color-scheme" content="light dark" />
+		<!--<meta name="color-scheme" content="light dark" />-->
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
@@ -175,8 +175,7 @@
 
 				<p>EPUB publications by default are intended to reflow to fit the available screen space. It is also
 					possible to create publications that have pixel-precise fixed layouts using images and/or CSS
-					positioning. The metadata to control layouts are defined in <a href="#sec-rendering-control"
-					></a>.</p>
+					positioning. The metadata to control layouts are defined in <a href="#sec-rendering"></a>.</p>
 
 				<p>[=Media overlay documents=] complement EPUB content documents. They provide declarative markup for
 					synchronizing the text in EPUB content documents with prerecorded audio. The result is the ability
@@ -350,7 +349,9 @@
 							unless it also has the media type of an EPUB content document.</p>
 					</dd>
 
-					<dt><dfn class="export">EPUB conformance checker</dfn></dt>
+					<dt>
+						<dfn class="export">EPUB conformance checker</dfn>
+					</dt>
 					<dd>
 						<p>An application that verifies the requirements of this specification against [=EPUB
 							publications=] and reports on their conformance.</p>
@@ -456,8 +457,8 @@
 					</dt>
 					<dd>
 						<p>An [=EPUB content document=] with fixed dimensions directly referenced from the [=EPUB spine
-							| spine=]. Fixed-layout documents are designated <code>pre-paginated</code> in the [=package
-							document=], as defined in <a href="#sec-fixed-layouts"></a>.</p>
+							| spine=]. Fixed-layout documents are displayed in either [=pre-paginated=] or [=roll=]
+							layouts.</p>
 					</dd>
 
 					<dt>
@@ -615,15 +616,6 @@
 						<p>An [=EPUB content document=] that includes scripting or an [=XHTML content document=] that
 							contains [[html]] [^form^] elements.</p>
 						<p>Refer to <a href="#sec-scripted-content"></a> for more information.</p>
-					</dd>
-
-					<dt>
-						<dfn class="export">roll document</dfn>
-					</dt>
-					<dd>
-						<p>An [=EPUB content document=] with fixed dimensions directly referenced from the [=EPUB spine
-							| spine=] and presented in a roll. Roll documents are designated <code>roll</code> in the
-							[=package document=], as defined in <a href="#layout"></a>.</p>
 					</dd>
 
 					<dt>
@@ -1090,9 +1082,15 @@
 						<tr>
 							<td id="cmt-sfnt">
 								<ol class="cmt">
-									<li><code>font/ttf</code></li>
-									<li><code>application/font-sfnt</code></li>
-									<li><code>application/x-font-ttf</code></li>
+									<li>
+										<code>font/ttf</code>
+									</li>
+									<li>
+										<code>application/font-sfnt</code>
+									</li>
+									<li>
+										<code>application/x-font-ttf</code>
+									</li>
 								</ol>
 							</td>
 							<td>[[truetype]] </td>
@@ -1101,9 +1099,15 @@
 						<tr>
 							<td id="cmt-otf">
 								<ol class="cmt">
-									<li><code>font/otf</code></li>
-									<li><code>application/font-sfnt</code></li>
-									<li><code>application/vnd.ms-opentype</code></li>
+									<li>
+										<code>font/otf</code>
+									</li>
+									<li>
+										<code>application/font-sfnt</code>
+									</li>
+									<li>
+										<code>application/vnd.ms-opentype</code>
+									</li>
 								</ol>
 							</td>
 							<td>[[opentype]]</td>
@@ -1112,8 +1116,12 @@
 						<tr>
 							<td id="cmt-woff">
 								<ol class="cmt">
-									<li><code>font/woff</code></li>
-									<li><code>application/font-woff</code></li>
+									<li>
+										<code>font/woff</code>
+									</li>
+									<li>
+										<code>application/font-woff</code>
+									</li>
 								</ol>
 							</td>
 							<td> [[woff]] </td>
@@ -1132,9 +1140,15 @@
 						<tr>
 							<td id="cmt-js">
 								<ol class="cmt">
-									<li><code>application/javascript</code></li>
-									<li><code>application/ecmascript</code></li>
-									<li><code>text/javascript</code></li>
+									<li>
+										<code>application/javascript</code>
+									</li>
+									<li>
+										<code>application/ecmascript</code>
+									</li>
+									<li>
+										<code>text/javascript</code>
+									</li>
 								</ol>
 							</td>
 							<td> [[rfc4329]] </td>
@@ -2184,8 +2198,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>container</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>container</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2228,8 +2243,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>rootfiles</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>rootfiles</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2263,8 +2279,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>rootfile</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>rootfile</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2327,8 +2344,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>links</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>links</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2446,14 +2464,17 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>encryption</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>encryption</code>
+											</dfn>
 										</p>
 									</dd>
 
 									<dt>Namespace:</dt>
 									<dd>
-										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
+										<p>
+											<code>urn:oasis:names:tc:opendocument:xmlns:container</code>
+										</p>
 									</dd>
 
 									<dt>Usage:</dt>
@@ -2620,8 +2641,9 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>Compression</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>Compression</code>
+											</dfn>
 										</p>
 									</dd>
 
@@ -2752,14 +2774,17 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>signatures</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+												<code>signatures</code>
+											</dfn>
 										</p>
 									</dd>
 
 									<dt>Namespace:</dt>
 									<dd>
-										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
+										<p>
+											<code>urn:oasis:names:tc:opendocument:xmlns:container</code>
+										</p>
 									</dd>
 
 									<dt>Usage:</dt>
@@ -3506,7 +3531,9 @@
 					<dt>Element Name:</dt>
 					<dd>
 						<p>
-							<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>package</code></dfn>
+							<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+								<code>package</code>
+							</dfn>
 						</p>
 					</dd>
 
@@ -3634,8 +3661,9 @@
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>metadata</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>metadata</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -3788,8 +3816,9 @@
 								<dt>Element Name:</dt>
 								<dd>
 									<p>
-										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-												><code>dc:identifier</code></dfn>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+											<code>dc:identifier</code>
+										</dfn>
 									</p>
 								</dd>
 
@@ -3895,8 +3924,9 @@
 								<dt>Element Name:</dt>
 								<dd>
 									<p>
-										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-												><code>dc:title</code></dfn>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+											<code>dc:title</code>
+										</dfn>
 									</p>
 								</dd>
 
@@ -4015,8 +4045,9 @@
 								<dt>Element Name:</dt>
 								<dd>
 									<p>
-										<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-												><code>dc:language</code></dfn>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+											<code>dc:language</code>
+										</dfn>
 									</p>
 								</dd>
 
@@ -4111,16 +4142,28 @@
 								<dd>
 									<ul class="nomark">
 										<li>
-											<p><a href="#attrdef-dir"><code>dir</code></a>
-												<code>[optional]</code></p>
+											<p>
+												<a href="#attrdef-dir">
+													<code>dir</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code></p>
+											<p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-												<code>[optional]</code></p>
+											<p>
+												<a href="#attrdef-xml-lang">
+													<code>xml:lang</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -4355,7 +4398,9 @@
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>meta</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>meta</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -4554,7 +4599,9 @@
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>link</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>link</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -4827,8 +4874,9 @@ XHTML:
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>manifest</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>manifest</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -4885,7 +4933,9 @@ XHTML:
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>item</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>item</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -5002,11 +5052,21 @@ XHTML:
 							element matches their respective definitions:</p>
 
 						<ul>
-							<li><a href="#sec-mathml">mathml</a></li>
-							<li><a href="#sec-remote-resources">remote-resources</a></li>
-							<li><a href="#sec-scripted">scripted</a></li>
-							<li><a href="#sec-svg">svg</a></li>
-							<li><a href="#sec-switch">switch</a></li>
+							<li>
+								<a href="#sec-mathml">mathml</a>
+							</li>
+							<li>
+								<a href="#sec-remote-resources">remote-resources</a>
+							</li>
+							<li>
+								<a href="#sec-scripted">scripted</a>
+							</li>
+							<li>
+								<a href="#sec-svg">svg</a>
+							</li>
+							<li>
+								<a href="#sec-switch">switch</a>
+							</li>
 						</ul>
 
 						<aside class="example" id="example-item-properties-scripted-mathml"
@@ -5338,8 +5398,9 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>spine</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>spine</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -5439,8 +5500,9 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>itemref</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>itemref</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -5590,8 +5652,9 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>collection</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+									<code>collection</code>
+								</dfn>
 							</p>
 						</dd>
 
@@ -5765,6 +5828,414 @@ No Entry</pre>
 				</section>
 			</section>
 		</section>
+		<section id="sec-rendering">
+			<h2>Layout rendering</h2>
+
+			<section id="sec-general-rendering-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>EPUB 3 offers three different layout options for [=EPUB content documents=]:</p>
+
+				<ul>
+					<li>
+						<a href="#sec-reflowable">reflowable</a>
+					</li>
+					<li>
+						<a href="#sec-reflowable">pre-paginated</a>
+					</li>
+					<li>
+						<a href="#sec-reflowable">roll</a>
+					</li>
+				</ul>
+
+				<p>Not all rendering information can be expressed through the underlying technologies that EPUB is built
+					upon. For example, although HTML with CSS provides powerful layout capabilities, those capabilities
+					are limited to the scope of the document being rendered.</p>
+
+				<p>This section defines properties that allow the expression of package-level rendering intentions
+					(i.e., functionality that can only be implemented by the [=EPUB reading system=]). If a reading
+					system supports the desired rendering, these properties enable the user to be presented the content
+					as it was optimally designed.</p>
+			</section>
+
+			<section id="sec-layout-types">
+				<h3>Layout types</h3>
+
+				<section id="sec-reflowable">
+					<h4>Reflowable layouts</h4>
+
+					<p>A reflowable layout is one where the contents of [=EPUB content documents=] are reflowed to fit
+						the available space in the [=reading system=] viewport. A reading system can then dynamically
+						paginate the content or provide it in a scrolled manner.</p>
+
+					<p>Reflowable layouts are the default for EPUB 3 and were historically the only way its predecessor
+						formats were laid out. Because they are the default, it is not required to declare any metadata
+						to state that an [=EPUB publication=] is intended to be reflowed. If an explicit declaration is
+						preferred, however, the <a href="#layout"><code>rendition:layout</code> property</a> MAY be set
+						in a <code>meta</code> element with the value <dfn id="def-layout-reflowable"
+								><code>reflowable</code></dfn>.</p>
+
+					<aside class="example" title="Declaring an EPUB publication is reflowable">
+						<pre>&lt;package &#8230;>
+   &lt;metadata>
+      &lt;meta property="rendition:layout">reflowable&lt;/meta>
+      &#8230;
+   &lt;/metadata>
+   &#8230;
+&lt;/package></pre>
+					</aside>
+
+					<p>In addition to setting an entire EPUB publication as reflowable, it is possible to override a <a
+							href="#sec-pre-paginated">pre-paginated layout</a> to specify that some spine items are
+						reflowable. To do so, the <a href="#layout-reflowable"><code>rendition:layout-reflowable</code>
+							spine override</a> MUST be set in the <code>properties</code> attribute on each spine
+							<code>itemref</code> that is reflowable.</p>
+
+					<aside class="example" title="Reflowable document in a pre-paginated layout">
+						<pre>&lt;package &#8230;>
+   &lt;metadata>
+      &lt;meta property="rendition:layout">pre-paginated&lt;/meta>
+      &#8230;
+   &lt;/metadata>
+   &lt;manifest>
+      &lt;item id="reflow1" href="preface.html" media-type="application/xhtml+xml"/>
+   &lt;/manifest>
+   &lt;spine>
+   	&lt;itemref idref="reflow1" properties="rendition:layout-reflowable"/>
+   &lt;/spine>
+&lt;/package></pre>
+					</aside>
+
+					<div class="note">
+						<p><a href="#sec-roll">Roll layouts</a> do not support <a href="#layout-overrides">layout spine
+								overrides</a> so reflowable layouts cannot be similarly mixed with rolls.</p>
+					</div>
+
+					<p>The following properties from the <a href="#app-rendering-vocab">Package rendering vocabulary</a>
+						can be applied to reflowable spine items to further control their rendering:</p>
+
+					<ul>
+						<li>the <a href="#flow"><code>rendition:flow</code> property</a> and its <a
+								href="#flow-overrides">spine overrides</a> are used to indicate a preference for how
+							reading systems handle overflow content.</li>
+						<li>the <a href="#align-x-center"><code>rendition:align-x-center</code> spine override</a> is
+							used to indicate a preference for having the specified spine item's content be
+							center-aligned by reading systems.</li>
+					</ul>
+
+					<p>All other properties in the Package rendering vocabulary are ignored for reflowable spine
+						items.</p>
+				</section>
+
+				<section id="sec-pre-paginated">
+					<h4>Pre-paginated layouts</h4>
+
+					<p>In a pre-paginated layout, each [=fixed-layout document=] referenced a the [=EPUB spine | spine=]
+						[^itemref^] represents one page of content. Reading systems are expected to scale the document
+						to fit the viewport or synthetic spread.</p>
+
+					<div class="note">
+						<p>Pre-paginated layouts were commonly referred to as fixed layouts prior to the introduction of
+								<a href="#sec-roll">roll layouts</a>. As both layouts make use of [=fixed-layout
+							documents=], the term "fixed layout" is now used exclusively for describing EPUB content
+							documents with fixed dimensions, not for the layout type they appear in.</p>
+					</div>
+
+					<p>To declare that an EPUB publication uses a pre-paginated layout, the <a href="#layout"
+								><code>rendition:layout</code> property</a> MUST be declared in a <code>meta</code>
+						element with the value <dfn id="def-layout-pre-paginated">pre-paginated</dfn>.</p>
+
+					<aside class="example" title="Declaring an EPUB publication is reflowable">
+						<pre>&lt;package &#8230;>
+   &lt;metadata>
+      &lt;meta property="rendition:layout">pre-paginated&lt;/meta>
+      &#8230;
+   &lt;/metadata>
+   &#8230;
+&lt;/package></pre>
+					</aside>
+
+
+					<p>In addition to setting an entire EPUB publication as pre-paginated, it is possible to override a
+							<a href="#sec-reflowable">reflowable layout</a> to specify that some spine items are
+						pre-paginated. To do so, the <a href="#layout-pre-paginated"
+								><code>rendition:layout-pre-paginated</code> spine override</a> MUST be set in the <a
+							href="#attrdef-properties"><code>properties</code> attribute</a> on each spine
+							<code>itemref</code> that is pre-paginated.</p>
+
+					<aside class="example" title="Pre-paginated document in a reflowable layout">
+						<pre>&lt;package &#8230;>
+   &lt;metadata>
+      &lt;meta property="rendition:layout">reflowable&lt;/meta>
+      &#8230;
+   &lt;/metadata>
+   &lt;manifest>
+      &lt;item id="fxl1" href="page1.html" media-type="application/xhtml+xml"/>
+   &lt;/manifest>
+   &lt;spine>
+   	&lt;itemref idref="fxl1" properties="rendition:layout-pre-paginated"/>
+   &lt;/spine>
+&lt;/package></pre>
+					</aside>
+
+					<div class="note">
+						<p><a href="#sec-roll">Roll layouts</a> do not support spine overrides so pre-paginated layouts
+							cannot be similarly mixed with rolls.</p>
+					</div>
+
+					<p id="fxl-layout-duplication" data-tests="#lay-fxl-layout-duplication">When the property is set to
+							<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as defined
+						in <a href="#sec-content-dimensions"></a>.</p>
+
+					<p>The following properties from the <a href="#app-rendering-vocab">Package rendering vocabulary</a>
+						can be applied to pre-paginated spine items to further control their rendering:</p>
+
+					<ul>
+						<li>the <a href="#orientation"><code>rendition:orienatation</code> property</a> and its <a
+								href="#orientation-overrides">spine overrides</a> are used to indicate a preference for
+							how reading systems ...</li>
+						<li>the <a href="#spread"><code>rendition:spread</code> property</a> and its <a
+								href="#spread-overrides">spine overrides</a> are used to indicate a preference for how
+							reading systems ...</li>
+						<li>the <a href="#page-spread"><code>rendition:page-spread-*</code> spine override
+								properties</a> are used to indicate a preference for how to place spine items in a
+							synthetic spread (on the right or left side of a two-page spread, or centered without a
+							spread).</li>
+					</ul>
+
+					<p>All other properties in the Package rendering vocabulary are ignored for pre-paginated spine
+						items.</p>
+
+					<div class="note" id="uaag-fxl">
+						<p>Reading systems typically restrict or deny the application of user or user agent style sheets
+							to pre-paginated documents because dynamic style changes are likely to have unintended
+							consequence on the intrinsic properties of such documents. When choosing to use
+							pre-paginated content, it is advised to consider the negative impact on usability and
+							accessibility that these restrictions have. Refer to <a data-cite="UAAG20#gl-text-config"
+								>Guideline 1.4 - Provide text configuration</a> [[uaag20]] for related information.</p>
+					</div>
+
+					<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
+						<p>In this example, the document's layout is set to <code>pre-paginated</code> (i.e., it is
+							defined to be a [=fixed-layout document=]). Furthermore, media queries [[mediaqueries-3]]
+							are used to apply different style sheets for three different device categories. Note that
+							the media queries only affect the style sheet applied to the document; the size of the
+							content area set in the <code>viewport meta</code> tag is static.</p>
+
+						<p>Package document:</p>
+
+						<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
+      …
+      &lt;meta
+          property="rendition:layout"&gt;
+         pre-paginated
+      &lt;/meta&gt;
+      …
+   &lt;/metadata&gt;
+   …
+&lt;/package&gt;</pre>
+
+						<p>XHTML</p>
+
+						<pre>&lt;html …&gt;
+   &lt;head&gt;
+      &lt;meta
+          name="viewport"
+          content="width=1200,
+          height=900"/&gt;
+
+      &lt;link
+          rel="stylesheet"
+          href="eink-style.css"
+          media="(max-monochrome: 3)"/&gt;
+
+      &lt;link
+          rel="stylesheet"
+          href="skinnytablet-style.css"
+          media="((color) and (max-height:600px) and (orientation:landscape),
+                  (color) and (max-width:600px) and (orientation:portrait))"/&gt;
+
+      &lt;link
+          rel="stylesheet"
+          href="fattablet-style.css"
+          media="((color) and (min-height:601px) and (orientation:landscape),
+                  (color) and (min-width:601px) and (orientation:portrait))"/&gt;
+   &lt;/head&gt;
+   …
+&lt;/html&gt;</pre>
+					</aside>
+				</section>
+
+				<section id="sec-roll">
+					<h4>Roll layouts</h4>
+
+					<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code> property</a>
+						is declared in a <code>meta</code> element with the value <dfn id="def-layout-roll">roll</dfn>,
+						it indicates that the content is a roll (i.e., reading systems fit the width of each [=EPUB
+						spine | spine=] [^itemref^] to the viewport and display them in a continuous roll with no
+						visible gap). The roll layout style applies globally (i.e., for all spine items) and cannot be
+						overridden.</p>
+
+					<p>When a <code>roll</code> layout is declared, each spine item MUST reference a [=fixed-layout
+						document=]. The dimensions of each document MUST be set as defined in <a
+							href="#sec-content-dimensions"></a>.</p>
+
+					<p>No other properties or spine overrides from the <a href="#app-rendering-vocab">Package rendering
+							vocabulary</a> can be used to control the rendering of roll layouts.</p>
+
+					<div class="note" id="uaag-roll">
+						<p>Reading systems typically restrict or deny the application of user or user agent style sheets
+							to roll documents because dynamic style changes are likely to have unintended consequence on
+							the intrinsic properties of such documents. When choosing to use a roll, it is advised to
+							consider the negative impact on usability and accessibility that these restrictions have.
+							Refer to <a data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text configuration</a>
+							[[uaag20]] for related information.</p>
+					</div>
+
+					<aside class="example" id="roll-ex1" title="Roll Layout Document">
+						<p>In this example, the document's layout is set to <code>roll</code>.</p>
+
+						<p>Package document:</p>
+
+						<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
+      …
+      &lt;meta property="rendition:layout"&gt;
+         roll
+      &lt;/meta&gt;
+      …
+   &lt;/metadata&gt;
+   …
+&lt;/package&gt;</pre>
+
+						<figure id="layout-roll-figure">
+							<figcaption> Rendering of three roll documents<br />
+								<span class="attribution">(Comics courtesy of <a href="https://xkcd.com/927/">xkcd</a>,
+									licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+							</figcaption>
+							<img src="images/example_rendering_roll.svg" width="700" aria-details="layout-roll-diagram"
+								alt="Progression in a roll document with a continuously scrolled reading experience." />
+						</figure>
+
+						<details id="layout-roll-diagram" class="desc">
+							<summary>Image description</summary>
+							<p>Three rectangles representing three resource in an EPUB document. Each resource is an
+								image tile where the tile fills the width of the schematic view of a tablet.</p>
+						</details>
+					</aside>
+				</section>
+			</section>
+
+			<section id="sec-spread-placement" data-epubcheck="true"
+				data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L166,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L171">
+				<h3>Spread placement</h3>
+
+				<p>When a [=reading system=] renders a [=synthetic spread=], the default behavior is to populate the
+					spread by rendering the next [=EPUB content document=] in the next available unpopulated
+					[=viewport=], where the next available viewport is determined by the given <a
+						href="#attrdef-spine-page-progression-direction">page progression direction</a> or by local
+					declarations within [=EPUB content documents=]. To force reading systems to place a document in a
+					particular viewport, this automatic population behavior MAY be overridden by specifying one of the
+					following properties on its spine <code>itemref</code> element:</p>
+
+				<dl>
+					<dt id="page-spread-center">
+						<code>rendition:page-spread-center</code>
+					</dt>
+					<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a href="#spread-none"
+								><code>spread-none</code> property</a> for centering a spine item.</dd>
+
+					<dt id="fxl-page-spread-left">
+						<code>rendition:page-spread-left</code>
+					</dt>
+					<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
+								href="#page-spread-left">page-spread-left</a></code> property for placing a spine item
+						in the left-hand slot of a two-page spread.</dd>
+
+					<dt id="fxl-page-spread-right">
+						<code>rendition:page-spread-right</code>
+					</dt>
+					<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
+								href="#page-spread-right">page-spread-right</a></code> property for placing a spine item
+						in the right-hand slot of a two-page spread.</dd>
+				</dl>
+
+				<p>The <code>rendition:page-spread-center</code>, <code>rendition:page-spread-left</code>, and
+						<code>rendition:page-spread-right</code> properties apply to both pre-paginated and reflowable
+					content. They only apply when the reading system is creating synthetic spreads.</p>
+
+				<p>Although it is common practice to specify the use of a spread in certain device orientations, the
+					content itself does not represent a true spread &#8212; two consecutive pages that have to be
+					rendered side-by-side for readability, such as a two-page map. To indicate that two consecutive
+					pages represent a true spread, the <code>rendition:page-spread-left</code> and
+						<code>rendition:page-spread-right</code> properties SHOULD be set on the [=EPUB spine | spine=]
+					items for the two adjacent EPUB content documents, and the properties omitted on spine items where
+					one-up or two-up presentation is equally acceptable.</p>
+
+				<p>A spine item MUST NOT declare more than one <code>rendition:page-spread-*</code> property, and/or
+					their unprefixed equivalents (e.g., it is valid to specify both "<code>rendition:page-spread-left
+						page-spread-left</code>" in case reading systems only support one of properties).</p>
+
+				<div class="note" id="note-page-spread-aliases">
+					<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+						properties were created to allow the use of a single vocabulary for all fixed-layout properties.
+						Either property set can be used, but older reading systems might only recognize the unprefixed
+						versions.</p>
+
+					<p>The <code>rendition:page-spread-center</code> was created to make it easier to understand the
+						process of switching between two-page spreads and single centered pages. Either
+							<code>rendition:page-spread-center</code> or <code>spread-none</code> can be used to disable
+						spread behavior in reading systems.</p>
+				</div>
+
+				<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
+					<p>In this example, the intent is for the reading system to create a two-page fixed-layout center
+						plate using synthetic spreads in any device orientation. Note that the spread behavior for the
+						other (reflowable) parts has been left undefined, since the global value of
+							<code>rendition:spread</code> initializes to <code>auto</code> by default.</p>
+
+					<pre>&lt;package …&gt;
+…
+&lt;spine page-progression-direction="ltr"&gt;
+…
+&lt;itemref
+idref="center-plate-left"
+properties="rendition:spread-both rendition:page-spread-left"/&gt;
+&lt;itemref
+idref="center-plate-right"
+properties="rendition:spread-both rendition:page-spread-right"/&gt;
+…
+&lt;/spine&gt;
+&lt;/package&gt;</pre>
+				</aside>
+
+				<aside class="example" id="fxl-ex6" title="Creating a centered layout">
+					<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:layout"&gt;
+pre-paginated
+&lt;/meta&gt;
+&lt;meta
+property="rendition:spread"&gt;
+auto
+&lt;/meta&gt;
+&lt;/metadata&gt;
+&lt;spine&gt;
+…
+&lt;itemref
+idref="center-plate"
+properties="rendition:page-spread-center"/&gt;
+…
+&lt;/spine&gt;
+…
+&lt;/package&gt;</pre>
+				</aside>
+			</section>
+		</section>
 		<section id="sec-contentdocs">
 			<h2>EPUB content documents</h2>
 
@@ -5904,8 +6375,12 @@ No Entry</pre>
 							URL does not include either of the following strings in its [=domain=] [[url]]:</p>
 
 						<ul>
-							<li><code>w3.org</code></li>
-							<li><code>idpf.org</code></li>
+							<li>
+								<code>w3.org</code>
+							</li>
+							<li>
+								<code>idpf.org</code>
+							</li>
 						</ul>
 
 						<p>When using custom attributes, the content MUST remain consumable by a user without any
@@ -6133,6 +6608,110 @@ No Entry</pre>
 							</div>
 						</li>
 					</ul>
+				</section>
+			</section>
+
+			<section id="sec-fxl-docs">
+				<h3>Fixed-layout documents</h3>
+
+				<p>[=EPUB publications=], unlike print books or PDF files, are designed to change. The content flows, or
+					reflows, to fit the screen and to fit the needs of the user. As noted in <a
+						data-cite="epub-overview-34#sec-rendering">Rendering and CSS</a> "content presentation adapts to
+					the user, rather than the user having to adapt to a particular presentation of content."
+					[[epub-overview-34]]</p>
+
+				<p>But this principle does not work for all types of documents. Sometimes content and design are so
+					intertwined it is not possible to separate them. Any change in appearance risks changing the meaning
+					or losing all meaning. [=Fixed-layout documents=] give greater control over presentation when a
+					reflowable EPUB is not suitable for the content.</p>
+
+				<p>Fixed layouts are defined using a <a href="#sec-fxl-package">set of package document properties</a>
+					to control the presentation in [=reading systems=] while the <a href="#sec-content-dimensions"
+						>layout dimensions</a> are obtained from each respective [=EPUB content document=].</p>
+
+				<div class="note" id="note-mechanisms">
+					<p>EPUB 3 supports multiple formats for representing fixed-layout content. When fixed-layout content
+						is necessary, the choice of format will depend on many factors including desired degree of
+						precision, file size, accessibility, etc. This document does not attempt to dictate the choice
+						of format.</p>
+				</div>
+
+				<section id="sec-content-dimensions" data-epubcheck="true"
+					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L457,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L212,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L217,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L222,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L227,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L233,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L239,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L245,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L251,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L257,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L263,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L269,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L275,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L283,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L297,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L303,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L309">
+					<h4>Fixed-layout document dimensions</h4>
+
+					<p>This section defines rules for the expression and interpretation of dimensional properties of
+						[=fixed-layout documents=].</p>
+
+					<p id="confreg-fxl-icb">Fixed-layout documents specify their <a
+							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
+							block</a> [[css2]] in the manner applicable to their format:</p>
+
+					<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
+						<dt id="sec-fxl-icb-html" data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi">Expressing in
+							XHTML</dt>
+						<dd>
+							<p>For XHTML [=fixed-layout documents=], the <a
+									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+									containing block</a> [[css2]] is obtained from the REQUIRED <code>height</code> and
+									<code>width</code> definitions in a <a href="#app-viewport-meta"><code>viewport
+										meta</code> tag</a>, where:</p>
+							<ul>
+								<li>the <code>height</code>
+									<a href="#viewport.ebnf.property">property</a> MUST have as its <a
+										href="#viewport.ebnf.value">value</a> a positive <a
+										data-cite="css2/syndata.html#numbers">number</a> [[css2]] or the keyword
+										<code>device-height</code>; and </li>
+								<li>the <code>width</code> property MUST have as its value a positive <a
+										data-cite="css2/syndata.html#numbers">number</a> [[css2]] or the keyword
+										<code>device-width</code>. </li>
+							</ul>
+							<p>The <code>device-width</code> and <code>device-height</code> values refer to 100% of the
+								width and height, respectively, of the reading system's [=viewport=].</p>
+							<p>The <code>height</code> and <code>width</code> definitions MUST be specified in the first
+									<code>viewport meta</code> tag in document order in the [[html]] <a
+									data-cite="html#the-head-element"><code>head</code></a> element. Reading systems
+								will ignore subsequent <code>viewport meta</code> tags.</p>
+							<p>EPUB creators MUST NOT specify more than one <code>height</code> or <code>width</code>
+								definition within a <code>viewport meta</code> tag.</p>
+							<aside class="example"
+								title="Specifying the initial containing block in a viewport meta tag">
+								<pre>&lt;html …&gt;
+   &lt;head&gt;
+      …
+      &lt;meta
+          name="viewport"
+          content="width=1200, height=600"/&gt;
+      …
+   &lt;/head&gt;
+   …
+&lt;/html&gt;</pre>
+							</aside>
+						</dd>
+
+						<dt id="sec-fxl-icb-svg" data-tests="#fxl-svg-icb_multi">Expressing in SVG</dt>
+						<dd>
+							<p>For SVG [=fixed-layout documents=], the initial containing block&#160;[[css2]] dimensions
+								MUST be expressed using the <a
+									href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
+									attribute</a> [[svg]].</p>
+							<aside class="example"
+								title="Specifying the initial containing block in the viewBox attribute">
+								<p>In this example, the <code>viewBox</code> attribute sets the ICB to an aspect ratio
+									of 844 pixels wide by 1200 pixels high.</p>
+
+								<pre>&lt;svg xmlns="http://www.w3.org/2000/svg"
+	     version="1.1"
+	     viewBox="0 0 844 1200"&gt;
+	   …
+	&lt;/svg&gt;</pre>
+							</aside>
+						</dd>
+					</dl>
+
+					<p class="note"> The initial containing block definition affects only the document where it is
+						defined. The dimensions of the containing blocks in the other content documents within the same
+						publication may be different. </p>
 				</section>
 			</section>
 
@@ -6979,1013 +7558,6 @@ No Entry</pre>
 				</aside>
 			</section>
 		</section>
-		<section id="sec-rendering-control">
-			<h2>Layout rendering control</h2>
-
-			<section id="sec-general-rendering-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>Not all rendering information can be expressed through the underlying technologies that EPUB is built
-					upon. For example, although HTML with CSS provides powerful layout capabilities, those capabilities
-					are limited to the scope of the document being rendered.</p>
-
-				<p>This section defines properties that allow the expression of package-level rendering intentions
-					(i.e., functionality that can only be implemented by the [=EPUB reading system=]). If a reading
-					system supports the desired rendering, these properties enable the user to be presented the content
-					as it was optimally designed.</p>
-			</section>
-
-			<section id="layout" data-epubcheck="true"
-				data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L22,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L27,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L36,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L43,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L50">
-				<h5>Layout control</h5>
-
-				<p>The <code>rendition:layout</code> property specifies whether the content is reflowable, pre-paginated
-					or roll.</p>
-
-				<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code> property</a> is
-					specified on a <code>meta</code> element, it indicates that the pre-paginated, roll or reflowable
-					layout style applies globally (i.e., for all spine items).</p>
-
-				<p>The <code>rendition:layout</code> property MUST specify one of the following values:</p>
-
-				<dl class="variablelist">
-					<dt id="def-layout-reflowable">reflowable</dt>
-					<dd>
-						<p>The content is not pre-paginated (i.e., [=reading systems=] may apply dynamic pagination when
-							rendering). Default value.</p>
-					</dd>
-
-					<dt id="def-layout-pre-paginated">pre-paginated</dt>
-					<dd>
-						<p>The content is pre-paginated (i.e., reading systems produce exactly one page per [=EPUB spine
-							| spine=] [^itemref^] when rendering).</p>
-					</dd>
-
-					<dt id="def-layout-roll">roll</dt>
-					<dd>
-						<p>The content is a roll (i.e., reading systems fit the width of each [=EPUB spine | spine=]
-							[^itemref^] to the viewport and display them in a continuous roll with no visible gap).</p>
-					</dd>
-				</dl>
-
-				<div class="note" id="uaag">
-					<p>Reading systems typically restrict or deny the application of user or user agent style sheets to
-						pre-paginated or roll documents because dynamic style changes are likely to have unintended
-						consequence on the intrinsic properties of such documents. When choosing to use pre-paginated or
-						roll instead of reflowable content, it is advised to consider the negative impact on usability
-						and accessibility that these restrictions have. Refer to <a data-cite="UAAG20#gl-text-config"
-							>Guideline 1.4 - Provide text configuration</a> [[uaag20]] for related information.</p>
-				</div>
-
-				<p id="fxl-layout-duplication" data-tests="#lay-fxl-layout-duplication">When the property is set to
-						<code>pre-paginated</code> or <code>roll</code> for a spine item, its content dimensions MUST be
-					set as defined in <a href="#sec-content-dimensions"></a>.</p>
-
-				<p>The <code>rendition:layout</code> property MUST NOT be declared more than once. In addition, the
-					property MUST NOT be declared using the <a href="#attrdef-refines"><code>refines</code>
-						attribute</a>. Refer to <a href="#layout-overrides"></a> for setting the property for individual
-					[=EPUB content documents=].</p>
-
-				<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
-					<p>In this example, the document's layout is set to <code>pre-paginated</code> (i.e., it is defined
-						to be a [=fixed-layout document=]). Furthermore, media queries [[mediaqueries-3]] are used to
-						apply different style sheets for three different device categories. Note that the media queries
-						only affect the style sheet applied to the document; the size of the content area set in the
-							<code>viewport meta</code> tag is static.</p>
-
-					<p>Package document:</p>
-
-					<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-      …
-   &lt;/metadata&gt;
-   …
-&lt;/package&gt;</pre>
-
-					<p>XHTML</p>
-
-					<pre>&lt;html …&gt;
-   &lt;head&gt;
-      &lt;meta
-          name="viewport"
-          content="width=1200,
-          height=900"/&gt;
-
-      &lt;link
-          rel="stylesheet"
-          href="eink-style.css"
-          media="(max-monochrome: 3)"/&gt;
-
-      &lt;link
-          rel="stylesheet"
-          href="skinnytablet-style.css"
-          media="((color) and (max-height:600px) and (orientation:landscape),
-                  (color) and (max-width:600px) and (orientation:portrait))"/&gt;
-
-      &lt;link
-          rel="stylesheet"
-          href="fattablet-style.css"
-          media="((color) and (min-height:601px) and (orientation:landscape),
-                  (color) and (min-width:601px) and (orientation:portrait))"/&gt;
-   &lt;/head&gt;
-   …
-&lt;/html&gt;</pre>
-				</aside>
-
-				<aside class="example" id="roll-ex1" title="Roll Layout Document">
-					<p>In this example, the document's layout is set to <code>roll</code>.</p>
-
-					<p>Package document:</p>
-
-					<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta property="rendition:layout"&gt;
-         roll
-      &lt;/meta&gt;
-      …
-   &lt;/metadata&gt;
-   …
-&lt;/package&gt;</pre>
-
-					<figure id="layout-roll-figure">
-						<figcaption> Rendering of three roll documents<br />
-							<span class="attribution">(Comics courtesy of <a href="https://xkcd.com/927/">xkcd</a>,
-								licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-									2.5</a>.)</span>
-						</figcaption>
-						<img src="images/example_rendering_roll.svg" width="700" aria-details="layout-roll-diagram"
-							alt="Progression in a roll document with a continuously scrolled reading experience." />
-					</figure>
-
-					<details id="layout-roll-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>Three rectangles representing three resource in an EPUB document. Each resource is an image
-							tile where the tile fills the width of the schematic view of a tablet.</p>
-					</details>
-
-				</aside>
-
-				<section id="layout-overrides" data-epubcheck="true"
-					data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L59,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L64">
-					<h6>Layout overrides</h6>
-
-					<p id="property-layout-local">The following properties MAY be specified on [=EPUB spine | spine=]
-						[^itemref^] elements to override the <a href="#property-layout-global">global value</a>:</p>
-
-					<dl>
-						<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
-						<dd>Specifies that the given spine item is pre-paginated.</dd>
-
-						<dt id="layout-reflowable">rendition:layout-reflowable</dt>
-						<dd>Specifies that the given spine item is reflowable.</dd>
-					</dl>
-
-					<p>A spine item MUST NOT declare more than one of these overrides.</p>
-				</section>
-			</section>
-
-			<section id="sec-fixed-layouts">
-				<h3>Fixed layouts</h3>
-
-				<section id="fxl-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>[=EPUB publications=], unlike print books or PDF files, are designed to change. The content
-						flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a
-							data-cite="epub-overview-34#sec-rendering">Rendering and CSS</a> "content presentation
-						adapts to the user, rather than the user having to adapt to a particular presentation of
-						content." [[epub-overview-34]]</p>
-
-					<p>But this principle does not work for all types of documents. Sometimes content and design are so
-						intertwined it is not possible to separate them. Any change in appearance risks changing the
-						meaning or losing all meaning. [=Fixed-layout documents=] give greater
-						control over presentation when a reflowable EPUB is not suitable for the content.</p>
-
-					<p>Fixed layouts are defined using a <a href="#sec-fxl-package">set of package document
-							properties</a> to control the presentation in [=reading systems=] while the <a
-							href="#sec-content-dimensions">layout dimensions</a> are obtained from each respective
-						[=EPUB content document=].</p>
-
-					<div class="note" id="note-mechanisms">
-						<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
-							content is necessary, the choice of mechanism will depend on many factors including desired
-							degree of precision, file size, accessibility, etc. This section does not attempt to dictate
-							the choice of mechanism.</p>
-					</div>
-				</section>
-
-				<section id="sec-content-dimensions" data-epubcheck="true"
-					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L457,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L212,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L217,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L222,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L227,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L233,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L239,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L245,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L251,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L257,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L263,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L269,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L275,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L283,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L297,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L303,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L309">
-					<h4>Content document dimensions</h4>
-
-					<p>This section defines rules for the expression and interpretation of dimensional properties of
-						[=fixed-layout documents=].</p>
-
-					<p id="confreg-fxl-icb">Fixed-layout documents specify their <a
-							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
-							block</a> [[css2]] in the manner applicable to their format:</p>
-
-					<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
-						<dt id="sec-fxl-icb-html" data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi">Expressing in
-							XHTML</dt>
-						<dd>
-							<p>For XHTML [=fixed-layout documents=], the <a
-									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-									containing block</a> [[css2]] is obtained from the REQUIRED <code>height</code> and
-									<code>width</code> definitions in a <a href="#app-viewport-meta"><code>viewport
-										meta</code> tag</a>, where:</p>
-							<ul>
-								<li>the <code>height</code>
-									<a href="#viewport.ebnf.property">property</a> MUST have as its <a
-										href="#viewport.ebnf.value">value</a> a positive <a
-										data-cite="css2/syndata.html#numbers">number</a> [[css2]] or the keyword
-										<code>device-height</code>; and </li>
-								<li>the <code>width</code> property MUST have as its value a positive <a
-										data-cite="css2/syndata.html#numbers">number</a> [[css2]] or the keyword
-										<code>device-width</code>. </li>
-							</ul>
-							<p>The <code>device-width</code> and <code>device-height</code> values refer to 100% of the
-								width and height, respectively, of the reading system's [=viewport=].</p>
-							<p>The <code>height</code> and <code>width</code> definitions MUST be specified in the first
-									<code>viewport meta</code> tag in document order in the [[html]] <a
-									data-cite="html#the-head-element"><code>head</code></a> element. Reading systems
-								will ignore subsequent <code>viewport meta</code> tags.</p>
-							<p>EPUB creators MUST NOT specify more than one <code>height</code> or <code>width</code>
-								definition within a <code>viewport meta</code> tag.</p>
-							<aside class="example"
-								title="Specifying the initial containing block in a viewport meta tag">
-								<pre>&lt;html …&gt;
-   &lt;head&gt;
-      …
-      &lt;meta
-          name="viewport"
-          content="width=1200, height=600"/&gt;
-      …
-   &lt;/head&gt;
-   …
-&lt;/html&gt;</pre>
-							</aside>
-						</dd>
-
-						<dt id="sec-fxl-icb-svg" data-tests="#fxl-svg-icb_multi">Expressing in SVG</dt>
-						<dd>
-							<p>For SVG [=fixed-layout documents=], the initial containing
-								block&#160;[[css2]] dimensions MUST be expressed using the <a
-									href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
-									attribute</a> [[svg]].</p>
-							<aside class="example"
-								title="Specifying the initial containing block in the viewBox attribute">
-								<p>In this example, the <code>viewBox</code> attribute sets the ICB to an aspect ratio
-									of 844 pixels wide by 1200 pixels high.</p>
-
-								<pre>&lt;svg xmlns="http://www.w3.org/2000/svg"
-	     version="1.1"
-	     viewBox="0 0 844 1200"&gt;
-	   …
-	&lt;/svg&gt;</pre>
-							</aside>
-						</dd>
-					</dl>
-
-					<p class="note"> The initial containing block definition affects only the document where it is
-						defined. The dimensions of the containing blocks in the other content documents within the same
-						publication may be different. </p>
-				</section>
-
-				<section id="sec-fxl-package">
-					<h4>Layout controls</h4>
-
-					<section id="orientation" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L74,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L79,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L86,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L93">
-						<h5>Orientation</h5>
-
-						<p>The <code>rendition:orientation</code> property specifies which orientation the [=EPUB
-							publication=] is intended to be rendered in. </p>
-
-						<p id="property-orientation-global">When the <a href="#orientation"
-									><code>rendition:orientation</code> property</a> is specified on a [^meta^] element,
-							it indicates that the intended orientation applies globally (i.e., for all [=EPUB spine |
-							spine=] items).</p>
-
-						<p>One of the following values MUST be used with the <code>rendition:orientation</code>
-							property:</p>
-
-						<dl class="variablelist">
-							<dt>landscape</dt>
-							<dd>
-								<p>Render the content in landscape orientation.</p>
-							</dd>
-
-							<dt>portrait</dt>
-							<dd>
-								<p>Render the content in portrait orientation.</p>
-							</dd>
-
-							<dt>auto</dt>
-							<dd>
-								<p>The content is not orientation constrained. Default value.</p>
-							</dd>
-						</dl>
-
-						<p id="fxl-orientation-duplication">The <code>rendition:orientation</code> property MUST NOT be
-							declared more than once. In addition, it MUST NOT be declared using the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a>. Refer to <a
-								href="#orientation-overrides"></a> for setting the property for individual [=EPUB
-							content documents=].</p>
-
-						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
-							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
-
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-
-      &lt;meta
-          property="rendition:orientation"&gt;
-         landscape
-      &lt;/meta&gt;
-   &lt;/metadata&gt;
-   …
-&lt;/package&gt;</pre>
-						</aside>
-
-						<section id="orientation-overrides" data-epubcheck="true"
-							data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L102,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L107">
-							<h6>Orientation overrides</h6>
-
-							<p id="property-orientation-local">The following properties MAY be specified on [=EPUB spine
-								| spine=] [^itemref^] elements to override the <a href="#property-orientation-global"
-									>global value</a>:</p>
-
-							<dl>
-								<dt id="orientation-auto">rendition:orientation-auto</dt>
-								<dd>The [=reading system=] determines the orientation to render the spine item in.</dd>
-
-								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
-								<dd>Render the given spine item in landscape orientation.</dd>
-
-								<dt id="orientation-portrait">rendition:orientation-portrait</dt>
-								<dd>Render the given spine item in portrait orientation.</dd>
-							</dl>
-
-							<p>A spine item MUST NOT declare more than one of these overrides.</p>
-						</section>
-					</section>
-
-					<section id="spread" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L117,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L122,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L129,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L136,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L143,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L178">
-						<h5>Synthetic spreads</h5>
-
-						<p>The <code>rendition:spread</code> property specifies the intended [=reading system=]
-							synthetic spread behavior.</p>
-
-						<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
-								<code>meta</code> element, it indicates that the intended [=synthetic spread=] behavior
-							applies globally (i.e., for all spine items).</p>
-
-						<p>One of the following values MUST be used with the <code>rendition:spread</code> property:</p>
-
-						<dl class="variablelist">
-							<dt>none</dt>
-							<dd>
-								<p>Do not incorporate spine items in a synthetic spread. Render the items in a single
-									[=viewport=] positioned at the center of the screen.</p>
-							</dd>
-
-							<dt>landscape</dt>
-							<dd>
-								<p>Render a synthetic spread for spine items only when the device is in landscape
-									orientation.</p>
-							</dd>
-
-							<dt>both</dt>
-							<dd>
-								<p>Render a synthetic spread regardless of device orientation.</p>
-							</dd>
-
-							<dt>auto</dt>
-							<dd>
-								<p>No synthetic spread behavior preference is defined. Default value.</p>
-							</dd>
-						</dl>
-
-						<p>The <code>rendition:spread</code> property MUST NOT be declared more than once. In addition,
-							it MUST NOT be declared using the <a href="#attrdef-refines"><code>refines</code>
-								attribute</a>. Refer to <a href="#spread-overrides"></a> for setting the property for
-							individual [=EPUB content documents=].</p>
-
-						<div class="note">
-							<p>When synthetic spreads are used in the context of [=XHTML content document | XHTML=] and
-								[=SVG content documents=], the dimensions given via the <a href="#sec-fxl-icb-html"
-										><code>viewport meta</code> element</a> and <a href="#sec-fxl-icb-svg"
-										><code>viewBox</code> attribute</a> represents the size of one page in the
-								spread, respectively.</p>
-						</div>
-
-						<div class="note">
-							<p>Refer to the [^spine^] element for information about declaration of global flow
-								directionality using the <code>page-progression-direction</code> attribute and that of
-								local page-progression-direction within content documents.</p>
-						</div>
-
-						<aside class="example" id="spread-none-example"
-							title="A fixed-layout EPUB publication without synthetic spread">
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-
-      &lt;meta
-          property="rendition:spread"&gt;
-         none
-      &lt;/meta&gt;
-   &lt;/metadata&gt;
-   …
-&lt;/package&gt;</pre>
-
-							<figure id="spread-none-figure">
-								<figcaption> Rendering of three fixed-layout documents without synthetic spread.
-										<br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_none.svg" width="600" aria-details="spread-none-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time everywhere"
-								 />
-							</figure>
-
-							<details id="spread-none-diagram" class="desc">
-								<summary>Image description</summary>
-								<p>Two rows of schematic views of tablets (three in each row). The tablets in the top
-									row are in portrait mode, and in landscape mode in the bottom one. The schematic
-									views of the tablets within a row are linked with left-to-right arrows.</p>
-								<p>In the tablets of each row the consecutive panels of a comics are displayed; the
-									panels are centered in their respective tablets.</p>
-							</details>
-						</aside>
-
-
-						<aside class="example" id="spread-landscape-example"
-							title="Specifying the usage of synthetic spreads in landscape orientation only">
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-
-      &lt;meta
-          property="rendition:spread"&gt;
-         landscape
-      &lt;/meta&gt;
-   &lt;/metadata&gt;
-   …
-&lt;/package&gt;</pre>
-
-
-							<figure id="spread-landscape-figure">
-								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in
-									landscape orientation only. <br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_landscape.svg" width="600"
-									aria-details="spread-landscape-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time in portrait and using synthetic spread in landscape."
-								 />
-							</figure>
-
-							<details id="spread-landscape-diagram" class="desc">
-								<summary>Image description</summary>
-								<p>Two rows of schematic views of tablets (three in top row, and two in the bottom). The
-									tablets in the top row are in portrait mode, and in landscape mode in the bottom
-									one. The schematic views of the tablets within a row are linked with left-to-right
-									arrows.</p>
-								<p>In both rows three panels of a comics are displayed. In the top row the panels are
-									centered in their respective tablets. In the bottom row, the first tablet contains
-									the first and second panels of the comics side by side; the second tablet contains
-									the second and third panels of the comics side-by-side.</p>
-							</details>
-						</aside>
-
-
-						<aside class="example" id="spread-both-example"
-							title="Specifying to use synthetic spreads both in portrait and in landscape orientations">
-							<p>See also <a href="#spread-both-figure"></a>.</p>
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-
-      &lt;meta
-          property="rendition:spread"&gt;
-         both
-      &lt;/meta&gt;
-   &lt;/metadata&gt;
-   …
-&lt;/package&gt;</pre>
-
-							<figure id="spread-both-figure">
-								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in both
-									portrait and landscape orientations. <br /><span class="attribution">(Comics
-										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_both.svg" width="600" aria-details="spread-both-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, using synthetic spread in both cases."
-								 />
-							</figure>
-
-							<details id="spread-both-diagram" class="desc">
-								<summary>Image description</summary>
-								<p>Two rows of schematic views of tablets (two in each row). The tablets in the top row
-									are in portrait mode, and in landscape mode in the bottom one. The schematic views
-									of the tablets within a row are linked with left-to-right arrows.</p>
-								<p>In both rows three panels of a comics are displayed. The first tablet in a row
-									contains the first and second panels of the comics side by side; the second tablet
-									contains the second and third panels of the comics side-by-side.</p>
-							</details>
-						</aside>
-
-
-						<aside class="example" id="spread-both-with-intro-example"
-							title="Overriding the global spread behavior">
-							<p>In this example, the global reflowable setting is overridden in the spine for the
-								introductory page. The intention is for reading systems to render it as a reflowable
-								document.</p>
-
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-      &lt;meta
-          property="rendition:spread"&gt;
-         both
-      &lt;/meta&gt;
-   &lt;/metadata&gt;
-
-   &lt;spine&gt;
-      &lt;itemref
-          idref="introduction"
-          properties="rendition:layout-reflowable"/&gt;
-      …
-   &lt;/spine&gt;
-   …
-&lt;/package&gt;</pre>
-
-							<figure id="spread-both-with-intro-figure">
-								<figcaption>Rendering of an introduction document in reflowable layout, followed by
-									three fixed-layout documents with synthetic spread in portrait orientation.
-										<br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_both_with_reflowable_intro.svg" width="600"
-									aria-details="spread-both-with-intro-diagram"
-									alt="Progression of FXL pages both in portrait using synthetic spread in both cases, preceded by an introduction with reflowable content."
-								 />
-							</figure>
-
-							<details id="spread-both-with-intro-diagram" class="desc">
-								<summary>Image description</summary>
-								<p>A row of schematic views of three tablets in portrait mode, and linked with
-									left-to-right arrows.</p>
-								<p>The first tablet views includes a single, column-like strip (i.e., a rectangle
-									without a bottom edge following beyond the bottom of the tablet) with a text flowing
-									down the strip, and starting with the word "Introduction". This is followed by two
-									schematic tablets with three panels of comics displayed. The first tablet in the row
-									contains the first and second panels of the comics side by side; the second tablet
-									contains the second and third panels of the comics side-by-side.</p>
-							</details>
-						</aside>
-
-						<section id="spread-overrides" data-epubcheck="true"
-							data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L151,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L156">
-							<h6>Synthetic spread overrides</h6>
-
-							<p id="property-spread-local">The following properties MAY be specified on [=EPUB spine |
-								spine=] [^itemref^] elements to override the <a href="#property-spread-global">global
-									value</a>:</p>
-
-							<dl>
-								<dt id="spread-auto">rendition:spread-auto</dt>
-								<dd>The [=reading system=] determines when to render a synthetic spread for the spine
-									item. </dd>
-
-								<dt id="spread-both">rendition:spread-both</dt>
-								<dd>Render a synthetic spread for the spine item in both portrait and landscape
-									orientations. </dd>
-
-								<dt id="spread-landscape">rendition:spread-landscape</dt>
-								<dd>Render a synthetic spread for the spine item only when in landscape
-									orientation.</dd>
-
-								<dt id="spread-none">rendition:spread-none</dt>
-								<dd>Do not render a synthetic spread for the spine item.</dd>
-							</dl>
-
-							<p>A spine item MUST NOT declare more than one of these overrides.</p>
-						</section>
-					</section>
-
-					<section id="page-spread" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L166,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L171">
-						<h5>Spread placement</h5>
-
-						<p>When a [=reading system=] renders a [=synthetic spread=], the default behavior is to populate
-							the spread by rendering the next [=EPUB content document=] in the next available unpopulated
-							[=viewport=], where the next available viewport is determined by the given <a
-								href="#attrdef-spine-page-progression-direction">page progression direction</a> or by
-							local declarations within [=EPUB content documents=]. To force reading systems to place a
-							document in a particular viewport, this automatic population behavior MAY be overridden by
-							specifying one of the following properties on its spine <code>itemref</code> element:</p>
-
-						<dl>
-							<dt id="page-spread-center">
-								<code>rendition:page-spread-center</code></dt>
-							<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a
-									href="#spread-none"><code>spread-none</code> property</a> for centering a spine
-								item.</dd>
-
-							<dt id="fxl-page-spread-left">
-								<code>rendition:page-spread-left</code>
-							</dt>
-							<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
-										href="#page-spread-left">page-spread-left</a></code> property for placing a
-								spine item in the left-hand slot of a two-page spread.</dd>
-
-							<dt id="fxl-page-spread-right">
-								<code>rendition:page-spread-right</code>
-							</dt>
-							<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
-										href="#page-spread-right">page-spread-right</a></code> property for placing a
-								spine item in the right-hand slot of a two-page spread.</dd>
-						</dl>
-
-						<p>The <code>rendition:page-spread-center</code>, <code>rendition:page-spread-left</code>, and
-								<code>rendition:page-spread-right</code> properties apply to both pre-paginated and
-							reflowable content. They only apply when the reading system is creating synthetic
-							spreads.</p>
-
-						<p>Although it is common practice to specify the use of a spread in certain device orientations,
-							the content itself does not represent a true spread &#8212; two consecutive pages that have
-							to be rendered side-by-side for readability, such as a two-page map. To indicate that two
-							consecutive pages represent a true spread, the <code>rendition:page-spread-left</code> and
-								<code>rendition:page-spread-right</code> properties SHOULD be set on the [=EPUB spine |
-							spine=] items for the two adjacent EPUB content documents, and the properties omitted on
-							spine items where one-up or two-up presentation is equally acceptable.</p>
-
-						<p>A spine item MUST NOT declare more than one <code>rendition:page-spread-*</code> property,
-							and/or their unprefixed equivalents (e.g., it is valid to specify both
-								"<code>rendition:page-spread-left page-spread-left</code>" in case reading systems only
-							support one of properties).</p>
-
-						<div class="note" id="note-page-spread-aliases">
-							<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-								properties were created to allow the use of a single vocabulary for all fixed-layout
-								properties. Either property set can be used, but older reading systems might only
-								recognize the unprefixed versions.</p>
-
-							<p>The <code>rendition:page-spread-center</code> was created to make it easier to understand
-								the process of switching between two-page spreads and single centered pages. Either
-									<code>rendition:page-spread-center</code> or <code>spread-none</code> can be used to
-								disable spread behavior in reading systems.</p>
-						</div>
-
-						<aside class="example" id="spread-page-spread-right-example"
-							title="Starting the first document on the right">
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-          reflowable
-      &lt;/meta&gt;
-
-      &lt;meta
-          property="rendition:spread"&gt;
-          landscape
-      &lt;/meta&gt;
-      …
-   &lt;/metadata&gt;
-   &lt;spine page-progression-direction="ltr"&gt;
-      …
-      &lt;itemref
-          idref="first-panel"
-          properties="rendition:page-spread-right"/&gt;
-      …
-   &lt;/spine&gt;
-&lt;/package&gt;</pre>
-
-							<figure id="spread-page-spread-right-figure">
-								<figcaption>Rendering of three fixed-layout documents, with synthetic spread in
-									landscape orientation starting on the right. <br /><span class="attribution">(Comics
-										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_page_spread_right.svg" width="600"
-									aria-details="spread-page-spread-right-diagram"
-									alt="Progression of FXL pages in landscape modes, showing synthetic spread in both cases but with the first page appearing on the right side of the first page."
-								 />
-							</figure>
-
-							<details id="spread-page-spread-right-diagram" class="desc">
-								<summary>Image description</summary>
-								<p>A row of schematic views of two tablets in landscape mode, and linked with a
-									left-to-right arrow.</p>
-								<p>Three panels of a comics are displayed in the tablets. The first tablet in the row
-									contains the first panels of the comics on the right hand of the tablet, with the
-									left side empty; the second tablet contains the second and third panels of the
-									comics side-by-side.</p>
-							</details>
-						</aside>
-
-						<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
-							<p>In this example, the intent is for the reading system to create a two-page fixed-layout
-								center plate using synthetic spreads in any device orientation. Note that the spread
-								behavior for the other (reflowable) parts has been left undefined, since the global
-								value of <code>rendition:spread</code> initializes to <code>auto</code> by default.</p>
-
-							<pre>&lt;package …&gt;
-   …
-   &lt;spine page-progression-direction="ltr"&gt;
-      …
-      &lt;itemref
-          idref="center-plate-left"
-          properties="rendition:spread-both rendition:page-spread-left"/&gt;
-      &lt;itemref
-          idref="center-plate-right"
-          properties="rendition:spread-both rendition:page-spread-right"/&gt;
-      …
-   &lt;/spine&gt;
-&lt;/package&gt;</pre>
-						</aside>
-
-						<aside class="example" id="fxl-ex6" title="Creating a centered layout">
-							<pre>&lt;package …&gt;
-   &lt;metadata …&gt;
-      …
-      &lt;meta
-          property="rendition:layout"&gt;
-         pre-paginated
-      &lt;/meta&gt;
-      &lt;meta
-          property="rendition:spread"&gt;
-         auto
-      &lt;/meta&gt;
-   &lt;/metadata&gt;
-   &lt;spine&gt;
-      …
-      &lt;itemref
-          idref="center-plate"
-          properties="rendition:page-spread-center"/&gt;
-      …
-   &lt;/spine&gt;
-   …
-&lt;/package&gt;</pre>
-						</aside>
-					</section>
-				</section>
-			</section>
-
-			<section id="sec-reflowable-layouts">
-				<h3>Reflowable layouts</h3>
-
-				<p>Although control over the rendering of [=EPUB content documents=] to create <a
-						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
-					technologies, there are also considerations for reflowable content that are unique to [=EPUB
-					publications=] (e.g., how to handle the flow of content in the [=viewport=]). This section defines
-					properties that provide control over presentation aspects of reflowable content.</p>
-
-				<section id="flow" data-epubcheck="true"
-					data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L320,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L325,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L332,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L339">
-					<h4>The <code>rendition:flow</code> property</h4>
-
-					<p>The <code>rendition:flow</code> property specifies the preference for how [=reading systems=]
-						handle content overflow. </p>
-
-					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
-						specified on a <code>meta</code> element, it indicates the preference for overflow content
-						handling (i.e., for all [=EPUB spine | spine=] items). Either dynamic pagination or scrolling
-						MAY be specified. For scrolled content, it is also possible to specify whether consecutive
-						[=EPUB content documents=] are to be rendered as a continuous scrolling view or whether each is
-						to be rendered separately (i.e., with a dynamic page break between each).</p>
-
-					<p>One of the following values MUST be used with the <code>rendition:flow</code> property:</p>
-
-					<dl class="variablelist">
-						<dt id="paginated">paginated</dt>
-						<dd id="paginated-dd" data-tests="#lay-pkg-flow-paginated">
-							<p>Dynamically paginate all overflow content.</p>
-						</dd>
-
-						<dt id="scrolled-continuous">scrolled-continuous</dt>
-						<dd id="scrolled-continuous-dd" data-tests="#lay-pkg-flow-scrolled-continuous">
-							<p>Render all EPUB content documents such that overflow content is scrollable, and the
-								[=EPUB publication=] is presented as one continuous scroll from spine item to spine item
-								(except where <a href="#flow-overrides">locally overridden</a>).</p>
-							<p>Resources SHOULD NOT have different block flow directions as it makes continuous scrolled
-								rendition in EPUB reading systems problematic.</p>
-						</dd>
-
-						<dt id="scrolled-doc">scrolled-doc</dt>
-						<dd id="scrolled-doc-dd" data-tests="#lay-pkg-flow-scrolled-doc">
-							<p>Render all EPUB content documents such that overflow content is scrollable, and each
-								spine item is presented as a separate scrollable document.</p>
-						</dd>
-
-						<dt id="auto">auto</dt>
-						<dd>
-							<p>Render overflow content using the reading system default method or a user preference,
-								whichever is applicable. Default value.</p>
-						</dd>
-					</dl>
-
-					<p id="html-body-page-break-before">Note that when two reflowable EPUB content documents occur
-						sequentially in the spine, the default rendering for their [[!html]] <a
-							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
-							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-								><code>page-break-before</code> property</a> [[!csssnapshot]] having been set to
-							<code>always</code>. In addition to using the <code>rendition:flow</code> property, this
-						behavior MAY be overridden through an appropriate style sheet declaration if the reading system
-						supports such overrides.</p>
-
-					<p>The <code>rendition:flow</code> property MUST NOT be declared more than once. In addition, it
-						MUST NOT be declared using the <a href="#attrdef-refines"><code>refines</code> attribute</a>.
-						Refer to <a href="#flow-overrides"></a> for setting the property for individual EPUB content
-						documents.</p>
-
-					<figure id="fig-flow-paginated-single">
-						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
-								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-						<img src="images/example_rendering_paginated_single_spine.svg" width="600"
-							aria-details="flow-paginated-single-diagram"
-							alt="The continuous progression of paginated content produced for a single document." />
-					</figure>
-
-					<details id="flow-paginated-single-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
-							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
-							headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a
-							schematic view of a tablet.</p>
-					</details>
-
-					<figure id="fig-flow-paginated-multiple">
-						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
-								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-						<img src="images/example_rendering_paginated_multiple_spine.svg" width="600"
-							aria-details="flow-paginated-multiple-diagram"
-							alt="The continuous progression of paginated content produced for each document with transitions to
-					new pages between documents." />
-					</figure>
-
-					<details id="flow-paginated-multiple-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
-							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
-							headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the
-							rightmost rectangle, leaving an empty space at the bottom of the middle rectangle. The
-							leftmost rectangle is enclosed in a schematic view of a tablet.</p>
-					</details>
-
-					<figure id="fig-flow-scrolled-continuous">
-						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
-								<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
-						<img src="images/example_rendering_scrolled_continuous.svg" width="220"
-							aria-details="flow-scrolled-continuous-diagram"
-							alt="The progression of a continuous scroll of content extends vertically off the user's screen,
-					with new documents added to the bottom as encountered." />
-					</figure>
-
-					<details id="flow-scrolled-continuous-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing
-							down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top part
-							of the strip is enclosed in a schematic view of a tablet.</p>
-					</details>
-
-					<figure id="fig-flow-scrolled-doc">
-						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
-								<code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
-						<img src="images/example_rendering_scrolled_doc.svg" width="600"
-							aria-details="flow-scrolled-doc-diagram"
-							alt="The progression of scrollable documents depicting how only the content within each document
-					is scrollable." />
-					</figure>
-
-					<details id="flow-scrolled-doc-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle and
-							middle-to-right with respective arrows, each containing a text flowing down the strip. The
-							text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with a
-							chapter header and flows down the strip. The top part of the leftmost strip is enclosed in a
-							schematic view of a tablet.</p>
-					</details>
-
-					<section id="flow-overrides" data-epubcheck="true"
-						data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L348,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L353">
-						<h5>Spine overrides</h5>
-
-						<p id="layout-property-flow-local">The following properties MAY be specified on [=EPUB spine |
-							spine=] [^itemref^] elements to override the <a href="#property-flow-global">global
-								value</a>:</p>
-
-						<dl>
-							<dt id="flow-auto">rendition:flow-auto</dt>
-							<dd>No preference for overflow content handling.</dd>
-
-							<dt id="flow-paginated">rendition:flow-paginated</dt>
-							<dd>Dynamically paginate content overflow.</dd>
-
-							<dt id="flow-scrolled-continuous">rendition:flow-scrolled-continuous</dt>
-							<dd>Provide a scrolled view for overflow content. Consecutive spine items with this property
-								are to be rendered as a continuous scroll.</dd>
-
-							<dt id="flow-scrolled-doc">rendition:flow-scrolled-doc</dt>
-							<dd>Provide a scrolled view for overflow content. Each spine item with this property is to
-								be rendered as a separate scrollable document.</dd>
-						</dl>
-
-						<p>A spine item MUST NOT declare more than one of these overrides.</p>
-
-						<aside class="example" id="property-flow-ex1"
-							title="Overriding a global paginated flow declaration">
-							<p>In this example, the intent is to have a paginated [=EPUB publication=] with a scrollable
-								table of contents.</p>
-							<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-	…
-	&lt;meta
-		property="rendition:flow"&gt;
-		paginated
-	&lt;/meta&gt;
-	…
-&lt;/metadata&gt;
-
-…
-
-&lt;spine&gt;
-	&lt;itemref
-		idref="toc"
-		properties="rendition:flow-scrolled-doc"/&gt;
-	&lt;itemref
-		idref="c01"/&gt;
-&lt;/spine&gt;
-&lt;/package&gt;</pre>
-						</aside>
-					</section>
-				</section>
-
-				<section id="align-x-center">
-					<h4>The <code>rendition:align-x-center</code> property</h4>
-
-					<p>The <code>rendition:align-x-center</code> property specifies to center the given [=EPUB spine |
-						spine=] horizontally in the [=viewport=] or spread.</p>
-
-					<p>The property MUST NOT be set globally for all [=EPUB content documents=] (i.e., in a [^meta^]
-						element without a <a href="#attrdef-refines"><code>refines</code> attribute</a>). It is only
-						available as a spine override for individual EPUB content documents via the [^itemref^]
-						element's <code>properties</code> attribute.</p>
-
-					<div class="note">
-						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
-							in the absence of reliable centering control within the content rendering. As support for
-							paged media evolves in CSS, this property is expected to be deprecated. The use of CSS
-							solutions is encouraged when effective.</p>
-					</div>
-				</section>
-			</section>
-
-			<section id="sec-roll-layout">
-				<h3>Roll layouts</h4>
-			</section>
-		</section>
 		<section id="sec-media-overlays">
 			<h2>Media overlays</h2>
 
@@ -8058,8 +7630,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>smil</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>smil</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8131,8 +7704,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>head</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>head</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8204,8 +7778,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>body</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>body</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8281,8 +7856,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>seq</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>seq</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8359,8 +7935,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>par</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>par</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8426,8 +8003,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>text</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>text</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -8492,8 +8070,9 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>audio</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+										<code>audio</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -9461,26 +9040,34 @@ html.my-document-playing * {
 			<p>Some of the key standards for authoring accessible web content include:</p>
 
 			<dl>
-				<dt><a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a>
+				</dt>
 				<dd>
 					<p>The requirements and practices for creating accessible web content are documented in the
 						[[wcag2]].</p>
 				</dd>
 
-				<dt><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (ARIA)</a>
+				</dt>
 				<dd>
 					<p>The [[wai-aria]] specification defines roles, states, and properties for making dynamic content
 						that does not use native HTML elements and attributes accessible. It also provides a set of
 						landmarks for navigating web pages.</p>
 				</dd>
 
-				<dt><a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA Module (DPUB-ARIA)</a>
+				</dt>
 				<dd>
 					<p>The [[dpub-aria]] specification is an extension of [[wai-aria]] that provides additional roles
 						specific to identifying common publishing structures.</p>
 				</dd>
 
-				<dt><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a></dt>
+				<dt>
+					<a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
+				</dt>
 				<dd>
 					<p>[[html-aria]] specifies how the roles, states, and properties defined ARIA and DPUB-ARIA can be
 						used in HTML documents.</p>
@@ -10021,8 +9608,9 @@ html.my-document-playing * {
 							<dt>Attribute Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr"
-											><code>epub:type</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+										<code>epub:type</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -10055,8 +9643,9 @@ html.my-document-playing * {
 							<dt>Attribute Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr"
-											><code>epub-type</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr">
+										<code>epub-type</code>
+									</dfn>
 								</p>
 							</dd>
 
@@ -10641,7 +10230,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-orientation</code></td>
+								<td>
+									<code>-epub-text-orientation</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10664,16 +10255,28 @@ html.my-document-playing * {
 						</thead>
 						<tbody>
 							<tr>
-								<td><code>vertical-right</code></td>
-								<td><code>mixed</code></td>
+								<td>
+									<code>vertical-right</code>
+								</td>
+								<td>
+									<code>mixed</code>
+								</td>
 							</tr>
 							<tr>
-								<td><code>rotate-right</code></td>
-								<td><code>sideways</code></td>
+								<td>
+									<code>rotate-right</code>
+								</td>
+								<td>
+									<code>sideways</code>
+								</td>
 							</tr>
 							<tr>
-								<td><code>rotate-normal</code></td>
-								<td><code>sideways</code></td>
+								<td>
+									<code>rotate-normal</code>
+								</td>
+								<td>
+									<code>sideways</code>
+								</td>
 							</tr>
 						</tbody>
 					</table>
@@ -10690,7 +10293,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-writing-mode</code></td>
+								<td>
+									<code>-epub-writing-mode</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10711,7 +10316,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-combine-horizontal</code></td>
+								<td>
+									<code>-epub-text-combine-horizontal</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10733,12 +10340,20 @@ html.my-document-playing * {
 						</thead>
 						<tbody>
 							<tr>
-								<td><code>-epub-text-combine-horizontal: none</code></td>
-								<td><code>text-combine-upright: none</code></td>
+								<td>
+									<code>-epub-text-combine-horizontal: none</code>
+								</td>
+								<td>
+									<code>text-combine-upright: none</code>
+								</td>
 							</tr>
 							<tr>
-								<td><code>-epub-text-combine-horizontal: all</code></td>
-								<td><code>text-combine-upright: all</code></td>
+								<td>
+									<code>-epub-text-combine-horizontal: all</code>
+								</td>
+								<td>
+									<code>text-combine-upright: all</code>
+								</td>
 							</tr>
 						</tbody>
 					</table>
@@ -10761,7 +10376,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-hyphens</code></td>
+								<td>
+									<code>-epub-hyphens</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10785,7 +10402,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-line-break</code></td>
+								<td>
+									<code>-epub-line-break</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10805,7 +10424,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-align-last</code></td>
+								<td>
+									<code>-epub-text-align-last</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10825,7 +10446,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-word-break</code></td>
+								<td>
+									<code>-epub-word-break</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10845,7 +10468,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>text-transform</code></td>
+								<td>
+									<code>text-transform</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10876,7 +10501,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-emphasis-color</code></td>
+								<td>
+									<code>-epub-text-emphasis-color</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10897,7 +10524,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-emphasis-position</code></td>
+								<td>
+									<code>-epub-text-emphasis-position</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10918,7 +10547,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-emphasis-style</code></td>
+								<td>
+									<code>-epub-text-emphasis-style</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10941,7 +10572,9 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-underline-position</code></td>
+								<td>
+									<code>-epub-text-underline-position</code>
+								</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -11266,7 +10899,9 @@ html.my-document-playing * {
 						href="#sec-publication-resources"></a> for more information about these categories.)</p>
 
 				<dl>
-					<dt><code>meta/data.xml</code></dt>
+					<dt>
+						<code>meta/data.xml</code>
+					</dt>
 					<dd>
 						<p>The resource is a metadata record, stored in the [=EPUB container=]. It is linked via a
 							[^link^] element in the package document metadata. It is therefore a [=linked resource=] on
@@ -11274,14 +10909,18 @@ html.my-document-playing * {
 							part on any other planes. </p>
 					</dd>
 
-					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
+					<dt>
+						<code>https://www.example.org/meta/data2.xml</code>
+					</dt>
 					<dd>
 						<p>The resource is a metadata record, stored remotely. It is linked via a [^link^] element in
 							the package document metadata. It is therefore a linked resource on the manifest plane,
 							(i.e., it is not listed in the manifest). It is not part on any other planes.</p>
 					</dd>
 
-					<dt><code>page.xhtml</code></dt>
+					<dt>
+						<code>page.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is an XHTML document. It is listed in the [=EPUB spine | spine=]. It is a
 							[=publication resource=] on the manifest plane, a [=container resource=], an [=EPUB content
@@ -11289,14 +10928,18 @@ html.my-document-playing * {
 							is necessary.</p>
 					</dd>
 
-					<dt><code>nav.xhtml</code></dt>
+					<dt>
+						<code>nav.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is the [=EPUB navigation document=]. It is not listed in the spine. It is a
 							publication resource on the manifest plane, a container resource, and is not present on
 							either the spine plane or the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>style.css</code></dt>
+					<dt>
+						<code>style.css</code>
+					</dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[html]]
 								<a data-cite="html#the-link-element"><code>link</code></a> element. It is a publication
@@ -11304,7 +10947,9 @@ html.my-document-playing * {
 							is a [=core media type resource=] on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>font/font-file.otf</code></dt>
+					<dt>
+						<code>font/font-file.otf</code>
+					</dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
 							CSS file. It is a publication resource on the manifest plane, is a container resource, is
@@ -11312,7 +10957,9 @@ html.my-document-playing * {
 							fallback is necessary.</p>
 					</dd>
 
-					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
+					<dt>
+						<code>https://www.example.org/fonts/font-file2.otf</code>
+					</dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
 							CSS file. It is a publication resource on the manifest plane, is a [=remote resource=], is
@@ -11320,7 +10967,9 @@ html.my-document-playing * {
 							fallback is necessary.</p>
 					</dd>
 
-					<dt><code>font/font-file.cff</code></dt>
+					<dt>
+						<code>font/font-file.cff</code>
+					</dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
 							referenced from a CSS file. Its media type is not listed as a <a
@@ -11329,7 +10978,9 @@ html.my-document-playing * {
 							resource=] on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>speech/cmn.pls</code></dt>
+					<dt>
+						<code>speech/cmn.pls</code>
+					</dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
 							from an [[html]] <a data-cite="html#the-link-element"><code>link</code></a> element. It is a
@@ -11337,7 +10988,9 @@ html.my-document-playing * {
 							plane, and is an exempt resource on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>image/image_1.png</code></dt>
+					<dt>
+						<code>image/image_1.png</code>
+					</dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[html]] [^img^] element. It is a publication resource on the manifest plane, a container
@@ -11345,7 +10998,9 @@ html.my-document-playing * {
 							content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>image/image_2.png</code></dt>
+					<dt>
+						<code>image/image_2.png</code>
+					</dt>
 					<dd>
 						<p>The resource is a PNG image file. It is referenced via an [[html]] [^a^] element. Because it
 							is referenced from a hyperlink, it <em>has to</em> be listed in the spine. It is a
@@ -11355,7 +11010,9 @@ html.my-document-playing * {
 								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
-					<dt><code>image_desc.xhtml</code></dt>
+					<dt>
+						<code>image_desc.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not
 							explicitly listed in the spine (but it "replaces" the existing spine item when needed). It
@@ -11364,7 +11021,9 @@ html.my-document-playing * {
 							document, it is not present on the content plane. No fallback is necessary.</p>
 					</dd>
 
-					<dt><code>image/image_3.heic</code></dt>
+					<dt>
+						<code>image/image_3.heic</code>
+					</dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
 							referenced from an [[html]] [^source^] element. Its media type is not listed as a <a
@@ -11374,7 +11033,9 @@ html.my-document-playing * {
 							provided via the sibling [[html]] [^img^] element in an [[html]] [^picture^] element.</p>
 					</dd>
 
-					<dt><code>image/image_3.png</code></dt>
+					<dt>
+						<code>image/image_3.png</code>
+					</dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[html]] [^img^] element that is used as an intrinsic fallback of the [[html]] [^picture^]
@@ -11383,7 +11044,9 @@ html.my-document-playing * {
 							fallback is necessary.</p>
 					</dd>
 
-					<dt><code>widget.xhtml</code></dt>
+					<dt>
+						<code>widget.xhtml</code>
+					</dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
 							[[html]] [^iframe^] element. It is a publication resource on the manifest plane, a container
@@ -11392,7 +11055,9 @@ html.my-document-playing * {
 							necessary.</p>
 					</dd>
 
-					<dt><code>https://www.example.org/some_content</code></dt>
+					<dt>
+						<code>https://www.example.org/some_content</code>
+					</dt>
 					<dd>
 						<p>The resource is referenced via an [[html]] [^a^] element and is not stored in the EPUB
 							container. Reading systems will normally open this link via a separate browser instance. It

--- a/epub34/authoring/vocab/itemref-properties.html
+++ b/epub34/authoring/vocab/itemref-properties.html
@@ -25,7 +25,7 @@
 							associated <code>item</code> element's [=EPUB content document=] represents the
 							left-hand side of a two-page spread.</p>
 						<p>The <a href="#fxl-page-spread-left"><code>rendition:page-spread-left</code> 
-							property</a> is an alias for this property. Refer to <a href="#page-spread"></a>
+							property</a> is an alias for this property. Refer to <a href="#sec-spread-placement"></a>
 							for more information about their use.</p>
 					</td>
 				</tr>
@@ -51,7 +51,7 @@
 							associated <code>item</code> element's [=EPUB content document=]
 							represents the right-hand side of a two-page spread.</p>
 						<p>The <a href="#fxl-page-spread-right"><code>rendition:page-spread-right</code> 
-							property</a> is an alias for this property. Refer to <a href="#page-spread"></a>
+							property</a> is an alias for this property. Refer to <a href="#sec-spread-placement"></a>
 							for more information about their use.</p>
 					</td>
 				</tr>

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -1,112 +1,978 @@
-<section id="app-rendering-vocab">
-	<h3>Package rendering vocabulary</h3>
-	
-	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
-		<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
-	
-	<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
-		use</a> with the package rendering properties and does not have to be declared in the
-		[=package document=].</p>
-	
-	<div class="note">
-		<p>Unlike the other vocabularies in this appendix, the properties in the Package Rendering Vocabulary
-			consist of a mix of properties (expressed in [^meta^] elements)
-			and [=EPUB spine | spine=] overrides (expressed on [^itemref^] elements).</p>
-		
-		<p>The usage requirements are also defined in <a href="#sec-rendering-control"></a> not in this appendix.
-			The following table provides a map to the properties, overrides, and where they are defined.</p>
-	</div>
-		
-	<table class="tabledef">
-		<thead>
-			<tr>
-				<th>Property</th>
-				<th>Overrides</th>
-				<th>Defined in</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td><code>rendition:layout</code></td>
-				<td>
-					<ul>
-						<li><code>rendition:layout-pre-paginated</code></li>
-						<li><code>rendition:layout-reflowable</code></li>
-					</ul>
-				</td>
-				<td><a href="#layout"></a></td>
-			</tr>
-			<tr>
-				<td><code>rendition:orientation</code></td>
-				<td>
-					<ul>
-						<li><code>rendition:orientation-auto</code></li>
-						<li><code>rendition:orientation-landscape</code></li>
-						<li><code>rendition:orientation-portrait</code></li>
-					</ul>
-				</td>
-				<td><a href="#orientation"></a></td>
-			</tr>
-			<tr>
-				<td><code>rendition:spread</code></td>
-				<td>
-					<ul>
-						<li><code>rendition:spread-auto</code></li>
-						<li><code>rendition:spread-both</code></li>
-						<li><code>rendition:spread-landscape</code></li>
-						<li><code>rendition:spread-none</code></li>
-					</ul>
-				</td>
-				<td><a href="#spread"></a></td>
-			</tr>
-			<tr>
-				<td>—</td>
-				<td>
-					<ul>
-						<li><code>rendition:page-spread-center</code></li>
-						<li><code>rendition:page-spread-left</code></li>
-						<li><code>rendition:page-spread-right</code></li>
-					</ul>
-				</td>
-				<td><a href="#page-spread"></a></td>
-			</tr>
-			<tr>
-				<td><code>rendition:flow</code></td>
-				<td>
-					<ul>
-						<li><code>rendition:flow-paginated</code></li>
-						<li><code>rendition:flow-scrolled-continuous</code></li>
-						<li><code>rendition:flow-scrolled-doc</code></li>
-						<li><code>rendition:flow-auto</code></li>
-					</ul>
-				</td>
-				<td><a href="#flow"></a></td>
-			</tr>
-			<tr>
-				<td>—</td>
-				<td>
-					<ul>
-						<li><code>rendition:align-x-center</code></li>
-					</ul>
-				</td>
-				<td><a href="#align-x-center"></a></td>
-			</tr>
-		</tbody>
-	</table>
-	
-	<section id="sec-rendering-custom-properties" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_package-rendering-vocab.feature_L19">
-		<h4>Custom rendering properties</h4>
-		
-		<p>Custom properties and [=EPUB spine | spine=] overrides can be included in the 
-			[=package document=] to address rendering issues specific to particular 
-			[=reading systems=], as defined by the developers of those reading systems.</p>
-		
-		<p>The only restrictions are that such properties MUST NOT be defined with a 
-			<code>rendition:</code> prefix and MUST NOT conflict behaviorally with properties 
-			in the <a href="app-rendering-vocab">package rendering vocabulary</a>.</p>
-			
-		<p>If extensions are needed for use by multiple independent reading systems, the 
-			preferred method is to extend the package rendering vocabulary through a revision 
-			to this standard.</p>
-	</section>
-</section>
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>test</title>
+	</head>
+	<body>
+		<section id="app-rendering-vocab">
+			<h3>Package rendering vocabulary</h3>
+
+			<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
+					<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
+
+			<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for use</a>
+				with the package rendering properties and does not have to be declared in the [=package document=].</p>
+
+			<div class="note">
+				<p>Unlike the other vocabularies in this appendix, the properties in the Package Rendering Vocabulary
+					consist of a mix of properties (expressed in [^meta^] elements) and [=EPUB spine | spine=] overrides
+					(expressed on [^itemref^] elements).</p>
+
+				<p>The usage requirements are defined in <a href="#sec-rendering"></a> not in this appendix. The
+					following table provides a map to the properties, overrides, and where they are defined.</p>
+			</div>
+
+			<section id="sec-centering">
+				<h4>Center aligment</h4>
+
+				<section id="sec-align-x-center">
+					<h5>The <code>rendition:align-x-center</code> property</h5>
+
+					<div class="note">
+						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
+							in the absence of reliable centering control within the content rendering. As support for
+							paged media evolves in CSS, this property is expected to be deprecated. The use of CSS
+							solutions is encouraged when effective.</p>
+					</div>
+
+					<table class="tabledef" id="align-x-center">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:align-x-center</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:align-x-center</code> [=EPUB spine | spine=] override
+										property specifies to center the content of given reflowable spine item
+										horizontally in the [=viewport=] or spread.</p>
+									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
+												><code>properties</code></a> attributes.</p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+			</section>
+
+			<section id="sec-content-flow">
+				<h4>Flow</h4>
+
+				<section id="sec-flow" data-epubcheck="true"
+					data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L320,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L325,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L332,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L339,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L348,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L353">
+					<h5>The <code>rendition:flow</code> property</h5>
+
+					<table class="tabledef" id="flow">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:flow</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:flow</code> property specifies the preference for how
+										[=reading systems=] handle content overflow. </p>
+
+									<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code>
+											property</a> is specified on a <code>meta</code> element, it indicates the
+										preference for overflow content handling (i.e., for all [=EPUB spine | spine=]
+										items). Either dynamic pagination or scrolling MAY be specified. For scrolled
+										content, it is also possible to specify whether consecutive [=EPUB content
+										documents=] are to be rendered as a continuous scrolling view or whether each is
+										to be rendered separately (i.e., with a dynamic page break between each).</p>
+
+									<p id="html-body-page-break-before">Note that when two reflowable EPUB content
+										documents occur sequentially in the spine, the default rendering for their
+										[[!html]] <a data-cite="html#the-body-element"><code>body</code></a> elements is
+										consistent with the <a
+											href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+												><code>page-break-before</code> property</a> [[!csssnapshot]] having
+										been set to <code>always</code>. In addition to using the
+											<code>rendition:flow</code> property, this behavior MAY be overridden
+										through an appropriate style sheet declaration if the reading system supports
+										such overrides.</p>
+								</td>
+							</tr>
+							<tr>
+								<th>Allowed value(s):</th>
+								<td>
+									<p>MUST be one of the following values:</p>
+
+									<dl class="variablelist">
+										<dt id="paginated">paginated</dt>
+										<dd id="paginated-dd" data-tests="#lay-pkg-flow-paginated">
+											<p>Dynamically paginate all overflow content.</p>
+										</dd>
+
+										<dt id="scrolled-continuous">scrolled-continuous</dt>
+										<dd id="scrolled-continuous-dd" data-tests="#lay-pkg-flow-scrolled-continuous">
+											<p>Render all EPUB content documents such that overflow content is
+												scrollable, and the [=EPUB publication=] is presented as one continuous
+												scroll from spine item to spine item (except where <a
+													href="#flow-overrides">locally overridden</a>).</p>
+											<p>Resources SHOULD NOT have different block flow directions as it makes
+												continuous scrolled rendition in EPUB reading systems problematic.</p>
+										</dd>
+
+										<dt id="scrolled-doc">scrolled-doc</dt>
+										<dd id="scrolled-doc-dd" data-tests="#lay-pkg-flow-scrolled-doc">
+											<p>Render all EPUB content documents such that overflow content is
+												scrollable, and each spine item is presented as a separate scrollable
+												document.</p>
+										</dd>
+
+										<dt id="auto">auto</dt>
+										<dd>
+											<p>Render overflow content using the reading system default method or a user
+												preference, whichever is applicable. Default value.</p>
+										</dd>
+									</dl>
+								</td>
+							</tr>
+							<tr>
+								<th>Cardinality:</th>
+								<td>
+									<code>zero or one</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Extends:</th>
+								<td>Only applies to the EPUB publication. MUST NOT be used when the <a
+										href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+							</tr>
+						</tbody>
+					</table>
+
+					<figure id="fig-flow-paginated-single">
+						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
+						<img src="images/example_rendering_paginated_single_spine.svg" width="600"
+							aria-details="flow-paginated-single-diagram"
+							alt="The continuous progression of paginated content produced for a single document." />
+					</figure>
+
+					<details id="flow-paginated-single-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
+							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
+							headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a
+							schematic view of a tablet.</p>
+					</details>
+
+					<figure id="fig-flow-paginated-multiple">
+						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
+								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
+						<img src="images/example_rendering_paginated_multiple_spine.svg" width="600"
+							aria-details="flow-paginated-multiple-diagram"
+							alt="The continuous progression of paginated content produced for each document with transitions to
+new pages between documents." />
+					</figure>
+
+					<details id="flow-paginated-multiple-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
+							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
+							headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the
+							rightmost rectangle, leaving an empty space at the bottom of the middle rectangle. The
+							leftmost rectangle is enclosed in a schematic view of a tablet.</p>
+					</details>
+
+					<figure id="fig-flow-scrolled-continuous">
+						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+								<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
+						<img src="images/example_rendering_scrolled_continuous.svg" width="220"
+							aria-details="flow-scrolled-continuous-diagram"
+							alt="The progression of a continuous scroll of content extends vertically off the user's screen,
+with new documents added to the bottom as encountered." />
+					</figure>
+
+					<details id="flow-scrolled-continuous-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing
+							down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top part
+							of the strip is enclosed in a schematic view of a tablet.</p>
+					</details>
+
+					<figure id="fig-flow-scrolled-doc">
+						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
+								<code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
+						<img src="images/example_rendering_scrolled_doc.svg" width="600"
+							aria-details="flow-scrolled-doc-diagram"
+							alt="The progression of scrollable documents depicting how only the content within each document
+is scrollable." />
+					</figure>
+
+					<details id="flow-scrolled-doc-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle and
+							middle-to-right with respective arrows, each containing a text flowing down the strip. The
+							text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with a
+							chapter header and flows down the strip. The top part of the leftmost strip is enclosed in a
+							schematic view of a tablet.</p>
+					</details>
+				</section>
+
+				<section id="sec-flow-auto">
+					<h5>The <code>rendition:flow-auto</code> property</h5>
+
+					<table class="tabledef" id="flow-auto">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:flow-auto</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:flow-auto</code> property indicates no preference for the
+										handling of overflow content in the associated <code>item</code> element.</p>
+									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
+												><code>properties</code></a> attributes.</p>
+									<p>MUST not be declared on a spine item that also declares the <a
+											href="flow-paginated"><code>rendition:flow-paginated</code></a>, <a
+											href="flow-scrolled-continuous"
+												><code>rendition:flow-scrolled-continuous</code></a>, or <a
+											href="flow-scrolled-doc"><code>rendition:flow-scrolled-doc</code></a>
+										properties.</p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-flow-paginated">
+					<h5>The <code>rendition:flow-paginated</code> property</h5>
+
+					<table class="tabledef" id="flow-paginated">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:flow-paginated</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:flow-paginated</code> property indicates to dynamically
+										paginate content overflow in the associated <code>item</code> element.</p>
+									<p>When used, MUST only be declared in the [^itemref^] <a href="#attrdef-properties"
+												><code>properties</code></a> attribute.</p>
+									<p>MUST not be declared on a spine item that also declares the <a href="flow-auto"
+												><code>rendition:flow-auto</code></a>, <a
+											href="flow-scrolled-continuous"
+												><code>rendition:flow-scrolled-continuous</code></a>, or <a
+											href="flow-scrolled-doc"><code>rendition:flow-scrolled-doc</code></a>
+										properties.</p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-flow-scrolled-continuous">
+					<h5>The <code>rendition:flow-scrolled-continuous</code> property</h5>
+
+					<table class="tabledef" id="flow-scrolled-continuous">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:flow-scrolled-continuous</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:flow-scrolled-doc</code> property indicates to provide a
+										scrolled view for overflow content in the associated <code>item</code>
+										element.</p>
+									<p>Consecutive spine items with this property are to be rendered as a continuous
+										scroll.</p>
+									<p>When used, MUST only be declared in the [^itemref^] <a href="#attrdef-properties"
+												><code>properties</code></a> attribute.</p>
+									<p>MUST not be declared on a spine item that also declares the <a href="flow-auto"
+												><code>rendition:flow-auto</code></a>, <a href="flow-paginated"
+												><code>rendition:flow-paginated</code></a>, or <a
+											href="flow-scrolled-doc"><code>rendition:flow-scrolled-doc</code></a>
+										properties.</p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-flow-scrolled-doc">
+					<h5>The <code>rendition:flow-scrolled-doc</code> property</h5>
+
+					<table class="tabledef" id="flow-scrolled-doc">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:flow-scrolled-doc</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:flow-auto</code> property indicates to provide a scrolled
+										view for overflow content in the associated <code>item</code> element.</p>
+									<p>Each spine item with this property is to be rendered as a separate scrollable
+										document.</p>
+									<p>When used, MUST only be declared in the [^itemref^] <a href="#attrdef-properties"
+												><code>properties</code></a> attribute.</p>
+									<p>MUST not be declared on a spine item that also declares the <a href="flow-auto"
+												><code>rendition:flow-auto</code></a>, <a href="flow-paginated"
+												><code>rendition:flow-paginated</code></a>, or <a
+											href="flow-scrolled-continuous"
+												><code>rendition:flow-scrolled-continuous</code></a> properties.</p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-flow-examples">
+					<h5>Flow examples</h5>
+
+					<aside class="example" id="property-flow-ex1" title="Overriding a global paginated flow declaration">
+						<p>In this example, the intent is to have a paginated [=EPUB publication=] with a scrollable
+							table of contents.</p>
+						<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:flow"&gt;
+paginated
+&lt;/meta&gt;
+…
+&lt;/metadata&gt;
+
+…
+
+&lt;spine&gt;
+&lt;itemref
+idref="toc"
+properties="rendition:flow-scrolled-doc"/&gt;
+&lt;itemref
+idref="c01"/&gt;
+&lt;/spine&gt;
+&lt;/package&gt;</pre>
+					</aside>
+				</section>
+			</section>
+
+			<section id="sec-layout-specify" data-epubcheck="true"
+				data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L22,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L27,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L36,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L43,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L50,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L59,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L64">
+				<h4>Layout</h4>
+
+				<section id="sec-layout">
+					<h5>The <code>rendition:layout</code> property</h5>
+
+					<table class="tabledef" id="layout">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:layout</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:layout</code> property specifies whether the EPUB publication
+										is reflowable, pre-paginated or a roll.</p>
+
+									<p>For reflowable and pre-paginated publications, the global layout MAY be <a
+											href="#layout-overrides">overriden</a> for individual [=EPUB content
+										documents=].</p>
+								</td>
+							</tr>
+							<tr>
+								<th>Allowed value(s):</th>
+								<td>
+									<p>MUST be one of the following values:</p>
+
+									<dl class="variablelist">
+										<dt id="def-layout-reflowable">reflowable</dt>
+										<dd>
+											<p>The content is not pre-paginated (i.e., [=reading systems=] may apply
+												dynamic pagination when rendering). Default value.</p>
+										</dd>
+
+										<dt id="def-layout-pre-paginated">pre-paginated</dt>
+										<dd>
+											<p>The content is pre-paginated (i.e., reading systems produce exactly one
+												page per [=EPUB spine | spine=] [^itemref^] when rendering).</p>
+										</dd>
+
+										<dt id="def-layout-roll">roll</dt>
+										<dd>
+											<p>The content is a roll (i.e., reading systems fit the width of each [=EPUB
+												spine | spine=] [^itemref^] to the viewport and display them in a
+												continuous roll with no visible gap).</p>
+										</dd>
+									</dl>
+								</td>
+							</tr>
+							<tr>
+								<th>Cardinality:</th>
+								<td>
+									<code>zero or one</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Extends:</th>
+								<td>Only applies to the EPUB publication. MUST NOT be used when the <a
+										href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-layout-pre-paginated">
+					<h5>The <code>rendition:layout-pre-paginated</code> property</h5>
+
+					<table class="tabledef" id="layout-pre-paginated">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:layout-pre-paginated</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:layout-pre-paginated</code> property indicates the resource
+										in the associated <code>item</code> element is intended to be rendered in a <a
+											href="#sec-pre-paginated">pre-paginated layout</a>.</p>
+									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
+												><code>properties</code></a> attributes.</p>
+									<p>MUST NOT be declared on a spine item that also declares the <a
+											href="#layout-reflowable"><code>rendition:layout-reflowable</code>
+											property</a></p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-layout-reflowable">
+					<h5>The <code>rendition:layout-reflowable</code> property</h5>
+
+					<table class="tabledef" id="layout-reflowable">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:layout-reflowable</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:layout-reflowable</code> property indicates the resource in
+										the associated <code>item</code> element is intended to be rendered in a <a
+											href="#sec-reflowable">reflowable layout</a>.</p>
+									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
+												><code>properties</code></a> attributes.</p>
+									<p>MUST NOT be declared on a spine item that also declares the <a
+											href="#layout-pre-paginated"><code>rendition:layout-pre-paginated</code>
+											property</a></p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+			</section>
+
+			<section id="sec-content-orientation" data-epubcheck="true"
+				data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L74,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L79,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L86,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L93,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L102,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L107">
+				<h4>Orientation</h4>
+
+				<section id="sec-orientation">
+					<h5>The <code>rendition:orientation</code> property</h5>
+
+					<table class="tabledef" id="orientation">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:orientation</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:orientation</code> property specifies which orientation the
+										[=EPUB publication=] is intended to be rendered in. </p>
+
+									<p id="property-orientation-global">When the <a href="#orientation"
+												><code>rendition:orientation</code> property</a> is specified on a
+										[^meta^] element, it indicates that the intended orientation applies globally
+										(i.e., for all [=EPUB spine | spine=] items).</p>
+								</td>
+							</tr>
+							<tr>
+								<th>Allowed value(s):</th>
+								<td>
+									<p>MUST be one of the following values:</p>
+
+									<dl class="variablelist">
+										<dt>landscape</dt>
+										<dd>
+											<p>Render the content in landscape orientation.</p>
+										</dd>
+
+										<dt>portrait</dt>
+										<dd>
+											<p>Render the content in portrait orientation.</p>
+										</dd>
+
+										<dt>auto</dt>
+										<dd>
+											<p>The content is not orientation constrained. Default value.</p>
+										</dd>
+									</dl>
+								</td>
+							</tr>
+							<tr>
+								<th>Cardinality:</th>
+								<td>
+									<code>zero or one</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Extends:</th>
+								<td>Only applies to the EPUB publication. MUST NOT be used when the <a
+										href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-orientation-auto">
+					<h5>The <code>rendition:orientation-auto</code> property</h5>
+					<p>The [=reading system=] determines the orientation to render the spine item in.</p>
+				</section>
+
+				<section id="sec-orientation-landscape">
+					<h5>The <code>rendition:orientation-landscape</code> property</h5>
+					<p>Render the given spine item in landscape orientation.</p>
+				</section>
+
+				<section id="sec-orientation-portrait">
+					<h5>The <code>rendition:orientation-portrait</code> property</h5>
+					<p>Render the given spine item in portrait orientation.</p>
+				</section>
+
+				<section id="orientation-examples">
+					<h5>Orientation examples</h5>
+
+					<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
+						<p>In this example, items in the spine are to be rendered in landscape mode.</p>
+
+						<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:layout"&gt;
+pre-paginated
+&lt;/meta&gt;
+
+&lt;meta
+property="rendition:orientation"&gt;
+landscape
+&lt;/meta&gt;
+&lt;/metadata&gt;
+…
+&lt;/package&gt;</pre>
+					</aside>
+				</section>
+			</section>
+
+			<section id="sec-synthetic-spreads" data-epubcheck="true"
+				data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L117,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L122,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L129,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L136,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L143,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L178,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L151,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L156">
+				<h4>Synthetic spreads</h4>
+
+				<section id="sec-spread">
+					<h5>The <code>rendition:spread</code> property</h5>
+
+					<table class="tabledef" id="spread">
+						<tbody>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>rendition:spread</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>
+									<p>The <code>rendition:spread</code> property specifies the intended [=reading
+										system=] synthetic spread behavior.</p>
+								</td>
+							</tr>
+							<tr>
+								<th>Allowed value(s):</th>
+								<td>
+									<p>MUST be one of the following values:</p>
+
+									<dl class="variablelist">
+										<dt>none</dt>
+										<dd>
+											<p>Do not incorporate spine items in a synthetic spread. Render the items in
+												a single [=viewport=] positioned at the center of the screen.</p>
+										</dd>
+
+										<dt>landscape</dt>
+										<dd>
+											<p>Render a synthetic spread for spine items only when the device is in
+												landscape orientation.</p>
+										</dd>
+
+										<dt>both</dt>
+										<dd>
+											<p>Render a synthetic spread regardless of device orientation.</p>
+										</dd>
+
+										<dt>auto</dt>
+										<dd>
+											<p>No synthetic spread behavior preference is defined. Default value.</p>
+										</dd>
+									</dl>
+								</td>
+							</tr>
+							<tr>
+								<th>Cardinality:</th>
+								<td>
+									<code>zero or one</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Extends:</th>
+								<td>Only applies to the EPUB publication. MUST NOT be used when the <a
+										href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+							</tr>
+						</tbody>
+					</table>
+
+					<div class="note">
+						<p>When synthetic spreads are used in the context of [=XHTML content document | XHTML=] and
+							[=SVG content documents=], the dimensions given via the <a href="#sec-fxl-icb-html"
+									><code>viewport meta</code> element</a> and <a href="#sec-fxl-icb-svg"
+									><code>viewBox</code> attribute</a> represents the size of one page in the spread,
+							respectively.</p>
+					</div>
+
+					<div class="note">
+						<p>Refer to the [^spine^] element for information about declaration of global flow
+							directionality using the <code>page-progression-direction</code> attribute and that of local
+							page-progression-direction within content documents.</p>
+					</div>
+				</section>
+
+				<section id="sec-spread-auto">
+					<h5>The <code>rendition:spread-auto</code> property</h5>
+					<p>The [=reading system=] determines when to render a synthetic spread for the spine item.</p>
+				</section>
+
+				<section id="sec-spread-both">
+					<h5>The <code>rendition:spread-both</code> property</h5>
+					<p>Render a synthetic spread for the spine item in both portrait and landscape orientations.</p>
+				</section>
+
+				<section id="sec-spread-landscape">
+					<h5>The <code>rendition:spread-landscape</code> property</h5>
+					<p>Render a synthetic spread for the spine item only when in landscape orientation.</p>
+				</section>
+
+				<section id="sec-spread-none">
+					<h5>The <code>rendition:spread-none</code> property</h5>
+					<p>Do not render a synthetic spread for the spine item.</p>
+				</section>
+
+
+				<section id="spread-examples">
+					<h5>Spread examples</h5>
+
+					<aside class="example" id="spread-none-example"
+						title="A fixed-layout EPUB publication without synthetic spread">
+						<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:layout"&gt;
+pre-paginated
+&lt;/meta&gt;
+
+&lt;meta
+property="rendition:spread"&gt;
+none
+&lt;/meta&gt;
+&lt;/metadata&gt;
+…
+&lt;/package&gt;</pre>
+
+						<figure id="spread-none-figure">
+							<figcaption> Rendering of three fixed-layout documents without synthetic spread. <br /><span
+									class="attribution">(Comics courtesy of <a href="https://xkcd.com/927/">xkcd</a>,
+									licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+							</figcaption>
+							<img src="images/example_spread_none.svg" width="600" aria-details="spread-none-diagram"
+								alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time everywhere"
+							 />
+						</figure>
+
+						<details id="spread-none-diagram" class="desc">
+							<summary>Image description</summary>
+							<p>Two rows of schematic views of tablets (three in each row). The tablets in the top row
+								are in portrait mode, and in landscape mode in the bottom one. The schematic views of
+								the tablets within a row are linked with left-to-right arrows.</p>
+							<p>In the tablets of each row the consecutive panels of a comics are displayed; the panels
+								are centered in their respective tablets.</p>
+						</details>
+					</aside>
+
+					<aside class="example" id="spread-landscape-example"
+						title="Specifying the usage of synthetic spreads in landscape orientation only">
+						<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:layout"&gt;
+pre-paginated
+&lt;/meta&gt;
+
+&lt;meta
+property="rendition:spread"&gt;
+landscape
+&lt;/meta&gt;
+&lt;/metadata&gt;
+…
+&lt;/package&gt;</pre>
+
+
+						<figure id="spread-landscape-figure">
+							<figcaption> Rendering of three fixed-layout documents, with synthetic spread in landscape
+								orientation only. <br /><span class="attribution">(Comics courtesy of <a
+										href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+										href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc 2.5</a>.)</span>
+							</figcaption>
+							<img src="images/example_spread_landscape.svg" width="600"
+								aria-details="spread-landscape-diagram"
+								alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time in portrait and using synthetic spread in landscape."
+							 />
+						</figure>
+
+						<details id="spread-landscape-diagram" class="desc">
+							<summary>Image description</summary>
+							<p>Two rows of schematic views of tablets (three in top row, and two in the bottom). The
+								tablets in the top row are in portrait mode, and in landscape mode in the bottom one.
+								The schematic views of the tablets within a row are linked with left-to-right
+								arrows.</p>
+							<p>In both rows three panels of a comics are displayed. In the top row the panels are
+								centered in their respective tablets. In the bottom row, the first tablet contains the
+								first and second panels of the comics side by side; the second tablet contains the
+								second and third panels of the comics side-by-side.</p>
+						</details>
+					</aside>
+
+					<aside class="example" id="spread-both-example"
+						title="Specifying to use synthetic spreads both in portrait and in landscape orientations">
+						<p>See also <a href="#spread-both-figure"></a>.</p>
+						<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:layout"&gt;
+pre-paginated
+&lt;/meta&gt;
+
+&lt;meta
+property="rendition:spread"&gt;
+both
+&lt;/meta&gt;
+&lt;/metadata&gt;
+…
+&lt;/package&gt;</pre>
+
+						<figure id="spread-both-figure">
+							<figcaption> Rendering of three fixed-layout documents, with synthetic spread in both
+								portrait and landscape orientations. <br /><span class="attribution">(Comics courtesy of
+										<a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+										href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc 2.5</a>.)</span>
+							</figcaption>
+							<img src="images/example_spread_both.svg" width="600" aria-details="spread-both-diagram"
+								alt="Progression of FXL pages both in portrait and in landscape modes, using synthetic spread in both cases."
+							 />
+						</figure>
+
+						<details id="spread-both-diagram" class="desc">
+							<summary>Image description</summary>
+							<p>Two rows of schematic views of tablets (two in each row). The tablets in the top row are
+								in portrait mode, and in landscape mode in the bottom one. The schematic views of the
+								tablets within a row are linked with left-to-right arrows.</p>
+							<p>In both rows three panels of a comics are displayed. The first tablet in a row contains
+								the first and second panels of the comics side by side; the second tablet contains the
+								second and third panels of the comics side-by-side.</p>
+						</details>
+					</aside>
+
+					<aside class="example" id="spread-both-with-intro-example"
+						title="Overriding the global spread behavior">
+						<p>In this example, the global reflowable setting is overridden in the spine for the
+							introductory page. The intention is for reading systems to render it as a reflowable
+							document.</p>
+
+						<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:layout"&gt;
+pre-paginated
+&lt;/meta&gt;
+&lt;meta
+property="rendition:spread"&gt;
+both
+&lt;/meta&gt;
+&lt;/metadata&gt;
+
+&lt;spine&gt;
+&lt;itemref
+idref="introduction"
+properties="rendition:layout-reflowable"/&gt;
+…
+&lt;/spine&gt;
+…
+&lt;/package&gt;</pre>
+
+						<figure id="spread-both-with-intro-figure">
+							<figcaption>Rendering of an introduction document in reflowable layout, followed by three
+								fixed-layout documents with synthetic spread in portrait orientation. <br /><span
+									class="attribution">(Comics courtesy of <a href="https://xkcd.com/927/">xkcd</a>,
+									licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+							</figcaption>
+							<img src="images/example_spread_both_with_reflowable_intro.svg" width="600"
+								aria-details="spread-both-with-intro-diagram"
+								alt="Progression of FXL pages both in portrait using synthetic spread in both cases, preceded by an introduction with reflowable content."
+							 />
+						</figure>
+
+						<details id="spread-both-with-intro-diagram" class="desc">
+							<summary>Image description</summary>
+							<p>A row of schematic views of three tablets in portrait mode, and linked with left-to-right
+								arrows.</p>
+							<p>The first tablet views includes a single, column-like strip (i.e., a rectangle without a
+								bottom edge following beyond the bottom of the tablet) with a text flowing down the
+								strip, and starting with the word "Introduction". This is followed by two schematic
+								tablets with three panels of comics displayed. The first tablet in the row contains the
+								first and second panels of the comics side by side; the second tablet contains the
+								second and third panels of the comics side-by-side.</p>
+						</details>
+					</aside>
+
+					<aside class="example" id="spread-page-spread-right-example"
+						title="Starting the first document on the right">
+						<pre>&lt;package …&gt;
+&lt;metadata …&gt;
+…
+&lt;meta
+property="rendition:layout"&gt;
+reflowable
+&lt;/meta&gt;
+
+&lt;meta
+property="rendition:spread"&gt;
+landscape
+&lt;/meta&gt;
+…
+&lt;/metadata&gt;
+&lt;spine page-progression-direction="ltr"&gt;
+…
+&lt;itemref
+idref="first-panel"
+properties="rendition:page-spread-right"/&gt;
+…
+&lt;/spine&gt;
+&lt;/package&gt;</pre>
+
+						<figure id="spread-page-spread-right-figure">
+							<figcaption>Rendering of three fixed-layout documents, with synthetic spread in landscape
+								orientation starting on the right. <br /><span class="attribution">(Comics courtesy of
+										<a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+										href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc 2.5</a>.)</span>
+							</figcaption>
+							<img src="images/example_spread_page_spread_right.svg" width="600"
+								aria-details="spread-page-spread-right-diagram"
+								alt="Progression of FXL pages in landscape modes, showing synthetic spread in both cases but with the first page appearing on the right side of the first page."
+							 />
+						</figure>
+
+						<details id="spread-page-spread-right-diagram" class="desc">
+							<summary>Image description</summary>
+							<p>A row of schematic views of two tablets in landscape mode, and linked with a
+								left-to-right arrow.</p>
+							<p>Three panels of a comics are displayed in the tablets. The first tablet in the row
+								contains the first panels of the comics on the right hand of the tablet, with the left
+								side empty; the second tablet contains the second and third panels of the comics
+								side-by-side.</p>
+						</details>
+					</aside>
+				</section>
+			</section>
+
+			<section id="sec-spread-placement">
+				<h4>Spread placement</h4>
+
+				<section id="sec-page-spread-center">
+					<h5>The <code>rendition:page-spread-center</code> property</h5>
+					<p>The <code>rendition:page-spread-center</code> property is an alias of the <a href="#spread-none"
+								><code>spread-none</code> property</a> for centering a spine item.</p>
+				</section>
+
+				<section id="sec-page-spread-left">
+					<h5>The <code>rendition:page-spread-left</code> property</h5>
+					<p>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
+								href="#page-spread-left">page-spread-left</a></code> property for placing a spine item
+						in the left-hand slot of a two-page spread.</p>
+				</section>
+
+				<section id="sec-page-spread-right">
+					<h5>The <code>rendition:page-spread-right</code> property</h5>
+					<p>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
+								href="#page-spread-right">page-spread-right</a></code> property for placing a spine item
+						in the right-hand slot of a two-page spread.</p>
+				</section>
+			</section>
+
+			<section id="sec-rendering-custom-properties" data-epubcheck="true"
+				data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_package-rendering-vocab.feature_L19">
+				<h4>Custom rendering properties</h4>
+
+				<p>Custom properties and [=EPUB spine | spine=] overrides can be included in the [=package document=] to
+					address rendering issues specific to particular [=reading systems=], as defined by the developers of
+					those reading systems.</p>
+
+				<p>The only restrictions are that such properties MUST NOT be defined with a <code>rendition:</code>
+					prefix and MUST NOT conflict behaviorally with properties in the <a href="app-rendering-vocab"
+						>package rendering vocabulary</a>.</p>
+
+				<p>If extensions are needed for use by multiple independent reading systems, the preferred method is to
+					extend the package rendering vocabulary through a revision to this standard.</p>
+			</section>
+		</section>
+	</body>
+</html>

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -1,9 +1,3 @@
-<!DOCTYPE html>
-<html>
-	<head>
-		<title>test</title>
-	</head>
-	<body>
 		<section id="app-rendering-vocab">
 			<h3>Package rendering vocabulary</h3>
 
@@ -1248,5 +1242,3 @@ is scrollable." />
 					extend the package rendering vocabulary through a revision to this standard.</p>
 			</section>
 		</section>
-	</body>
-</html>

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -18,15 +18,15 @@
 					consist of a mix of properties (expressed in [^meta^] elements) and [=EPUB spine | spine=] overrides
 					(expressed on [^itemref^] elements).</p>
 
-				<p>The usage requirements are defined in <a href="#sec-rendering"></a> not in this appendix. The
-					following table provides a map to the properties, overrides, and where they are defined.</p>
+				<p>The usage requirements are defined in <a href="#sec-layout"></a> not in this appendix. The following
+					table provides a map to the properties, overrides, and where they are defined.</p>
 			</div>
 
 			<section id="sec-centering">
-				<h4>Center aligment</h4>
+				<h4>Center alignment</h4>
 
 				<section id="sec-align-x-center">
-					<h5>The <code>rendition:align-x-center</code> property</h5>
+					<h5>rendition:align-x-center</h5>
 
 					<div class="note">
 						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
@@ -49,8 +49,12 @@
 									<p>The <code>rendition:align-x-center</code> [=EPUB spine | spine=] override
 										property specifies to center the content of given reflowable spine item
 										horizontally in the [=viewport=] or spread.</p>
-									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
-												><code>properties</code></a> attributes.</p>
+								</td>
+							</tr>
+							<tr>
+								<th>Application:</th>
+								<td>
+									<p>MAY only be declared on [^spine^] [^itemref^] attributes.</p>
 								</td>
 							</tr>
 						</tbody>
@@ -63,7 +67,7 @@
 
 				<section id="sec-flow" data-epubcheck="true"
 					data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L320,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L325,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L332,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L339,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L348,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L353">
-					<h5>The <code>rendition:flow</code> property</h5>
+					<h5>rendition:flow</h5>
 
 					<table class="tabledef" id="flow">
 						<tbody>
@@ -218,127 +222,134 @@ is scrollable." />
 					</details>
 				</section>
 
-				<section id="sec-flow-auto">
-					<h5>The <code>rendition:flow-auto</code> property</h5>
+				<section id="flow-overrides">
+					<h5>Flow overrides</h5>
 
-					<table class="tabledef" id="flow-auto">
-						<tbody>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>rendition:flow-auto</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>
-									<p>The <code>rendition:flow-auto</code> property indicates no preference for the
-										handling of overflow content in the associated <code>item</code> element.</p>
-									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
-												><code>properties</code></a> attributes.</p>
-									<p>MUST not be declared on a spine item that also declares the <a
-											href="flow-paginated"><code>rendition:flow-paginated</code></a>, <a
-											href="flow-scrolled-continuous"
-												><code>rendition:flow-scrolled-continuous</code></a>, or <a
-											href="flow-scrolled-doc"><code>rendition:flow-scrolled-doc</code></a>
-										properties.</p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
+					<section id="sec-flow-auto">
+						<h5>rendition:flow-auto</h5>
 
-				<section id="sec-flow-paginated">
-					<h5>The <code>rendition:flow-paginated</code> property</h5>
+						<table class="tabledef" id="flow-auto">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:flow-auto</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:flow-auto</code> property indicates no preference for the
+											handling of overflow content in the associated <code>item</code>
+											element.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#flow-overrides">flow override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 
-					<table class="tabledef" id="flow-paginated">
-						<tbody>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>rendition:flow-paginated</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>
-									<p>The <code>rendition:flow-paginated</code> property indicates to dynamically
-										paginate content overflow in the associated <code>item</code> element.</p>
-									<p>When used, MUST only be declared in the [^itemref^] <a href="#attrdef-properties"
-												><code>properties</code></a> attribute.</p>
-									<p>MUST not be declared on a spine item that also declares the <a href="flow-auto"
-												><code>rendition:flow-auto</code></a>, <a
-											href="flow-scrolled-continuous"
-												><code>rendition:flow-scrolled-continuous</code></a>, or <a
-											href="flow-scrolled-doc"><code>rendition:flow-scrolled-doc</code></a>
-										properties.</p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
+					<section id="sec-flow-paginated">
+						<h5>rendition:flow-paginated</h5>
 
-				<section id="sec-flow-scrolled-continuous">
-					<h5>The <code>rendition:flow-scrolled-continuous</code> property</h5>
+						<table class="tabledef" id="flow-paginated">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:flow-paginated</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:flow-paginated</code> property indicates to dynamically
+											paginate content overflow in the associated <code>item</code> element.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#flow-overrides">flow override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 
-					<table class="tabledef" id="flow-scrolled-continuous">
-						<tbody>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>rendition:flow-scrolled-continuous</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>
-									<p>The <code>rendition:flow-scrolled-doc</code> property indicates to provide a
-										scrolled view for overflow content in the associated <code>item</code>
-										element.</p>
-									<p>Consecutive spine items with this property are to be rendered as a continuous
-										scroll.</p>
-									<p>When used, MUST only be declared in the [^itemref^] <a href="#attrdef-properties"
-												><code>properties</code></a> attribute.</p>
-									<p>MUST not be declared on a spine item that also declares the <a href="flow-auto"
-												><code>rendition:flow-auto</code></a>, <a href="flow-paginated"
-												><code>rendition:flow-paginated</code></a>, or <a
-											href="flow-scrolled-doc"><code>rendition:flow-scrolled-doc</code></a>
-										properties.</p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
+					<section id="sec-flow-scrolled-continuous">
+						<h5>rendition:flow-scrolled-continuous</h5>
 
-				<section id="sec-flow-scrolled-doc">
-					<h5>The <code>rendition:flow-scrolled-doc</code> property</h5>
+						<table class="tabledef" id="flow-scrolled-continuous">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:flow-scrolled-continuous</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:flow-scrolled-doc</code> property indicates to provide a
+											scrolled view for overflow content in the associated <code>item</code>
+											element.</p>
+										<p>Consecutive spine items with this property are to be rendered as a continuous
+											scroll.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#flow-overrides">flow override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 
-					<table class="tabledef" id="flow-scrolled-doc">
-						<tbody>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>rendition:flow-scrolled-doc</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>
-									<p>The <code>rendition:flow-auto</code> property indicates to provide a scrolled
-										view for overflow content in the associated <code>item</code> element.</p>
-									<p>Each spine item with this property is to be rendered as a separate scrollable
-										document.</p>
-									<p>When used, MUST only be declared in the [^itemref^] <a href="#attrdef-properties"
-												><code>properties</code></a> attribute.</p>
-									<p>MUST not be declared on a spine item that also declares the <a href="flow-auto"
-												><code>rendition:flow-auto</code></a>, <a href="flow-paginated"
-												><code>rendition:flow-paginated</code></a>, or <a
-											href="flow-scrolled-continuous"
-												><code>rendition:flow-scrolled-continuous</code></a> properties.</p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
+					<section id="sec-flow-scrolled-doc">
+						<h5>rendition:flow-scrolled-doc</h5>
+
+						<table class="tabledef" id="flow-scrolled-doc">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:flow-scrolled-doc</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:flow-auto</code> property indicates to provide a scrolled
+											view for overflow content in the associated <code>item</code> element.</p>
+										<p>Each spine item with this property is to be rendered as a separate scrollable
+											document.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#flow-overrides">flow override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 				</section>
 
 				<section id="sec-flow-examples">
@@ -347,26 +358,26 @@ is scrollable." />
 					<aside class="example" id="property-flow-ex1" title="Overriding a global paginated flow declaration">
 						<p>In this example, the intent is to have a paginated [=EPUB publication=] with a scrollable
 							table of contents.</p>
-						<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:flow"&gt;
-paginated
-&lt;/meta&gt;
-…
-&lt;/metadata&gt;
+						<pre>&lt;package …>
+&lt;metadata …>
+	…
+	&lt;meta
+		property="rendition:flow">
+		paginated
+	&lt;/meta>
+	…
+&lt;/metadata>
 
 …
 
-&lt;spine&gt;
-&lt;itemref
-idref="toc"
-properties="rendition:flow-scrolled-doc"/&gt;
-&lt;itemref
-idref="c01"/&gt;
-&lt;/spine&gt;
-&lt;/package&gt;</pre>
+&lt;spine>
+	&lt;itemref
+		idref="toc"
+		properties="rendition:flow-scrolled-doc"/>
+	&lt;itemref
+		idref="c01"/>
+&lt;/spine>
+&lt;/package></pre>
 					</aside>
 				</section>
 			</section>
@@ -376,7 +387,7 @@ idref="c01"/&gt;
 				<h4>Layout</h4>
 
 				<section id="sec-layout">
-					<h5>The <code>rendition:layout</code> property</h5>
+					<h5>rendition:layout</h5>
 
 					<table class="tabledef" id="layout">
 						<tbody>
@@ -391,7 +402,6 @@ idref="c01"/&gt;
 								<td>
 									<p>The <code>rendition:layout</code> property specifies whether the EPUB publication
 										is reflowable, pre-paginated or a roll.</p>
-
 									<p>For reflowable and pre-paginated publications, the global layout MAY be <a
 											href="#layout-overrides">overriden</a> for individual [=EPUB content
 										documents=].</p>
@@ -439,60 +449,70 @@ idref="c01"/&gt;
 					</table>
 				</section>
 
-				<section id="sec-layout-pre-paginated">
-					<h5>The <code>rendition:layout-pre-paginated</code> property</h5>
+				<section id="layout-overrides">
+					<h5>Layout overrides</h5>
 
-					<table class="tabledef" id="layout-pre-paginated">
-						<tbody>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>rendition:layout-pre-paginated</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>
-									<p>The <code>rendition:layout-pre-paginated</code> property indicates the resource
-										in the associated <code>item</code> element is intended to be rendered in a <a
-											href="#sec-pre-paginated">pre-paginated layout</a>.</p>
-									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
-												><code>properties</code></a> attributes.</p>
-									<p>MUST NOT be declared on a spine item that also declares the <a
-											href="#layout-reflowable"><code>rendition:layout-reflowable</code>
-											property</a></p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
+					<section id="sec-layout-pre-paginated">
+						<h6>rendition:layout-pre-paginated</h6>
 
-				<section id="sec-layout-reflowable">
-					<h5>The <code>rendition:layout-reflowable</code> property</h5>
+						<table class="tabledef" id="layout-pre-paginated">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:layout-pre-paginated</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:layout-pre-paginated</code> property indicates the
+											resource in the associated <code>item</code> element is intended to be
+											rendered in a <a href="#sec-pre-paginated">pre-paginated layout</a>.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#layout-overrides">layout override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 
-					<table class="tabledef" id="layout-reflowable">
-						<tbody>
-							<tr>
-								<th>Name:</th>
-								<td>
-									<code>rendition:layout-reflowable</code>
-								</td>
-							</tr>
-							<tr>
-								<th>Description:</th>
-								<td>
-									<p>The <code>rendition:layout-reflowable</code> property indicates the resource in
-										the associated <code>item</code> element is intended to be rendered in a <a
-											href="#sec-reflowable">reflowable layout</a>.</p>
-									<p>When used, MUST only be declared in [^itemref^] <a href="#attrdef-properties"
-												><code>properties</code></a> attributes.</p>
-									<p>MUST NOT be declared on a spine item that also declares the <a
-											href="#layout-pre-paginated"><code>rendition:layout-pre-paginated</code>
-											property</a></p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
+					<section id="sec-layout-reflowable">
+						<h6>rendition:layout-reflowable</h6>
+
+						<table class="tabledef" id="layout-reflowable">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:layout-reflowable</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:layout-reflowable</code> property indicates the resource
+											in the associated <code>item</code> element is intended to be rendered in a
+												<a href="#sec-reflowable">reflowable layout</a>.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#layout-overrides">layout override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 				</section>
 			</section>
 
@@ -501,7 +521,7 @@ idref="c01"/&gt;
 				<h4>Orientation</h4>
 
 				<section id="sec-orientation">
-					<h5>The <code>rendition:orientation</code> property</h5>
+					<h5>rendition:orientation</h5>
 
 					<table class="tabledef" id="orientation">
 						<tbody>
@@ -561,42 +581,119 @@ idref="c01"/&gt;
 					</table>
 				</section>
 
-				<section id="sec-orientation-auto">
-					<h5>The <code>rendition:orientation-auto</code> property</h5>
-					<p>The [=reading system=] determines the orientation to render the spine item in.</p>
+				<section id="orientation-overrides">
+					<h5>Orientation overrides</h5>
+
+					<section id="sec-orientation-auto">
+						<h6>rendition:orientation-auto</h6>
+
+						<table class="tabledef" id="orientatio-auto">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:orientatio-auto</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The [=reading system=] determines the orientation to render the spine item
+											in.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#orientation-overrides">orientation override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section id="sec-orientation-landscape">
+						<h6>rendition:orientation-landscape</h6>
+
+						<table class="tabledef" id="orientation-landscape">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:orientation-landscape</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>Render the given spine item in landscape orientation.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#orientation-overrides">orientation override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section id="sec-orientation-portrait">
+						<h6>rendition:orientation-portrait</h6>
+
+						<table class="tabledef" id="orientation-portrait">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:orientation-portrait</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>Render the given spine item in portrait orientation.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#orientation-overrides">orientation override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 				</section>
 
-				<section id="sec-orientation-landscape">
-					<h5>The <code>rendition:orientation-landscape</code> property</h5>
-					<p>Render the given spine item in landscape orientation.</p>
-				</section>
-
-				<section id="sec-orientation-portrait">
-					<h5>The <code>rendition:orientation-portrait</code> property</h5>
-					<p>Render the given spine item in portrait orientation.</p>
-				</section>
-
-				<section id="orientation-examples">
+				<section id="sec-orientation-examples">
 					<h5>Orientation examples</h5>
 
 					<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
 						<p>In this example, items in the spine are to be rendered in landscape mode.</p>
 
-						<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:layout"&gt;
-pre-paginated
-&lt;/meta&gt;
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
 
-&lt;meta
-property="rendition:orientation"&gt;
-landscape
-&lt;/meta&gt;
-&lt;/metadata&gt;
-…
-&lt;/package&gt;</pre>
+      &lt;meta
+          property="rendition:orientation">
+         landscape
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
 					</aside>
 				</section>
 			</section>
@@ -606,7 +703,7 @@ landscape
 				<h4>Synthetic spreads</h4>
 
 				<section id="sec-spread">
-					<h5>The <code>rendition:spread</code> property</h5>
+					<h5>rendition:spread</h5>
 
 					<table class="tabledef" id="spread">
 						<tbody>
@@ -682,47 +779,248 @@ landscape
 					</div>
 				</section>
 
-				<section id="sec-spread-auto">
-					<h5>The <code>rendition:spread-auto</code> property</h5>
-					<p>The [=reading system=] determines when to render a synthetic spread for the spine item.</p>
+				<section id="spread-overrides">
+					<h5>Spread overrides</h5>
+
+					<section id="sec-spread-auto">
+						<h6>rendition:spread-auto</h6>
+
+						<table class="tabledef" id="spread-auto">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:spread-auto</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The [=reading system=] determines when to render a synthetic spread for the
+											spine item.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#spread-overrides">spread override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section id="sec-spread-both">
+						<h6>rendition:spread-both</h6>
+
+						<table class="tabledef" id="spread-both">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:spread-both</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>Render a synthetic spread for the spine item in both portrait and landscape
+											orientations.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#spread-overrides">spread override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section id="sec-spread-landscape">
+						<h6>rendition:spread-landscape</h6>
+
+						<table class="tabledef" id="spread-landscape">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:spread-landscape</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>Render a synthetic spread for the spine item only when in landscape
+											orientation.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#spread-overrides">spread override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section id="sec-spread-none">
+						<h6>rendition:spread-none</h6>
+
+						<table class="tabledef" id="spread-none">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:spread-none</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>Do not render a synthetic spread for the spine item.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#spread-overrides">spread override property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 				</section>
 
-				<section id="sec-spread-both">
-					<h5>The <code>rendition:spread-both</code> property</h5>
-					<p>Render a synthetic spread for the spine item in both portrait and landscape orientations.</p>
-				</section>
+				<section id="spread-placement">
+					<h5>Spread placement</h5>
 
-				<section id="sec-spread-landscape">
-					<h5>The <code>rendition:spread-landscape</code> property</h5>
-					<p>Render a synthetic spread for the spine item only when in landscape orientation.</p>
-				</section>
+					<section id="sec-page-spread-center">
+						<h6>rendition:page-spread-center</h6>
 
-				<section id="sec-spread-none">
-					<h5>The <code>rendition:spread-none</code> property</h5>
-					<p>Do not render a synthetic spread for the spine item.</p>
-				</section>
+						<table class="tabledef" id="page-spread-center">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:page-spread-center</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:page-spread-center</code> property is an alias of the <a
+												href="#spread-none"><code>spread-none</code> property</a> for centering
+											a spine item.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#spread-placement">spread placement property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
 
+					<section id="sec-page-spread-left">
+						<h6>rendition:page-spread-left</h6>
+
+						<table class="tabledef" id="page-spread-left">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:page-spread-left</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:page-spread-left</code> property is an alias of the
+													<code><a href="#page-spread-left">page-spread-left</a></code>
+											property for placing a spine item in the left-hand slot of a two-page
+											spread.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#spread-placement">spread placement property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section id="sec-page-spread-right">
+						<h6>rendition:page-spread-right</h6>
+
+						<table class="tabledef" id="page-spread-right">
+							<tbody>
+								<tr>
+									<th>Name:</th>
+									<td>
+										<code>rendition:page-spread-right</code>
+									</td>
+								</tr>
+								<tr>
+									<th>Description:</th>
+									<td>
+										<p>The <code>rendition:page-spread-right</code> property is an alias of the
+													<code><a href="#page-spread-right">page-spread-right</a></code>
+											property for placing a spine item in the right-hand slot of a two-page
+											spread.</p>
+									</td>
+								</tr>
+								<tr>
+									<th>Application:</th>
+									<td>
+										<p>MAY be declared only on [^spine^] [^itemref^] attributes.</p>
+										<p>MUST NOT be declared on a spine item that also declares another <a
+												href="#spread-placement">spread placement property</a>.</p>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+				</section>
 
 				<section id="spread-examples">
 					<h5>Spread examples</h5>
 
 					<aside class="example" id="spread-none-example"
 						title="A fixed-layout EPUB publication without synthetic spread">
-						<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:layout"&gt;
-pre-paginated
-&lt;/meta&gt;
+						<pre>>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
 
-&lt;meta
-property="rendition:spread"&gt;
-none
-&lt;/meta&gt;
-&lt;/metadata&gt;
-…
-&lt;/package&gt;</pre>
+      &lt;meta
+          property="rendition:spread">
+         none
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
 
 						<figure id="spread-none-figure">
 							<figcaption> Rendering of three fixed-layout documents without synthetic spread. <br /><span
@@ -747,21 +1045,21 @@ none
 
 					<aside class="example" id="spread-landscape-example"
 						title="Specifying the usage of synthetic spreads in landscape orientation only">
-						<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:layout"&gt;
-pre-paginated
-&lt;/meta&gt;
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
 
-&lt;meta
-property="rendition:spread"&gt;
-landscape
-&lt;/meta&gt;
-&lt;/metadata&gt;
-…
-&lt;/package&gt;</pre>
+      &lt;meta
+          property="rendition:spread">
+         landscape
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
 
 
 						<figure id="spread-landscape-figure">
@@ -792,21 +1090,21 @@ landscape
 					<aside class="example" id="spread-both-example"
 						title="Specifying to use synthetic spreads both in portrait and in landscape orientations">
 						<p>See also <a href="#spread-both-figure"></a>.</p>
-						<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:layout"&gt;
-pre-paginated
-&lt;/meta&gt;
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
 
-&lt;meta
-property="rendition:spread"&gt;
-both
-&lt;/meta&gt;
-&lt;/metadata&gt;
-…
-&lt;/package&gt;</pre>
+      &lt;meta
+          property="rendition:spread">
+         both
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
 
 						<figure id="spread-both-figure">
 							<figcaption> Rendering of three fixed-layout documents, with synthetic spread in both
@@ -836,27 +1134,27 @@ both
 							introductory page. The intention is for reading systems to render it as a reflowable
 							document.</p>
 
-						<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:layout"&gt;
-pre-paginated
-&lt;/meta&gt;
-&lt;meta
-property="rendition:spread"&gt;
-both
-&lt;/meta&gt;
-&lt;/metadata&gt;
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         both
+      &lt;/meta>
+   &lt;/metadata>
 
-&lt;spine&gt;
-&lt;itemref
-idref="introduction"
-properties="rendition:layout-reflowable"/&gt;
-…
-&lt;/spine&gt;
-…
-&lt;/package&gt;</pre>
+   &lt;spine>
+      &lt;itemref
+          idref="introduction"
+          properties="rendition:layout-reflowable"/>
+      …
+   &lt;/spine>
+   …
+&lt;/package></pre>
 
 						<figure id="spread-both-with-intro-figure">
 							<figcaption>Rendering of an introduction document in reflowable layout, followed by three
@@ -886,28 +1184,28 @@ properties="rendition:layout-reflowable"/&gt;
 
 					<aside class="example" id="spread-page-spread-right-example"
 						title="Starting the first document on the right">
-						<pre>&lt;package …&gt;
-&lt;metadata …&gt;
-…
-&lt;meta
-property="rendition:layout"&gt;
-reflowable
-&lt;/meta&gt;
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+          reflowable
+      &lt;/meta>
 
-&lt;meta
-property="rendition:spread"&gt;
-landscape
-&lt;/meta&gt;
-…
-&lt;/metadata&gt;
-&lt;spine page-progression-direction="ltr"&gt;
-…
-&lt;itemref
-idref="first-panel"
-properties="rendition:page-spread-right"/&gt;
-…
-&lt;/spine&gt;
-&lt;/package&gt;</pre>
+      &lt;meta
+          property="rendition:spread">
+          landscape
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   &lt;spine page-progression-direction="ltr">
+      …
+      &lt;itemref
+          idref="first-panel"
+          properties="rendition:page-spread-right"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
 
 						<figure id="spread-page-spread-right-figure">
 							<figcaption>Rendering of three fixed-layout documents, with synthetic spread in landscape
@@ -931,30 +1229,6 @@ properties="rendition:page-spread-right"/&gt;
 								side-by-side.</p>
 						</details>
 					</aside>
-				</section>
-			</section>
-
-			<section id="sec-spread-placement">
-				<h4>Spread placement</h4>
-
-				<section id="sec-page-spread-center">
-					<h5>The <code>rendition:page-spread-center</code> property</h5>
-					<p>The <code>rendition:page-spread-center</code> property is an alias of the <a href="#spread-none"
-								><code>spread-none</code> property</a> for centering a spine item.</p>
-				</section>
-
-				<section id="sec-page-spread-left">
-					<h5>The <code>rendition:page-spread-left</code> property</h5>
-					<p>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
-								href="#page-spread-left">page-spread-left</a></code> property for placing a spine item
-						in the left-hand slot of a two-page spread.</p>
-				</section>
-
-				<section id="sec-page-spread-right">
-					<h5>The <code>rendition:page-spread-right</code> property</h5>
-					<p>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
-								href="#page-spread-right">page-spread-right</a></code> property for placing a spine item
-						in the right-hand slot of a two-page spread.</p>
 				</section>
 			</section>
 


### PR DESCRIPTION
Opening this pull request to give an idea of what I'd like to do with the layout rendering control section. As I mentioned in #2788, I find what we have a confusing mess of property definitions in the body with poor explanations of how they go together for the layouts (like spreads and placement which aren't strictly for pre-paginated content but are lumped under fxl).

What I've done (so far) is:

- moved the layout section up ahead of content documents as, pedagogically, you're typically picking your layout before getting into the details of content documents
- add a layout types section to explain each of three main layout types
- moved all the property definition text back into appendix D.5 and stopped trying to categorize their uses (we can do that in the layout sections). It'll also help to not have one vocabulary that is a mapping table pointing into the body, and should help avoid an oddly empty section on layout control if we do indeed end up deprecating almost all of the properties
- kept synthetic spreads as a separate subsection from the layout types since it applies to both reflowable and pre-paginated content (which maybe gets pared down furhte
- moved the section on fixed layout documents and setting their dimensions into the content documents section.
- dropped the "roll document" stuff as it perpetuates a difference that doesn't exist at the content document level (roll and pre-paginated are different ways of presenting fixed layout documents)

I'm only opening this as a draft as it's not ready for review of the text yet, and I would suggest no bothering to read too deeply into what is there right now. I'll do a more serious edit of the sections if people agree with this approach.

(One aside in making these changes is that it made clearer to me what a mess scrolled-continuous is no matter what we do. It's not solely an overflow handling property but mixes scrolled-doc into a new type of layout that spans spine items (and is really odd as a spine override). It's too bad we couldn't define roll as either requiring fxl document or reflowable ones and deprecate scrolled-continuous (make reading systems recognize it as a roll layout). As it is, you'll get one kind of "roll" from scrolled-continuous and another kind from layout=roll.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2842.html" title="Last updated on Dec 7, 2025, 2:43 AM UTC (344a16c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2842/d65abd7...344a16c.html" title="Last updated on Dec 7, 2025, 2:43 AM UTC (344a16c)">Diff</a>