### PR TITLE
Clarify Text-to-Speech and Media Overlays expectations in EPUB 3.4

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -268,7 +268,7 @@
 				<section id="sec-overview-relations-smil">
 					<h4>Relationship to SMIL</h4>
 
-					<p>This specification relies on a subset of [[smil3]], from which the media overlays elements and
+					<p>This specification relies on a restricted subset of [[smil3]], from which the Media Overlays elements and
 						attributes defined in <a href="#sec-overlays-def"></a> are derived.</p>
 				</section>
 
@@ -1166,6 +1166,24 @@
 					<p>The Working Group typically only includes formats as core media type resources when they have
 						broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
 						upon — as at that stage they can be relied on for rendering in reading systems.</p>
+
+					<p><strong>Clarification:</strong>
+					  EPUB publications do not assume the presence of prerecorded narration.
+					  Text-to-Speech rendered by a Reading System and synchronized
+					  narration authored using Media Overlays represent distinct reading
+					  experiences. The availability of one does not imply the availability
+					  or suitability of the other.</p>
+
+					<p>EPUB publications that include Media Overlays do so to express an
+					  <em>authorial intent</em> to enable synchronized narration as part of
+					  the intended reading experience. In many publications, the presence of
+					  Media Overlays reflects a reliance on synchronized audio for the
+					  full-fidelity experience.</p>
+					
+					<p>More generally, the inclusion of a capability in an EPUB publication
+					  does not, by itself, imply that the publication relies on that
+					  capability. Reliance is an authorial decision that cannot be reliably
+					  inferred solely from the presence of resources.</p>
 				</div>
 			</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1736,7 +1736,15 @@
 				the [=EPUB spine | spine=].</p>
 		</section>
 		<section id="sec-media-overlays">
-			<h2>Media overlays processing</h2>
+			<h2>Media Overlays processing</h2>
+
+			<div class="note">
+			  <p>Reading systems may support text-to-speech rendering, Media Overlays
+			    playback, or both. These mechanisms are distinct. The absence of Media
+			    Overlays does not imply that text-to-speech is required, and the
+			    presence of Media Overlays does not imply that fallback rendering
+			    will provide an equivalent reading experience.</p>
+			</div>
 
 			<p id="confreq-rs-epub3-mo" class="support" data-tests="#mol-css">[=Reading systems=] with the capability to
 				render prerecorded audio SHOULD support <a data-cite="epub-34#sec-media-overlays">media overlays</a>


### PR DESCRIPTION
This PR adds non-normative clarifications to both the Authoring and
Reading Systems specifications to reduce longstanding ambiguity around
read-aloud expectations in EPUB publications.

The clarifications distinguish between:
- Text-to-Speech rendered by reading systems, and
- synchronized narration authored using Media Overlays.

On the authoring side, the note clarifies that EPUB publications do not
assume prerecorded narration and that the presence of Media Overlays
reflects authorial intent rather than a general fallback mechanism.

On the reading systems side, the note clarifies that support for
Text-to-Speech and Media Overlays are distinct, and that the presence or
absence of one does not imply equivalent fallback behavior.

These changes are editorial only, introduce no new requirements, and do
not modify conformance criteria.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/simzy39/epub-specs/pull/2866.html" title="Last updated on Dec 23, 2025, 1:10 PM UTC (1e8ddc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2866/6f5cdab...simzy39:1e8ddc6.html" title="Last updated on Dec 23, 2025, 1:10 PM UTC (1e8ddc6)">Diff</a>