### PR TITLE
Fixes for manifest fallback processing

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -830,14 +830,15 @@
 						the spine without any restrictions. EPUB content documents encompass both [=XHTML content
 						documents=] and [=SVG content documents=].</p>
 
-					<p>To use any other type of resource in the spine, called a [=foreign content document=], requires
-						including a <a href="#sec-manifest-fallbacks">manifest fallback</a> to an EPUB content document.
-						In this model, the [=EPUB manifest | manifest=] entry for the foreign content document has to
-						include a <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to
-						the next possible resource for reading systems to try when they do not support its format.
-						Although not common, a fallback resource can specify another fallback, thereby making chains
-						many resources deep. The one requirement is that there has to be at least one EPUB content
-						document in a [=manifest fallback chain=].</p>
+					<p>The use of any other type of resource in the spine, including [=core media type resources=], is
+						called a [=foreign content document=]. Foreign content documents require a <a
+							href="#sec-manifest-fallbacks">manifest fallback</a> to an EPUB content document. In this
+						model, the [=EPUB manifest | manifest=] entry for the foreign content document has to include a
+							<a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to the next
+						possible resource for reading systems to try when they do not support its format. Although not
+						common, a fallback resource can specify another fallback, thereby making chains many resources
+						deep. The one requirement is that there has to be at least one EPUB content document in a
+						[=manifest fallback chain=].</p>
 
 					<p>Although they are not directly listed in the spine, all of the resources in the fallback chain
 						are considered part of the spine, and by extension part of the spine plane, since any of the
@@ -1330,7 +1331,9 @@
 					<p>There are two cases for manifest fallbacks:</p>
 
 					<dl>
-						<dt id="spine-fallbacks" data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine">Spine fallbacks</dt>
+						<dt id="spine-fallbacks"
+							data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine"
+							>Spine fallbacks</dt>
 						<dd>
 							<p>A [=foreign content document=] MUST specify a fallback chain that MUST include at least
 								one [=EPUB content document=] to ensure that reading systems can always render the
@@ -6118,10 +6121,10 @@ No Entry</pre>
 							<figure id="spread-page-spread-right-figure">
 								<figcaption>Rendering of three fixed-layout documents, with synthetic spread in
 									landscape orientation starting on the right. <br />
-                                    <span class="attribution">(Illustrations from Kate Greenaway's "A Apple Pie", Frederick Warne, 1900;
-                                        <a href="http://hdl.loc.gov/loc.rbc/bit.11404" target="_blank">Digital Reproduction</a> by the
-                                        US Library of Congress, in public domain.)
-                                    </span>
+									<span class="attribution">(Illustrations from Kate Greenaway's "A Apple Pie",
+										Frederick Warne, 1900; <a href="http://hdl.loc.gov/loc.rbc/bit.11404"
+											target="_blank">Digital Reproduction</a> by the US Library of Congress, in
+										public domain.) </span>
 								</figcaption>
 								<img src="images/example_spread_page_spread_right_34.svg" width="600"
 									aria-details="spread-page-spread-right-diagram"
@@ -6132,15 +6135,15 @@ No Entry</pre>
 							<details id="spread-page-spread-right-diagram" class="desc">
 								<summary>Image description</summary>
 								<p>A row of schematic views of three tablets in landscape mode, and linked with
-									left-to-right arrows. They all show 1900 style children book illustrations, each with a single
-                                    text on a background of children engaged in various activities around an apple pie.</p>
-								<p>The first tablet shows a single image on the right side of the tablet, with the text "Apple Pie, by
-                                    Kate Greenway".
-                                    The second tablet shows two images on the left and right parts of the tablet, respectively: the left side
-                                    contains the text "A Apple Pie", the right side contains the text "B Bit It".
-                                    The third tablet shows also two images on the left and right parts of the tablet, respectively:
-                                    the left side contains the text "C Cut It", the right side contains the text "D Dealt It".
-                                </p>
+									left-to-right arrows. They all show 1900 style children book illustrations, each
+									with a single text on a background of children engaged in various activities around
+									an apple pie.</p>
+								<p>The first tablet shows a single image on the right side of the tablet, with the text
+									"Apple Pie, by Kate Greenway". The second tablet shows two images on the left and
+									right parts of the tablet, respectively: the left side contains the text "A Apple
+									Pie", the right side contains the text "B Bit It". The third tablet shows also two
+									images on the left and right parts of the tablet, respectively: the left side
+									contains the text "C Cut It", the right side contains the text "D Dealt It". </p>
 							</details>
 						</aside>
 
@@ -6270,24 +6273,23 @@ No Entry</pre>
 
 						<figure id="layout-roll-figure">
 							<figcaption> Rendering of three fixed-layout documents in a roll<br />
-                                <span class="attribution">(Illustrations from Kate Greenaway's "A Apple Pie", Frederick Warne, 1900;
-                                    <a href="http://hdl.loc.gov/loc.rbc/bit.11404" target="_blank">Digital Reproduction</a> by the
-                                    US Library of Congress, in public domain.)
-                                </span>
+								<span class="attribution">(Illustrations from Kate Greenaway's "A Apple Pie", Frederick
+									Warne, 1900; <a href="http://hdl.loc.gov/loc.rbc/bit.11404" target="_blank">Digital
+										Reproduction</a> by the US Library of Congress, in public domain.) </span>
 							</figcaption>
-							<img src="images/example_rendering_roll_34.svg" width="600" aria-details="layout-roll-diagram"
+							<img src="images/example_rendering_roll_34.svg" width="600"
+								aria-details="layout-roll-diagram"
 								alt="Progression in a roll layout with a continuously scrolled reading experience." />
 						</figure>
 
 						<details id="layout-roll-diagram" class="desc">
 							<summary>Image description</summary>
-                                <p>A schematic view of a tablet in portrait mode, partially overlapping a single
-                                    vertical stripe of four images. Part of the stripe is shown outside of the table's screen.
-                                    All images are 1900 style children book illustrations, each with a single
-                                    text with a background showing children engaging in various activities around an apple pie.
-                                    From top-to-bottom the text on the images say "A Apple Pie", "B Bit It", "C Cut It", and
-                                    "D Dealt It".
-                                </p>
+							<p>A schematic view of a tablet in portrait mode, partially overlapping a single vertical
+								stripe of four images. Part of the stripe is shown outside of the table's screen. All
+								images are 1900 style children book illustrations, each with a single text with a
+								background showing children engaging in various activities around an apple pie. From
+								top-to-bottom the text on the images say "A Apple Pie", "B Bit It", "C Cut It", and "D
+								Dealt It". </p>
 						</details>
 					</aside>
 				</section>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -328,9 +328,48 @@
 
 				<p id="confreq-rs-foreign"
 					data-tests="#pub-foreign_image,#pub-foreign_xml-spine,#pub-foreign_xml-suffix-spine,#pub-foreign_bad-fallback,#pub-foreign_json-spine"
-					>Reading systems MAY support an arbitrary set of [=foreign resource=] types, and if a foreign
-					resource is not supported, MUST process fallbacks as defined in <a href="#sec-pkg-doc-manifest"
-					></a>.</p>
+					>Reading systems MAY support an arbitrary set of [=foreign resource=] types.</p>
+			</section>
+
+			<section id="sec-epub-rs-resource-fallbacks">
+				<h4>Resource fallbacks</h4>
+
+				<p>For [=foreign resources=], if a reading system does not support a resource's MIME media type
+					[[rfc2046]]:</p>
+
+				<ul>
+					<li>it MUST give precedence to any fallbacks provided via <a
+							data-cite="epub-34#sec-intrinsic-fallbacks">intrinsic fallback methods</a> [[epub-34]] of
+						the element the resource is referenced from;</li>
+					<li>otherwise, it SHOULD traverse the resource's <a data-cite="epub-34#sec-manifest-fallbacks"
+							>manifest fallback chain</a> [[epub-34]], when one is specified, until it identifies a
+						supported publication resource to use in place of the unsupported resource.</li>
+				</ul>
+
+				<p>When manifest fallbacks are provided for [=core media type resources=], a reading system MAY traverse
+					the fallback chain to determine if a more optimal format is available for rendering.</p>
+
+				<p>For [=foreign content documents=], if a reading system does not support the resource's MIME media
+					type, it MUST traverse the resource's <a data-cite="epub-34#sec-manifest-fallbacks">manifest
+						fallback chain</a> [[epub-34]] until it identifies a supported publication resource to use in
+					place of the unsupported resource.</p>
+
+				<p>When <a data-cite="epub-34#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-34]] are provided
+					for [=epub content documents=], reading systems MAY choose from the available options to find the
+					optimal version to render in a given context (e.g., by inspecting the properties attribute for
+					each).</p>
+
+				<p id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple publication
+					resources in the fallback chain, it MAY select the resource to use based on the resource's <a
+						data-cite="epub-34#attrdef-item-properties"><code>properties</code> attribute</a> [[epub-34]]
+					values, otherwise it SHOULD honor the <a data-cite="epub-34#preferred-fallback-chain">preferred
+						fallback order</a> [[epub-34]].</p>
+
+				<p id="confreq-rs-pkg-manifest-fallback-fail">If a reading system does not support any resource in the
+					fallback chain, it MUST alert the user that it could not display the content. </p>
+
+				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at the
+					first reference to a manifest item it has already encountered.</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-remote-res">
@@ -905,31 +944,6 @@
 					SHOULD NOT use [=linked resources=] in the rendering of an [=EPUB publication=] due to the inherent
 					limitations and risks involved (e.g., lack of information about the resource and how to process it,
 					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
-
-				<p>
-					<span id="confreq-rs-pkg-manifest-fallback"
-						data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine"
-						>A reading system that does not support the MIME media type [[rfc2046]] of a given [=publication
-						resource=] MUST traverse the <a data-cite="epub-34#sec-manifest-fallbacks">manifest fallback
-							chain</a> [[epub-34]] until it identifies a supported publication resource to use in place
-						of the unsupported resource. </span>
-					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple
-						publication resources in the fallback chain, it MAY select the resource to use based on the
-						resource's <a data-cite="epub-34#attrdef-item-properties"><code>properties</code> attribute</a>
-						[[epub-34]] values, otherwise it SHOULD honor the <a
-							data-cite="epub-34#preferred-fallback-chain">preferred fallback order</a>
-						[[epub-34]].</span>
-					<span id="confreq-rs-pkg-manifest-fallback-fail">If a reading system does not support any resource
-						in the fallback chain, it MUST alert the user that it could not display the content. </span>
-				</p>
-
-				<p>When <a data-cite="epub-34#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-34]] are provided
-					for [=top-level content documents=], reading systems MAY choose from the available options to find
-					the optimal version to render in a given context (e.g., by inspecting the properties attribute for
-					each).</p>
-
-				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at the
-					first reference to a manifest item it has already encountered.</p>
 			</section>
 
 			<section id="sec-pkg-doc-spine">
@@ -945,9 +959,10 @@
 					<li>rendering successive primary items in the order given in the <code>spine</code>.</li>
 				</ul>
 
-				<p>If a reading system does not support the resource type referenced from an <code>itemref</code>
-					element, it MUST traverse the resource's manifest fallback chain to locate one it can use, as
-					defined in <a href="#sec-pkg-doc-manifest"></a>.</p>
+				<div class="note">
+					<p>Refer to <a href="#sec-epub-rs-resource-fallbacks"></a> for more information on handling manifest
+						fallbacks.</p>
+				</div>
 
 				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
 					the <code>spine</code> element, a reading system MAY automatically skip <a

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -349,7 +349,7 @@
 				<p>When manifest fallbacks are provided for [=core media type resources=], a reading system MAY traverse
 					the fallback chain to determine if a more optimal format is available for rendering.</p>
 
-				<p>For [=foreign content documents=], if a reading system does not support the resource's MIME media
+				<p  id="confreq-rendition-rs-spine-fallback" data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine">For [=foreign content documents=], if a reading system does not support the resource's MIME media
 					type, it MUST traverse the resource's <a data-cite="epub-34#sec-manifest-fallbacks">manifest
 						fallback chain</a> [[epub-34]] until it identifies a supported publication resource to use in
 					place of the unsupported resource.</p>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -946,6 +946,10 @@
 					<li>rendering successive primary items in the order given in the <code>spine</code>.</li>
 				</ul>
 
+				<p>If a reading system does not support the resource type referenced from an <code>itemref</code>
+					element, it MUST traverse its manifest fallback chain to locate one it can use, as defined in <a
+						href="#sec-pkg-doc-manifest"></a>.</p>
+
 				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
 					the <code>spine</code> element, a reading system MAY automatically skip <a
 						data-cite="epub-34#attrdef-itemref-linear">non-linear <code>itemref</code> elements</a>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -329,8 +329,8 @@
 				<p id="confreq-rs-foreign"
 					data-tests="#pub-foreign_image,#pub-foreign_xml-spine,#pub-foreign_xml-suffix-spine,#pub-foreign_bad-fallback,#pub-foreign_json-spine"
 					>Reading systems MAY support an arbitrary set of [=foreign resource=] types, and if a foreign
-					resource is not supported, MUST process fallbacks as defined in <a
-						data-cite="epub-34#sec-foreign-resources">foreign resources</a> [[epub-34]].</p>
+					resource is not supported, MUST process fallbacks as defined in <a href="#sec-pkg-doc-manifest"
+					></a>.</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-remote-res">
@@ -907,10 +907,13 @@
 					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
 				<p>
-					<span id="confreq-rs-pkg-manifest-fallback" data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine">A reading system that does not support the MIME media
-						type [[rfc2046]] of a given [=publication resource=] MUST traverse the <a
-							data-cite="epub-34#sec-manifest-fallbacks">manifest fallback chain</a> [[epub-34]] until it
-						identifies a supported publication resource to use in place of the unsupported resource. </span>
+					<span id="confreq-rs-pkg-manifest-fallback"
+						data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine"
+						>A reading system that does not support the MIME media type [[rfc2046]] of a [=publication
+						resource=] in its given <a data-cite="epub-34#sec-manifest-fallbacks">usage context</a>
+						[[epub-34]] MUST traverse the <a data-cite="epub-34#sec-manifest-fallbacks">manifest fallback
+							chain</a> [[epub-34]] until it identifies a supported publication resource to use in place
+						of the unsupported resource. </span>
 					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple
 						publication resources in the fallback chain, it MAY select the resource to use based on the
 						resource's <a data-cite="epub-34#attrdef-item-properties"><code>properties</code> attribute</a>
@@ -1338,11 +1341,13 @@
 			<section id="sec-fxl">
 				<h3>Fixed-layout documents</h3>
 
-				<p id="confreq-rs-epub3-fxl" data-tests="#lay-pp-spread-none,#lay-pp-embedded-images,#lay-pp-images-in-spine,#lay-pp-images-mixed,#lay-roll-embedded-images,#lay-roll-images-in-spine,#lay-roll-images-mixed" class="support">[=Reading systems=] MUST
-					support the rendering of EPUB content documents in [=spine=] items whose layout is designated as <a
-						href="#sec-pre-paginated-layouts"><code>pre-paginated</code></a> or <a href="#sec-roll-layouts"
-							><code>roll</code></a>. They MAY support the rendering of image [=foreign resources=] in
-					spine items whose layout is designated as <code>pre-paginated</code> or <code>roll</code>.</p>
+				<p id="confreq-rs-epub3-fxl"
+					data-tests="#lay-pp-spread-none,#lay-pp-embedded-images,#lay-pp-images-in-spine,#lay-pp-images-mixed,#lay-roll-embedded-images,#lay-roll-images-in-spine,#lay-roll-images-mixed"
+					class="support">[=Reading systems=] MUST support the rendering of EPUB content documents in
+					[=spine=] items whose layout is designated as <a href="#sec-pre-paginated-layouts"
+							><code>pre-paginated</code></a> or <a href="#sec-roll-layouts"><code>roll</code></a>. They
+					MAY support the rendering of image [=foreign resources=] in spine items whose layout is designated
+					as <code>pre-paginated</code> or <code>roll</code>.</p>
 
 				<div class="note">
 					<p>This requirement does not require reading systems to support roll layouts. Only if the layout is
@@ -2632,6 +2637,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
+					<li>21-Jan-2026: Clarified that the need to process fallbacks is dependent on the context in which a
+						media type is used. See <a href="https://github.com/w3c/epub-specs/issues/2893">issue
+						2893</a>.</li>
 					<li>18-Dec-2025: Removed references to reflowable documents being allowed in spreads and clarified
 						that spread placement properties only apply to pre-paginated documents. See <a
 							href="https://github.com/w3c/epub-specs/pull/2844#issuecomment-3632673767">pull request

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -909,9 +909,8 @@
 				<p>
 					<span id="confreq-rs-pkg-manifest-fallback"
 						data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine"
-						>A reading system that does not support the MIME media type [[rfc2046]] of a [=publication
-						resource=] in its given <a data-cite="epub-34#sec-manifest-fallbacks">usage context</a>
-						[[epub-34]] MUST traverse the <a data-cite="epub-34#sec-manifest-fallbacks">manifest fallback
+						>A reading system that does not support the MIME media type [[rfc2046]] of a given [=publication
+						resource=] MUST traverse the <a data-cite="epub-34#sec-manifest-fallbacks">manifest fallback
 							chain</a> [[epub-34]] until it identifies a supported publication resource to use in place
 						of the unsupported resource. </span>
 					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -947,8 +947,8 @@
 				</ul>
 
 				<p>If a reading system does not support the resource type referenced from an <code>itemref</code>
-					element, it MUST traverse its manifest fallback chain to locate one it can use, as defined in <a
-						href="#sec-pkg-doc-manifest"></a>.</p>
+					element, it MUST traverse the resource's manifest fallback chain to locate one it can use, as
+					defined in <a href="#sec-pkg-doc-manifest"></a>.</p>
 
 				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
 					the <code>spine</code> element, a reading system MAY automatically skip <a


### PR DESCRIPTION
Makes the following changes discussed in #2893 to the reading systems spec:

- redirects the manifest fallback processing requirement under the foreign resources section to where fallback processing is defined in the reading system spec rather than to the authoring requirements
- clarifies that the usage context affects support for media types

Also clarifies that core media type resources are foreign content documents in the spine plane section of the authoring spec.

Fixes #2893 

***

Reading Systems: [Preview](https://raw.githack.com/w3c/epub-specs/fix/fallback-support/epub34/rs/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/fallback-support/epub34/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2897.html" title="Last updated on Jan 23, 2026, 1:46 PM UTC (4233aa0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2897/d40315d...4233aa0.html" title="Last updated on Jan 23, 2026, 1:46 PM UTC (4233aa0)">Diff</a>