### PR TITLE
Update 3.3 editor status

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -38,10 +38,10 @@
 					w3cid: 7382,
 					orcid: "0000-0003-0782-2704",
 					companyURL: "https://www.w3.org",
-				},
-				{
+				}],
+				formerEditors: [{
 					name: "Dave Cramer",
-					company: "Invited Expert",
+					company: "W3C Invited Expert",
 					w3cid: 65283
 				}],
                 includePermalinks: true,

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -41,7 +41,7 @@
 				}],
 				formerEditors: [{
 					name: "Dave Cramer",
-					company: "Invited Expert",
+					company: "W3C Invited Expert",
 					w3cid: 65283
 				}],
                 includePermalinks: true,

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -38,7 +38,7 @@
 				}],
 				formerEditors: [{
 					name: "Dave Cramer",
-					company: "Invited Expert",
+					company: "W3C Invited Expert",
 					w3cid: 65283
 				}],
 				includePermalinks: true,


### PR DESCRIPTION
Addresses a complaint from pubrules that Dave is not active in the group for republishing 3.3 by listing him as a former editor. Also fixes the complaint that the label should be "W3C Invited Expert" in both the 3.3 and 3.4 specs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2874.html" title="Last updated on Jan 7, 2026, 1:55 PM UTC (06db4ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2874/758f0e3...06db4ea.html" title="Last updated on Jan 7, 2026, 1:55 PM UTC (06db4ea)">Diff</a>