### PR TITLE
Adding JPEG XL format

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -958,7 +958,7 @@
 							<th id="tbl-cmt-string">Media Type</th>
 							<th id="tbl-cmt-def">Content Type Definition</th>
 							<th id="tbl-cmt-appl">Applies to</th>
-                            <th id="tbl-cmt-epub-version">EPUB3</th>
+                            <th id="tbl-cmt-epub-version">EPUB</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1137,7 +1137,7 @@
 							</td>
 							<td> [[woff2]] </td>
 							<td>WOFF2 fonts</td>
-                            <td>3.3</td>
+                            <td>3.2</td>
 						</tr>
 						<tr>
 							<th colspan="4" id="cmt-grp-other" class="tbl-group">Other</th>
@@ -1195,7 +1195,7 @@
                         The Working Group typically only includes formats as core media type resources when they have
 						broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
 						upon — as at that stage they can be relied on for rendering in up-to-date reading systems.
-                        Nevertheless, authors must be aware that newer formats may not be supported on reading systems
+                        Nevertheless, authors must be aware that newer formats &#8212; introduced after EPUB 3.0 &#8212; may not be supported on reading systems
                         that, for example, rely on their own rendering engines, or have not been updated recently.
                     </p>
 				</div>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -998,6 +998,13 @@
 							<td> [[jpeg]] </td>
 							<td>JPEG images</td>
 						</tr>
+                        <tr>
+                            <td id="cmt-jxl" data-tests="#pub-cmt-jxl">
+                                <code>image/jxl</code>
+                            </td>
+                            <td> [[iso18181-1]] </td>
+                            <td>JPEG XL images</td>
+                        </tr>
 						<tr>
 							<td id="cmt-png" data-tests="#pub-cmt-png">
 								<code>image/png</code>
@@ -11110,6 +11117,8 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+                    <li>23-January-2026: Added JPEG XL as a core media type for images. See <a
+                            href="https://github.com/w3c/epub-specs/issues/2896">issue 2896</a>.</li>
 					<li>18-Dec-2025: Renamed "obsolete but conforming features" to "outdated features". As discussed in
 						the <a href="https://w3c.github.io/pm-wg/minutes/2025-12-11.html#59bf">2025-12-11 WG
 						meeting</a>.</li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -958,7 +958,7 @@
 							<th id="tbl-cmt-string">Media Type</th>
 							<th id="tbl-cmt-def">Content Type Definition</th>
 							<th id="tbl-cmt-appl">Applies to</th>
-                            <th id="tbl-cmt-epub-version">Introduced in<br/> EPUB3 version</th>
+                            <th id="tbl-cmt-epub-version">EPUB3</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -974,7 +974,7 @@
 							</td>
 							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
 								[[html]]</td>
-                            <td>3.0</td>
+                            <td>pre&#8209;3.0</td>
 						</tr>
 						<tr>
 							<th colspan="4" id="cmt-grp-image" class="tbl-group">Images</th>
@@ -985,7 +985,7 @@
 							</td>
 							<td> [[gif]] </td>
 							<td>GIF images</td>
-                            <td>3.0</td>
+                            <td>pre&#8209;3.0</td>
 						</tr>
                         <tr>
                             <td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
@@ -993,7 +993,7 @@
                             </td>
                             <td> [[jpeg]] </td>
                             <td>JPEG images</td>
-                            <td>3.0</td>
+                            <td>pre&#8209;3.0</td>
                         </tr>
  						<tr>
 							<td id="cmt-png" data-tests="#pub-cmt-png">
@@ -1001,7 +1001,7 @@
 							</td>
 							<td> [[png]] </td>
 							<td>PNG images</td>
-                            <td>3.0</td>
+                            <td>pre&#8209;3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-svg" data-tests="#pub-cmt-svg,#cnt-svg-support">
@@ -1011,7 +1011,7 @@
 								<a href="#sec-svg">SVG content documents</a>
 							</td>
 							<td>SVG documents</td>
-                            <td>3.0</td>
+                            <td>pre&#8209;3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-webp" data-tests="#pub-cmt-webp">
@@ -1075,7 +1075,7 @@
 								<a href="#sec-css">CSS Style Sheets</a>
 							</td>
 							<td>CSS Style Sheets</td>
-                            <td>3.0</td>
+                            <td>pre&#8209;3.0</td>
 						</tr>
 						<tr>
 							<th colspan="4" id="cmt-grp-font" class="tbl-group">Fonts</th>
@@ -1166,7 +1166,7 @@
 							</td>
 							<td> [[opf-201]] </td>
 							<td>The [=outdated=] NCX</td>
-                            <td>3.0</td>
+                            <td>pre&#8209;3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-smil">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -950,6 +950,7 @@
 						resource has to conform.</li>
 					<li><strong>Applies to</strong>—The publication resource type(s) that the Media Type and Content
 						Type Definition applies to.</li>
+                    <li><strong>In EPUB 3 since</strong>—The version of EPUB 3 which has adopted that Media Type. Note that some formats have a longer history (going back to EPUB 2), not detailed in the table.</li>
 				</ul>
 
 				<table id="tbl-core-media-types">
@@ -958,7 +959,7 @@
 							<th id="tbl-cmt-string">Media Type</th>
 							<th id="tbl-cmt-def">Content Type Definition</th>
 							<th id="tbl-cmt-appl">Applies to</th>
-                            <th id="tbl-cmt-epub-version">EPUB</th>
+                            <th id="tbl-cmt-epub-version">In EPUB 3 since</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -974,7 +975,8 @@
 							</td>
 							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
 								[[html]]</td>
-                            <td>pre&#8209;3.0</td>
+                            <td>3.0</td>
+                            <!-- <td>pre&#8209;3.0</td> -->
 						</tr>
 						<tr>
 							<th colspan="4" id="cmt-grp-image" class="tbl-group">Images</th>
@@ -985,7 +987,7 @@
 							</td>
 							<td> [[gif]] </td>
 							<td>GIF images</td>
-                            <td>pre&#8209;3.0</td>
+                            <td>3.0</td>
 						</tr>
                         <tr>
                             <td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
@@ -993,7 +995,7 @@
                             </td>
                             <td> [[jpeg]] </td>
                             <td>JPEG images</td>
-                            <td>pre&#8209;3.0</td>
+                            <td>3.0</td>
                         </tr>
  						<tr>
 							<td id="cmt-png" data-tests="#pub-cmt-png">
@@ -1001,7 +1003,7 @@
 							</td>
 							<td> [[png]] </td>
 							<td>PNG images</td>
-                            <td>pre&#8209;3.0</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-svg" data-tests="#pub-cmt-svg,#cnt-svg-support">
@@ -1011,7 +1013,7 @@
 								<a href="#sec-svg">SVG content documents</a>
 							</td>
 							<td>SVG documents</td>
-                            <td>pre&#8209;3.0</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-webp" data-tests="#pub-cmt-webp">
@@ -1075,7 +1077,7 @@
 								<a href="#sec-css">CSS Style Sheets</a>
 							</td>
 							<td>CSS Style Sheets</td>
-                            <td>pre&#8209;3.0</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<th colspan="4" id="cmt-grp-font" class="tbl-group">Fonts</th>
@@ -1166,7 +1168,7 @@
 							</td>
 							<td> [[opf-201]] </td>
 							<td>The [=outdated=] NCX</td>
-                            <td>pre&#8209;3.0</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-smil">
@@ -1195,8 +1197,9 @@
                         The Working Group typically only includes formats as core media type resources when they have
 						broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
 						upon — as at that stage they can be relied on for rendering in up-to-date reading systems.
-                        Nevertheless, authors must be aware that newer formats &#8212; introduced after EPUB 3.0 &#8212; may not be supported on reading systems
-                        that, for example, rely on their own rendering engines, or have not been updated recently.
+                        Nevertheless, authors must be aware that newer formats &#8212; introduced after EPUB 3.0,
+                        see the last column of the table &#8212; may not be supported on reading systems that,
+                        for example, rely on their own rendering engines, or have not been updated recently.
                     </p>
 				</div>
 			</section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1065,7 +1065,7 @@
                             <td>3.0</td>
 						</tr>
 						<tr>
-							<th colspan="34 id="cmt-grp-text" class="tbl-group">Style</th>
+							<th colspan="4" id="cmt-grp-text" class="tbl-group">Style</th>
 						</tr>
 						<tr>
 							<td id="cmt-css">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -958,11 +958,12 @@
 							<th id="tbl-cmt-string">Media Type</th>
 							<th id="tbl-cmt-def">Content Type Definition</th>
 							<th id="tbl-cmt-appl">Applies to</th>
+                            <th id="tbl-cmt-epub-version">Introduced in<br/> EPUB3 version</th>
 						</tr>
 					</thead>
 					<tbody>
 						<tr>
-							<th colspan="3" id="cmt-grp-html" class="tbl-group">HTML</th>
+							<th colspan="4" id="cmt-grp-html" class="tbl-group">HTML</th>
 						</tr>
 						<tr>
 							<td id="cmt-xhtml">
@@ -973,16 +974,10 @@
 							</td>
 							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
 								[[html]]</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
-							<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
-						</tr>
-						<tr>
-							<td id="cmt-avif" data-tests="#pub-cmt-avif">
-								<code>image/avif</code>
-							</td>
-							<td> [[av1-avif]] </td>
-							<td>AVIF images</td>
+							<th colspan="4" id="cmt-grp-image" class="tbl-group">Images</th>
 						</tr>
 						<tr>
 							<td id="cmt-gif" data-tests="#pub-cmt-gif">
@@ -990,27 +985,23 @@
 							</td>
 							<td> [[gif]] </td>
 							<td>GIF images</td>
-						</tr>
-						<tr>
-							<td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
-								<code>image/jpeg</code>
-							</td>
-							<td> [[jpeg]] </td>
-							<td>JPEG images</td>
+                            <td>3.0</td>
 						</tr>
                         <tr>
-                            <td id="cmt-jxl" data-tests="#pub-cmt-jxl">
-                                <code>image/jxl</code>
+                            <td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
+                                <code>image/jpeg</code>
                             </td>
-                            <td> [[iso18181-1]] </td>
-                            <td>JPEG XL images</td>
+                            <td> [[jpeg]] </td>
+                            <td>JPEG images</td>
+                            <td>3.0</td>
                         </tr>
-						<tr>
+ 						<tr>
 							<td id="cmt-png" data-tests="#pub-cmt-png">
 								<code>image/png</code>
 							</td>
 							<td> [[png]] </td>
 							<td>PNG images</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-svg" data-tests="#pub-cmt-svg,#cnt-svg-support">
@@ -1020,6 +1011,7 @@
 								<a href="#sec-svg">SVG content documents</a>
 							</td>
 							<td>SVG documents</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-webp" data-tests="#pub-cmt-webp">
@@ -1027,9 +1019,26 @@
 							</td>
 							<td> [[rfc9649]] </td>
 							<td>WebP images</td>
+                            <td>3.3</td>
 						</tr>
+                        <tr>
+                            <td id="cmt-avif" data-tests="#pub-cmt-avif">
+                                <code>image/avif</code>
+                            </td>
+                            <td> [[av1-avif]] </td>
+                            <td>AVIF images</td>
+                            <td>3.4</td>
+                        </tr>
+                        <tr>
+                            <td id="cmt-jxl" data-tests="#pub-cmt-jxl">
+                                <code>image/jxl</code>
+                            </td>
+                            <td> [[iso18181-1]] </td>
+                            <td>JPEG XL images</td>
+                            <td>3.4</td>
+                        </tr>
 						<tr>
-							<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
+							<th colspan="4" id="cmt-grp-audio" class="tbl-group">Audio</th>
 						</tr>
 						<tr>
 							<td id="cmt-mp3" data-tests="#pub-cmt-mp3">
@@ -1037,6 +1046,7 @@
 							</td>
 							<td> [[mp3]] </td>
 							<td>MP3 audio</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-mp4-aac" data-tests="#pub-cmt-mp4">
@@ -1044,6 +1054,7 @@
 							</td>
 							<td> [[mpeg4-audio]], [[mp4]] </td>
 							<td>AAC LC audio using MP4 container</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-ogg-opus" data-tests="#pub-cmt-opus">
@@ -1051,9 +1062,10 @@
 							</td>
 							<td> [[rfc7845]] </td>
 							<td>OPUS audio using OGG container</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
-							<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
+							<th colspan="34 id="cmt-grp-text" class="tbl-group">Style</th>
 						</tr>
 						<tr>
 							<td id="cmt-css">
@@ -1063,9 +1075,10 @@
 								<a href="#sec-css">CSS Style Sheets</a>
 							</td>
 							<td>CSS Style Sheets</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
-							<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
+							<th colspan="4" id="cmt-grp-font" class="tbl-group">Fonts</th>
 						</tr>
 						<tr>
 							<td id="cmt-sfnt">
@@ -1083,6 +1096,7 @@
 							</td>
 							<td>[[truetype]] </td>
 							<td>TrueType fonts</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-otf">
@@ -1100,6 +1114,7 @@
 							</td>
 							<td>[[opentype]]</td>
 							<td>OpenType fonts</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-woff">
@@ -1114,6 +1129,7 @@
 							</td>
 							<td> [[woff]] </td>
 							<td>WOFF fonts</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-woff2">
@@ -1121,9 +1137,10 @@
 							</td>
 							<td> [[woff2]] </td>
 							<td>WOFF2 fonts</td>
+                            <td>3.3</td>
 						</tr>
 						<tr>
-							<th colspan="3" id="cmt-grp-other" class="tbl-group">Other</th>
+							<th colspan="4" id="cmt-grp-other" class="tbl-group">Other</th>
 						</tr>
 						<tr>
 							<td id="cmt-js">
@@ -1141,6 +1158,7 @@
 							</td>
 							<td> [[rfc4329]] </td>
 							<td>Scripts.</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-ncx">
@@ -1148,6 +1166,7 @@
 							</td>
 							<td> [[opf-201]] </td>
 							<td>The [=outdated=] NCX</td>
+                            <td>3.0</td>
 						</tr>
 						<tr>
 							<td id="cmt-smil">
@@ -1157,6 +1176,7 @@
 								<a href="#sec-media-overlays">Media overlays</a>
 							</td>
 							<td>EPUB media overlay documents</td>
+                            <td>3.0</td>
 						</tr>
 					</tbody>
 				</table>
@@ -1169,10 +1189,15 @@
 							data-cite="epub-rs-34#sec-epub-rs-conf-cmt">Core media types</a> [[epub-rs-34]] for more
 						information about which reading systems rendering capabilities require support for which core
 						media type resources.</p>
-
-					<p>The Working Group typically only includes formats as core media type resources when they have
+                </div>
+                <div class="caution">
+					<p>
+                        The Working Group typically only includes formats as core media type resources when they have
 						broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
-						upon — as at that stage they can be relied on for rendering in reading systems.</p>
+						upon — as at that stage they can be relied on for rendering in up-to-date reading systems.
+                        Nevertheless, authors must be aware that newer formats may not be supported on reading systems
+                        that, for example, rely on their own rendering engines, or have not been updated recently.
+                    </p>
 				</div>
 			</section>
 

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -308,7 +308,7 @@
 				<h4>Core Media types</h4>
 
 				<p id="confreq-rs-epub3-images"
-					data-tests="#pub-cmt-avif,#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a
+					data-tests="#pub-cmt-avif,#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-jxl,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a
 					reading system has a [=viewport=], it MUST support the <a data-cite="epub-34#cmt-grp-image">image
 						core media type resources</a> [[epub-34]].</p>
 


### PR DESCRIPTION
The PR is a _draft_ in trying to resolve #2896, but also considering the issues raised on the [WG discussion](https://w3c.github.io/pm-wg/minutes/2026-01-22.html#526b). It contain the following:

- introducing JXL into the cmt table
- adding an extra column to the table, indicating the EPUB3 version when that particular type has been introduced (mostly 3.0, a few 3.3 and 3.4)
- there was already a note right after the table; it has been separated into a note and an extra caution box. To make the discussion on the draft easier, here is what the caution box says in the PR:

>  The Working Group typically only includes formats as core media type resources when they have
> broad support in web browser cores — the rendering engines that EPUB 3 reading systems build
> upon — as at that stage they can be relied on for rendering in up-to-date reading systems.
>  Nevertheless, authors must be aware that newer formats may not be supported on reading systems
>  that, for example, rely on their own rendering engines, or have not been updated recently.

The PR, eventually, aims at a fix of #2896.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2899.html" title="Last updated on Jan 28, 2026, 11:06 AM UTC (bfea447)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2899/50dc472...bfea447.html" title="Last updated on Jan 28, 2026, 11:06 AM UTC (bfea447)">Diff</a>