### PR TITLE
Clarify TTS vs Media Overlays expectations in reading systems

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1738,6 +1738,14 @@
 		<section id="sec-media-overlays">
 			<h2>Media overlays processing</h2>
 
+			<div class="note">
+			  <p>Reading systems may support text-to-speech rendering, Media Overlays
+			    playback, or both. These mechanisms are distinct. The absence of Media
+			    Overlays does not imply that text-to-speech is required, and the
+			    presence of Media Overlays does not imply that fallback rendering
+			    will provide an equivalent reading experience.</p>
+			</div>
+			
 			<p id="confreq-rs-epub3-mo" class="support" data-tests="#mol-css">[=Reading systems=] with the capability to
 				render prerecorded audio SHOULD support <a data-cite="epub-34#sec-media-overlays">media overlays</a>
 				[[epub-34]].</p>


### PR DESCRIPTION
This PR adds a non-normative note to the Reading Systems specification to clarify expectations around Text-to-Speech and Media Overlays.

The note explains that these mechanisms are distinct, that reading systems may support either or both, and that the presence or absence of one does not imply fallback behavior or equivalent rendering.

This change is editorial only and does not modify conformance requirements.