### PR TITLE
Manifest plane typo

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -774,7 +774,7 @@
 				<section id="sec-manifest-plane">
 					<h4>The manifest plane</h4>
 
-					<p>To <dfn class="export" data-lt-no-plural="">manifest plane</dfn> defines all the resources of an
+					<p>The <dfn class="export" data-lt-no-plural="">manifest plane</dfn> defines all the resources of an
 						[=EPUB publication=]. It is analogous to the [=package document=] [=EPUB manifest | manifest=],
 						but includes resources not present in that list.</p>
 


### PR DESCRIPTION
Handling the spelling mistake signalled by @david-russo in #2890.

Note that the issue refers to EPUB 3.3, and this PR is on EPUB 3.4. I do not think it is worth updating 3.3 as well, which will become obsolete in around a year...

Fix #2890


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2891.html" title="Last updated on Jan 18, 2026, 9:13 AM UTC (da2ee41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2891/c65a780...da2ee41.html" title="Last updated on Jan 18, 2026, 9:13 AM UTC (da2ee41)">Diff</a>