### PR TITLE
Updated note on container root and spelling

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1749,9 +1749,6 @@
 							[=package document=] is stored even though this is not a restriction defined in
 							[[epub-rs-34]]. To avoid interoperability issues with these reading systems, it is advised
 							to place all resources at or below the directory containing the package document.</p>
-
-						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
-								>creating multiple renditions</a> [[epub-multi-rend-11]] of the publication.</p>
 					</div>
 				</section>
 

--- a/wg-notes/multi-rend/index.html
+++ b/wg-notes/multi-rend/index.html
@@ -272,7 +272,7 @@
 			</aside>
 
 			<p>Each rendition of the EPUB publication SHOULD only list the [=publication resources=] necessary for its
-				rendering in its package document [=EPUB manifest | manifest=] [[epub-33]]. renditions MAY reference the
+				rendering in its package document [=EPUB manifest | manifest=] [[epub-33]]. Renditions MAY reference the
 				same publication resources.</p>
 
 			<div class="note">
@@ -462,7 +462,7 @@
 			</section>
 
 			<section id="rendition-selection-rs-conformance">
-				<h3>reading system conformance</h3>
+				<h3>Reading system conformance</h3>
 
 				<p>An EPUB reading system SHOULD determine the rendition to present to a user as defined in <a
 						href="#rendition-selection-proc-model"></a>.</p>
@@ -848,7 +848,7 @@
 				<p>This section describes the method by which reading systems locate the optimal [=rendition=] to
 					present to a user.</p>
 
-				<p>rendition selection SHOULD occur on initial rendering, and reading systems SHOULD re-evaluate the
+				<p>Rendition selection SHOULD occur on initial rendering, and reading systems SHOULD re-evaluate the
 					selection in response to changes in the user environment (e.g., change in device orientation or
 					viewport size).</p>
 
@@ -876,7 +876,7 @@
 
 				<div class="note">
 					<p>This processing model does not require that the selection process occur on a user's device, or
-						that all renditions be provided in the container. rendition selection could occur on the server
+						that all renditions be provided in the container. Rendition selection could occur on the server
 						side of a cloud-based delivery system, for example, and only a single best-match rendition sent
 						to the device.</p>
 				</div>
@@ -947,7 +947,7 @@
 			</section>
 
 			<section id="rendition-mapping-rs-conformance">
-				<h3>reading system conformance</h3>
+				<h3>Reading system conformance</h3>
 
 				<p>Reading systems SHOULD support the use of [=rendition mapping documents=] to switch between content. </p>
 


### PR DESCRIPTION
This pull request removes the unnecessary cross-reference to the multiple renditions note from the caution about the location of the package document being treated as the container root, since the multiple renditions document already contains a lengthy note about this issue.

It also fixes some instances of incorrectly lowercased words from the previous changeover from all terminology being treated as proper nouns.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2895.html" title="Last updated on Jan 20, 2026, 3:12 PM UTC (95c52ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2895/c65a780...95c52ae.html" title="Last updated on Jan 20, 2026, 3:12 PM UTC (95c52ae)">Diff</a>