### PR TITLE
Rewrote the section on json-ld serialization

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -910,12 +910,8 @@
             <p>
                 Following the [[[annotation-model]]] [[annotation-model]] specification, EPUB Annotations are
                 expressed as a "shape" of JSON-LD [[json-ld11]] (a variant of JSON [[ecma-404]] for linked data).
-                The shape is informally defined through a JSON Schema [[json-schema]]; see Appendix XXX for further details.
+                The shape is informally defined through a JSON Schema [[json-schema]]; see <a href="#5-json-schema"></a> for further details.
                 The media type of this format is <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>
-            </p>
-
-            <p class="ednote">I seem to remember that we agreed that, eventually, we would provide a JSON schema for annotations. I think
-                we really should; the text above makes the assumption that this will eventually happen.
             </p>
 
             <p> This specification introduces a dedicated file extension for serialized
@@ -923,8 +919,7 @@
             </p>
 
             <p>
-                To abide to the requirements of JSON-LD, each annotation file (whether a single annotation or an annotation set) MUST start with a
-                context declarations referring (see also the example below):
+                Following the requirements of JSON-LD, each annotation file (whether a single annotation or an annotation set) MUST start with a context declaration referring to the following contexts:
             </p>
 
             <table class="zebra">
@@ -942,7 +937,7 @@
                 </tr>
             </table>
 
-            <aside class="example" title="Context declaration">
+            <aside class="example" title="Required context declaration">
                 <pre>
                     {
                         "@context": [
@@ -951,12 +946,23 @@
                         ],
                         "id": "urn:uuid:123-123-123-123",
                         …
+                    }
                    </pre>
             </aside>
 
+            <p class="note">
+                Implementations that do not rely on the linked data aspects of annotations may rely on bespoke processing
+                based on the shape of the annotation or the annotation set. Such implementations may safely ignore the context
+                declarations and are not required to dereference the respective URLs.
+            </p>
+
+
             <p class="issue">The problem has been raised that implementers/users will forget to add two context declarations.
                 A possibility is to use the <a data-cite="json-ld11#imported-contexts">imported contexts</a> feature of JSON-LD, where the
-                new context file would import the first time.
+                new context file would import the first one. <br>
+                In theory, it is also possible to copy the relevant declarations of the core annotation context into the new one, but that approach may be too brittle (and would also require manual, and error prone, editorial work).
+                <br>
+                Both approaches would, however, simplify the structure of this section, too.
             </p>
         </section>
 

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -120,20 +120,6 @@
 				<tbody>
 					<tr>
 						<td>
-							<code>@context</code>
-						</td>
-						<td>The context that determines the meaning of the JSON as an Annotation.
-							It MUST be <a href="http://www.w3.org/ns/anno.jsonld">
-								http://www.w3.org/ns/anno.jsonld”</a>.
-
-                            <p class="issue">That is probably not true; we define additional classes, eg, Body, that is not defined in that context.</p>
-
-                            </td>
-						<td>string</td>
-						<td>Yes</td>
-					</tr>
-					<tr>
-						<td>
 							<code> id </code>
 						</td>
 						<td>The identity of the annotation. A uuid formatted as a URN is RECOMMENDED.</td>
@@ -221,7 +207,10 @@
             <aside class="example" title="Core structure of an EPUB annotation">
 			<pre>
                 {
-                    "@context": "http://www.w3.org/ns/anno.jsonld",
+                    "@context": [
+                        "http://www.w3.org/ns/anno.jsonld",
+                        "https://wwww.w3.org/ns/epub/anno.jsonld"
+                    ],
                     "id": "urn:uuid:123-123-123-123",
                     "type": "Annotation",
                     "created": "2023-10-14T15:13:28Z",
@@ -331,19 +320,22 @@
 
             <aside class="example" title=" the source of the annotation is the relative URL identifying an HTML document in an EPUB">
 			<pre>
-					{
-					  "@context": "http://www.w3.org/ns/anno.jsonld",
-					  "type": "Annotation",
-					  "target": {
-					    "source": "OEBPS/text/chapter1.html",
-					    "selector": [
-                            …
-					    ],
-					    "meta": {
-                            …
-					    }
-					  }
-					}
+                {
+                    "@context": [
+                        "http://www.w3.org/ns/anno.jsonld",
+                        "https://wwww.w3.org/ns/epub/anno.jsonld"
+                    ],
+                    "type": "Annotation",
+                    "target": {
+                        "source": "OEBPS/text/chapter1.html",
+                        "selector": [
+                        …
+                        ],
+                        "meta": {
+                        …
+                        }
+                    }
+                }
 			</pre>
             </aside>
             </section>
@@ -540,7 +532,10 @@
 			<pre>
 				<code class="lang-json">
 					{
-					  "@context": "http://www.w3.org/ns/anno.jsonld",
+                      "@context": [
+                        "http://www.w3.org/ns/anno.jsonld",
+                        "https://wwww.w3.org/ns/epub/anno.jsonld"
+                      ],
 					  "type": "Annotation",
 					  "target": {
 					    "source": "OEBPS/text/chapter11.html",
@@ -653,19 +648,21 @@
 
             <aside class="example" title="An annotation Body">
 			<pre>
-					{
-					  "@context": "http://www.w3.org/ns/anno.jsonld",
-					  "type": "Annotation",
-					  "body": {
-					    "type": "TextualBody",
-					    "value": "j'adore !",
-					    "keyword": "teacher",
-					    "color": "blue",
-					    "language": "fr",
-					    "textDirection": "ltr"
-					  }
-					}
-			</pre>
+    {
+        "@context": [
+            "http://www.w3.org/ns/anno.jsonld",
+            "https://wwww.w3.org/ns/epub/anno.jsonld"
+        ],
+        "type": "Annotation",
+        "body": {
+            "type": "TextualBody",
+            "value": "j'adore !",
+            "keyword": "teacher",
+            "color": "blue",
+            "language": "fr",
+            "textDirection": "ltr"
+        }
+    }</pre>
             </aside>
             </section>
 		</section>
@@ -694,18 +691,6 @@
 					</tr>
 				</thead>
 				<tbody>
-					<tr>
-						<td>
-							<code> @context </code>
-						</td>
-						<td> The context that determines the meaning of the JSON as an annotation
-							set. It MUST be “ <a href="http://www.w3.org/ns/anno.jsonld”">
-								http://www.w3.org/ns/anno.jsonld” </a> .
-                                <p class="issue">we will have to define our own vocabulary an context files to cover these.</p>
-                        </td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
 					<tr>
 						<td>
 							<code> id </code>
@@ -885,55 +870,95 @@
 
 			<aside class="example" title="An AnnotationSet containing one annotation">
 			<pre>
-					{
-					  "@context": "http://www.w3.org/ns/anno.jsonld",
-					  "id": "urn:uuid:123-123-123-123",
-					  "type": "AnnotationSet",
-					  "generator": "https://github.com/edrlab/thorium-reader/releases/tag/v3.1.0",
-					  "generated": "2023-09-01T10:00:00Z",
-					  "title": "Annotations Mme Prof, La Peste, cours 1ere B",
-					  "about": {
-					     "dc:identifier": [
-					        "urn:isbn:1234567890"
-					     ],
-					     "dc:format": "application/epub+zip",
-					     "dc:title": "Alice in Wonderland",
-					     "dc:publisher": "Example Publisher",
-					     "dc:creator": ["Anne O'Tater"],
-					     "dc:date": "1865"
-					  },
-					  "items": [
-					    {
-					      "@context": "http://www.w3.org/ns/anno.jsonld",
-					      "id": "urn:uuid:234-234-234-234",
-					      "type": "Annotation",
-					      "target": {
-					      },
-					      "body": {
-					      }
-					    }
-					  ]
-					}
-			</pre>
+    {
+        "@context": [
+            "http://www.w3.org/ns/anno.jsonld",
+            "https://wwww.w3.org/ns/epub/anno.jsonld"
+        ],
+        "id": "urn:uuid:123-123-123-123",
+        "type": "AnnotationSet",
+        "generator": "https://github.com/edrlab/thorium-reader/releases/tag/v3.1.0",
+        "generated": "2023-09-01T10:00:00Z",
+        "title": "Annotations Mme Prof, La Peste, cours 1ere B",
+        "about": {
+            "dc:identifier": [
+                "urn:isbn:1234567890"
+            ],
+            "dc:format": "application/epub+zip",
+            "dc:title": "Alice in Wonderland",
+            "dc:publisher": "Example Publisher",
+            "dc:creator": ["Anne O'Tater"],
+            "dc:date": "1865"
+        },
+        "items": [
+            {
+                "id": "urn:uuid:234-234-234-234",
+                "type": "Annotation",
+                "target": {
+                },
+                "body": {
+                }
+            }
+        ]
+    }</pre>
             </aside>
             </section>
-            <section>
+        </section>
+        <section>
 
 			<h3 id="2-3-serialization"> Serialization </h3>
-			<p> The examples throughout the document are serialized as [[JSON-LD11]] using the Context given in Appendix A
-				of the [[[annotation-vocab]]] [[annotation-vocab]], which is the preferred serialization format.
-				The media type of this format is <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>.</p>
+            <p>
+                Following the [[[annotation-model]]] [[annotation-model]] specification, EPUB Annotations are
+                expressed as a "shape" of JSON-LD [[json-ld11]] (a variant of JSON [[ecma-404]] for linked data).
+                The shape is informally defined through a JSON Schema [[json-schema]]; see Appendix XXX for further details.
+                The media type of this format is <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>
+            </p>
 
-            <div class="issue"><p>As noted elsewhere, there is an additional work to be done here: (a) create/define a proper (RDF) vocabulary for all
-                terms, classes, etc, that have been defined in this spec, and an accompanying context file that must be used with the core annotation context.
-                </p>
-                <p>The experience of the VC Working Group will come in handy to make that relatively straightforward.</p>
-            </div>
+            <p class="ednote">I seem to remember that we agreed that, eventually, we would provide a JSON schema for annotations. I think
+                we really should; the text above makes the assumption that this will eventually happen.
+            </p>
 
-			<p> This specification introduces a dedicated file extension for serialized
-				[=AnnotationSets=]: <code> .annotation </code>.</p>
+            <p> This specification introduces a dedicated file extension for serialized
+                [=AnnotationSets=]: <code>.annotation</code>.
+            </p>
+
+            <p>
+                To abide to the requirements of JSON-LD, each annotation file (whether a single annotation or an annotation set) MUST start with a
+                context declarations referring (see also the example below):
+            </p>
+
+            <table class="zebra">
+                <tr>
+                    <th>Context URL</th>
+                    <th>Description</th>
+                </tr>
+                <tr>
+                    <td><code>http://www.w3.org/ns/anno.jsonld</code></td>
+                    <td>Core context file for the [[[annotation-model]]].</td>
+                </tr>
+                <tr>
+                    <td><code>https://wwww.w3.org/ns/epub/anno.jsonld</code></td>
+                    <td>Specific terms for EPUB Annotions extending, an sometimes overriding the terms in the core context file.</td>
+                </tr>
+            </table>
+
+            <aside class="example" title="Context declaration">
+                <pre>
+                    {
+                        "@context": [
+                            "http://www.w3.org/ns/anno.jsonld",
+                            "https://wwww.w3.org/ns/epub/anno.jsonld"
+                        ],
+                        "id": "urn:uuid:123-123-123-123",
+                        …
+                   </pre>
+            </aside>
+
+            <p class="issue">The problem has been raised that implementers/users will forget to add two context declarations.
+                A possibility is to use the <a data-cite="json-ld11#imported-contexts">imported contexts</a> feature of JSON-LD, where the
+                new context file would import the first time.
+            </p>
         </section>
-		</section>
 
 		<section>
 			<h1 id="3-embedding-annotations-in-publications"> Embedding annotations in


### PR DESCRIPTION
The PR

- Puts the serialization into its own section (§7)
- Removes the references to context in the annotation and annotation set definitions
- Presents the context files in the serialization section
- Updates the examples for the context syntaxes