### PR TITLE
Added dfn-s to terms, and updated the serialization section

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -208,7 +208,7 @@
             <aside class="example" title="Core structure of an EPUB annotation">
 			<pre>
                 {
-                    "@context": "https://www.w3.org/ns/epub_anno.jsonld",
+                    "@context": "https://www.w3.org/ns/epub-anno.jsonld",
                     "id": "urn:uuid:123-123-123-123",
                     "type": "Annotation",
                     "created": "2023-10-14T15:13:28Z",
@@ -318,7 +318,7 @@
             <aside class="example" title=" the source of the annotation is the relative URL identifying an HTML document in an EPUB">
 			<pre>
                 {
-                    "@context": "https://www.w3.org/ns/epub_anno.jsonld",
+                    "@context": "https://www.w3.org/ns/epub-anno.jsonld",
                     "type": "Annotation",
                     "target": {
                         "source": "OEBPS/text/chapter1.html",
@@ -643,7 +643,7 @@
             <aside class="example" title="An annotation Body">
 			<pre>
 					{
-                      "@context": "https://www.w3.org/ns/epub_anno.jsonld",,
+                      "@context": "https://www.w3.org/ns/epub-anno.jsonld",,
 					  "type": "Annotation",
 					  "body": {
 					    "type": "TextualBody",
@@ -865,7 +865,7 @@
 			<aside class="example" title="An AnnotationSet containing one annotation">
 			<pre>
     {
-        "@context": "https://www.w3.org/ns/epub_anno.jsonld",
+        "@context": "https://www.w3.org/ns/epub-anno.jsonld",
         "id": "urn:uuid:123-123-123-123",
         "type": "AnnotationSet",
         "generator": "https://github.com/edrlab/thorium-reader/releases/tag/v3.1.0",
@@ -912,7 +912,7 @@
             <p>
                 Following the requirements of JSON-LD, each annotation file (whether a single annotation or an annotation set) MUST
                 start with a context declaration referring to the following, EPUB Annotation specific context:
-                <code>https://www.w3.org/ns/epub_anno.jsonld</code>.
+                <code>https://www.w3.org/ns/epub-anno.jsonld</code>.
                 This context file imports (using the <a data-cite="json-ld11#imported-contexts">imported contexts</a> feature of JSON-LD)
                 the "core" context file of the [[[annotation-model]]] [[annotation-model]], i.e., <code>https://www.w3.org/ns/anno.jsonld</code>.
                 The EPUB Annotation specific context file contains terms extending, an sometimes overriding the terms
@@ -922,7 +922,7 @@
             <aside class="example" title="Required context declaration">
                 <pre>
                     {
-                        "@context": "https://www.w3.org/ns/epub_anno.jsonld",
+                        "@context": "https://www.w3.org/ns/epub-anno.jsonld",
                         "id": "urn:uuid:123-123-123-123",
                         …
                     }

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -106,7 +106,7 @@
 			<h2 id="1-annotation"> Annotation </h2>
             <section>
 			<h3 id="1-1-annotation-object"> Annotation Object </h3>
-			<p> This <dfn>Annotation object</dfn> retains the following annotation properties from the
+			<p> The <dfn>Annotation object</dfn> retains the following annotation properties from the
                 <a data-cite="annotation-model#annotations">Web Annotation object</a> [[annotation-model]]:
              </p>
 			<table class="zebra">

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -36,6 +36,7 @@
                     profile: "web-platform",
                     specs:[ "epub-34"]
                 },
+                lint: { "no-unused-dfns": false },
                 localBiblio: {
                     "epub-ann-ucr": {
                         "authors": [
@@ -105,8 +106,8 @@
 			<h2 id="1-annotation"> Annotation </h2>
             <section>
 			<h3 id="1-1-annotation-object"> Annotation Object </h3>
-			<p> This document retains the following annotation properties from the
-                <a data-cite="annotation-model#annotations">Annotation object</a> [[annotation-model]]:
+			<p> This <dfn>Annotation object</dfn> retains the following annotation properties from the
+                <a data-cite="annotation-model#annotations">Web Annotation object</a> [[annotation-model]]:
              </p>
 			<table class="zebra">
 				<thead>
@@ -136,7 +137,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> motivation </code>
+							<code> <dfn>motivation</dfn> </code>
 						</td>
 						<td>The motivation for the annotation's creation.</td>
 						<td>"bookmarking" | "commenting" | "highlighting"</td>
@@ -144,7 +145,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> created </code>
+							<code> <dfn>created</dfn> </code>
 						</td>
 						<td>The time when the annotation was created.</td>
 						<td> ISO 8601 datetime </td>
@@ -152,7 +153,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> modified </code>
+							<code> <dfn>modified</dfn> </code>
 						</td>
 						<td>The time the annotation was modified after creation.</td>
 						<td> ISO 8601 datetime </td>
@@ -160,27 +161,27 @@
 					</tr>
 					<tr>
 						<td>
-							<code> creator </code>
+							<code> <dfn>creator</dfn> </code>
 						</td>
 						<td>The creator of the annotation. This may be a human, an
 							organization or a software agent.<br></td>
-						<td> [=Creator=] </td>
+						<td> [=Creator object=] </td>
 						<td> No </td>
 					</tr>
 					<tr>
 						<td>
-							<code> target </code>
+							<code> <dfn>target</dfn> </code>
 						</td>
 						<td>The target content of the annotation.</td>
-						<td> [=Target=] </td>
+						<td> [=Target object=] </td>
 						<td> Yes </td>
 					</tr>
 					<tr>
 						<td>
-							<code> body </code>
+							<code> <dfn>body</dfn> </code>
 						</td>
 						<td>The annotation body.</td>
-						<td> [=Body=] </td>
+						<td> [=Body object=] </td>
 						<td> No </td>
 					</tr>
 				</tbody>
@@ -207,10 +208,7 @@
             <aside class="example" title="Core structure of an EPUB annotation">
 			<pre>
                 {
-                    "@context": [
-                        "http://www.w3.org/ns/anno.jsonld",
-                        "https://wwww.w3.org/ns/epub/anno.jsonld"
-                    ],
+                    "@context": "https://www.w3.org/ns/epub_anno.jsonld",
                     "id": "urn:uuid:123-123-123-123",
                     "type": "Annotation",
                     "created": "2023-10-14T15:13:28Z",
@@ -228,7 +226,7 @@
             </section>
             <section>
 			<h3 id="1-2-creator"> Creator </h3>
-			<p> The <dfn>Creator</dfn> of an annotation is a person, an organization or a software agent. </p>
+			<p> The <dfn>Creator object</dfn> of an annotation is a person, an organization or a software agent. </p>
  			<p> This document defines the following creator properties: </p>
 			<table class="zebra">
 				<thead>
@@ -270,7 +268,7 @@
 
             <section>
 			<h3 id="1-3-target"> Target </h3>
-			<p>The <dfn>Target</dfn> of an annotation associates the annotation with a specific segment of a
+			<p>The <dfn>Target object</dfn> of an annotation associates the annotation with a specific segment of a
 				resource in the current publication.</p>
 			<p> This document defines three target sub-properties: </p>
 			<table class="zebra">
@@ -285,7 +283,7 @@
 				<tbody>
 					<tr>
 						<td>
-							<code> source </code>
+							<code> <dfn>source</dfn> </code>
 						</td>
 						<td> The identity of the target EPUB resource. </td>
 						<td> URI </td>
@@ -293,7 +291,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> selector </code>
+							<code> <dfn>selector</dfn> </code>
 						</td>
 						<td> The segment of the target EPUB resource that is annotated. </td>
 						<td> Array of Selector objects </td>
@@ -301,7 +299,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> meta </code>
+							<code> <dfn>meta</dfn> </code>
 						</td>
 						<td> Indications that help locate the segment in the resource. </td>
 						<td> Meta </td>
@@ -320,10 +318,7 @@
             <aside class="example" title=" the source of the annotation is the relative URL identifying an HTML document in an EPUB">
 			<pre>
                 {
-                    "@context": [
-                        "http://www.w3.org/ns/anno.jsonld",
-                        "https://wwww.w3.org/ns/epub/anno.jsonld"
-                    ],
+                    "@context": "https://www.w3.org/ns/epub_anno.jsonld",
                     "type": "Annotation",
                     "target": {
                         "source": "OEBPS/text/chapter1.html",
@@ -563,7 +558,7 @@
             <section>
 
 			<h3 id="1-4-body"> Body </h3>
-			<p>The <dfn>Body</dfn> of an annotation contains plain text, style, and optional tags.</p>
+			<p>The <dfn>Body object</dfn> of an annotation contains plain text, style, and optional tags.</p>
 			<p>This document specifies the following sub-properties:</p>
 			<table class="zebra">
 				<thead>
@@ -602,7 +597,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> color </code>
+							<code> <dfn>color</dfn> </code>
 						</td>
 						<td> The color of the annotation; yellow by default. </td>
 						<td> "pink" | "orange" | "yellow" | "green" | "blue" | "purple" </td>
@@ -610,7 +605,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> highlight </code>
+							<code> <dfn>highlight</dfn> </code>
 						</td>
 						<td> The style of the annotation; solid background by default. </td>
 						<td> "solid" | "underline" | "strikethrough" | "outline" </td>
@@ -634,7 +629,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code> tags </code>
+							<code> <dfn>tags</dfn> </code>
 						</td>
 						<td> Free text categorizing the annotation. </td>
 						<td> Array of string </td>
@@ -648,7 +643,7 @@
             <aside class="example" title="An annotation Body">
 			<pre>
 					{
-					  "@context": "http://www.w3.org/ns/anno.jsonld",
+                      "@context": "https://www.w3.org/ns/epub_anno.jsonld",,
 					  "type": "Annotation",
 					  "body": {
 					    "type": "TextualBody",
@@ -679,7 +674,7 @@
 				a Zip package. The <code>AnnotationCollection</code> provides a
 				way to retrieve annotations via a REST API and is, therefore, intrinsically paginated.</p>
 
-			<p> The <dfn>AnnotationSet</dfn> object contains: </p>
+			<p> The <dfn>AnnotationSet</dfn> contains: </p>
 			<table class="zebra">
 				<thead>
 					<tr>
@@ -709,7 +704,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code>generator</code>
+							<code><dfn>generator</dfn></code>
 						</td>
 						<td> The agent responsible for the generation of the object serialization. </td>
 						<td> [=Generator=] </td>
@@ -717,7 +712,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code>about</code>
+							<code><dfn>about</dfn></code>
 						</td>
 						<td> Information relative to the publication. </td>
 						<td> [=About=] </td>
@@ -733,7 +728,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code>title</code>
+							<code><dfn>title</dfn></code>
 						</td>
 						<td> A title to help identifying the set. </td>
 						<td> string </td>
@@ -741,7 +736,7 @@
 					</tr>
 					<tr>
 						<td>
-							<code>items</code>
+							<code><dfn>items</dfn></code>
 						</td>
 						<td> The annotations of the set. </td>
 						<td> Array of Annotation objects </td>
@@ -752,7 +747,7 @@
 
             <section>
 			<h3 id="2-1-generator"> Generator </h3>
-			<p>The <dfn>Generator</dfn> object contains information relative to the software from which the
+			<p>The <dfn>Generator object</dfn> contains information relative to the software from which the
 				serialized annotation has been produced.</p>
 			<table class="zebra">
 				<thead>
@@ -802,7 +797,7 @@
             </section>
             <section>
 			<h3 id="2-2-about"> About </h3>
-			<p> The <dfn>About</dfn> object contains information relative to the publication. Such metadata is
+			<p> The <dfn>About object</dfn> contains information relative to the publication. Such metadata is
 				intended to help associate an annotation set with a publication: </p>
 			<table class="zebra">
 				<thead>
@@ -870,10 +865,7 @@
 			<aside class="example" title="An AnnotationSet containing one annotation">
 			<pre>
     {
-        "@context": [
-            "http://www.w3.org/ns/anno.jsonld",
-            "https://wwww.w3.org/ns/epub/anno.jsonld"
-        ],
+        "@context": "https://www.w3.org/ns/epub_anno.jsonld",
         "id": "urn:uuid:123-123-123-123",
         "type": "AnnotationSet",
         "generator": "https://github.com/edrlab/thorium-reader/releases/tag/v3.1.0",
@@ -918,31 +910,19 @@
             </p>
 
             <p>
-                Following the requirements of JSON-LD, each annotation file (whether a single annotation or an annotation set) MUST start with a context declaration referring to the following contexts:
+                Following the requirements of JSON-LD, each annotation file (whether a single annotation or an annotation set) MUST
+                start with a context declaration referring to the following, EPUB Annotation specific context:
+                <code>https://www.w3.org/ns/epub_anno.jsonld</code>.
+                This context file imports (using the <a data-cite="json-ld11#imported-contexts">imported contexts</a> feature of JSON-LD)
+                the "core" context file of the [[[annotation-model]]] [[annotation-model]], i.e., <code>https://www.w3.org/ns/anno.jsonld</code>.
+                The EPUB Annotation specific context file contains terms extending, an sometimes overriding the terms
+                in the core annotation context file, as defined in this specification.
             </p>
-
-            <table class="zebra">
-                <tr>
-                    <th>Context URL</th>
-                    <th>Description</th>
-                </tr>
-                <tr>
-                    <td><code>http://www.w3.org/ns/anno.jsonld</code></td>
-                    <td>Core context file for the [[[annotation-model]]].</td>
-                </tr>
-                <tr>
-                    <td><code>https://wwww.w3.org/ns/epub/anno.jsonld</code></td>
-                    <td>Specific terms for EPUB Annotions extending, an sometimes overriding the terms in the core context file.</td>
-                </tr>
-            </table>
 
             <aside class="example" title="Required context declaration">
                 <pre>
                     {
-                        "@context": [
-                            "http://www.w3.org/ns/anno.jsonld",
-                            "https://wwww.w3.org/ns/epub/anno.jsonld"
-                        ],
+                        "@context": "https://www.w3.org/ns/epub_anno.jsonld",
                         "id": "urn:uuid:123-123-123-123",
                         …
                     }
@@ -954,16 +934,7 @@
                 based on the shape of the annotation or the annotation set. Such implementations may safely ignore the context
                 declarations and are not required to dereference the respective URLs.
             </p>
-
-
-            <p class="issue">The problem has been raised that implementers/users will forget to add two context declarations.
-                A possibility is to use the <a data-cite="json-ld11#imported-contexts">imported contexts</a> feature of JSON-LD, where the
-                new context file would import the first one. <br>
-                In theory, it is also possible to copy the relevant declarations of the core annotation context into the new one, but that approach may be too brittle (and would also require manual, and error prone, editorial work).
-                <br>
-                Both approaches would, however, simplify the structure of this section, too.
-            </p>
-        </section>
+         </section>
 
 		<section>
 			<h1 id="3-embedding-annotations-in-publications"> Embedding annotations in


### PR DESCRIPTION
As the title says: I have made the terms 'officially defined' using the `<dfn>` terms. In doing so, I have changed the object definition to say, e.g., "Body object" to avoid a clash with the (lower case) "body" property.

I have also updated the JSON-LD context usage based on our agreement to import the core annotation context file.

@llemeurfr I hope I did not create problems with your editings, but these cross references are needed for the vocabulary definition.

Fix #2880

