### PR TITLE
Clarify distinction between Text-to-Speech and Media Overlays

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1166,6 +1166,24 @@
 					<p>The Working Group typically only includes formats as core media type resources when they have
 						broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
 						upon — as at that stage they can be relied on for rendering in reading systems.</p>
+
+					<p><strong>Clarification:</strong>
+					  EPUB publications do not assume the presence of prerecorded narration.
+					  Text-to-Speech rendered by a Reading System and synchronized
+					  narration authored using Media Overlays represent distinct reading
+					  experiences. The availability of one does not imply the availability
+					  or suitability of the other.</p>
+
+					<p>EPUB publications that include Media Overlays do so to express an
+					  <em>authorial intent</em> to enable synchronized narration as part of
+					  the intended reading experience. In many publications, the presence of
+					  Media Overlays reflects a reliance on synchronized audio for the
+					  full-fidelity experience.</p>
+					
+					<p>More generally, the inclusion of a capability in an EPUB publication
+					  does not, by itself, imply that the publication relies on that
+					  capability. Reliance is an authorial decision that cannot be reliably
+					  inferred solely from the presence of resources.</p>
 				</div>
 			</section>
 


### PR DESCRIPTION
-Editorial clarification only (no new requirements) 
-Reduces confusion between TTS and authored synchronized narration 
-Points readers away from assuming one implies the other


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/simzy39/epub-specs/pull/2867.html" title="Last updated on Dec 23, 2025, 1:43 PM UTC (bc536a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2867/6f5cdab...simzy39:bc536a9.html" title="Last updated on Dec 23, 2025, 1:43 PM UTC (bc536a9)">Diff</a>