### PR TITLE
Move content fallbacks to outdated features

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1402,26 +1402,23 @@
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L280,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L285,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L290,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L296,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L302,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L308,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L313">
 						<h5>HTML <code>img</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that can be referenced
-							from the [[html]] [^img^] element, the following fallback conditions apply to its use:</p>
-						<ul>
-							<li>
-								<p>If it is the child of a [^picture^] element:</p>
-								<ul>
-									<li>it MUST reference core media type resources from its <code>src</code> and
-											<code>srcset</code> attributes when those attributes are set; and</li>
-									<li>each sibling [^source^] element MUST reference a [=core media type resource=]
-										from its <code>[^source/src^]</code> and <code>[^source/srcset^]</code>
-										attributes unless it specifies the MIME media type [[rfc2046]] of a [=foreign
-										resource=] in its <code>[^source/type^]</code> attribute.</li>
-								</ul>
-							</li>
+						<p id="confreq-resources-cd-fallback-img">To provide alternative format fallbacks, the [[html]]
+							[^img^] element can be used as the child of a [^picture^] element provided the following are
+							true:</p>
 
-							<li>
-								<p>Otherwise, its <code>[^img/srcset^]</code> attribute MUST NOT be used to provide
-									fallbacks to a core media type.</p>
-							</li>
+						<ul>
+							<li>the <code>img</code> element MUST only reference core media type resources from its
+									<code>src</code> and <code>srcset</code> attributes when those attributes are set;
+								and</li>
+							<li>each [^source^] element MUST only reference [=core media type resources=] from its
+									<code>[^source/src^]</code> and <code>[^source/srcset^]</code> attributes unless it
+								specifies the MIME media type [[rfc2046]] of a [=foreign resource=] in its
+									<code>[^source/type^]</code> attribute.</li>
 						</ul>
+
+						<p>When an <code>img</code> is not the child of <code>picture</code>, its <code>src</code> and
+								<code>srcset</code> attributes MUST NOT be used to provide fallbacks for foreign
+							resources.</p>
 					</section>
 
 					<section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1402,27 +1402,23 @@
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L280,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L285,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L290,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L296,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L302,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L308,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L313">
 						<h5>HTML <code>img</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that can be referenced
-							from the [[html]] [^img^] element, the following fallback conditions apply to its use:</p>
-						<ul>
-							<li>
-								<p>If it is the child of a [^picture^] element:</p>
-								<ul>
-									<li>it MUST reference core media type resources from its <code>src</code> and
-											<code>srcset</code> attributes when those attributes are set; and</li>
-									<li>each sibling [^source^] element MUST reference a [=core media type resource=]
-										from its <code>[^source/src^]</code> and <code>[^source/srcset^]</code>
-										attributes unless it specifies the MIME media type [[rfc2046]] of a [=foreign
-										resource=] in its <code>[^source/type^]</code> attribute.</li>
-								</ul>
-							</li>
+						<p id="confreq-resources-cd-fallback-img">If the [[html]] [^img^] element is the child of a
+							[^picture^] element, the following fallback conditions apply to its use:</p>
 
-							<li>
-								<p>Otherwise, it MAY reference foreign resources in its <code>[^img/srcset^]</code>
-									attribute provided there is also a reference to at least one core media type
-									resource.</p>
-							</li>
+						<ul>
+							<li>it MUST reference core media type resources from its <code>src</code> and
+									<code>srcset</code> attributes when those attributes are set; and</li>
+							<li>each sibling [^source^] element MUST reference a [=core media type resource=] from its
+									<code>[^source/src^]</code> and <code>[^source/srcset^]</code> attributes unless it
+								specifies the MIME media type [[rfc2046]] of a [=foreign resource=] in its
+									<code>[^source/type^]</code> attribute.</li>
 						</ul>
+
+						<div class="note">
+							<p>It is not advised to reference foreign resources from an [^img^] that is not the child a
+								[^picture^] element even if it is still technically possible to use the [=outdated=] <a
+									href="#content-fallbacks">content fallbacks</a> feature to do so.</p>
+						</div>
 					</section>
 
 					<section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -885,17 +885,14 @@
 					<p>The opposite of core media type resources are foreign resources. These are resources that reading
 						systems are not guaranteed to support the rendering of. As a result, similar to how using
 						foreign content documents in the spine requires fallbacks to ensure their rendering, using
-						foreign resources in content documents also requires fallbacks. These fallbacks are provided in
-						one of two ways: using the capabilities of the host format or via manifest fallbacks.</p>
+						foreign resources in content documents also requires fallbacks. These fallbacks are provided
+						using the capabilities of the host format.</p>
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
 						for example, have intrinsic fallback capabilities. One example is the [^picture^]
 						element&#160;[[html]], which allows multiple alternative image formats to be specified.</p>
 
-					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
-						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
-						is discouraged. For more information about foreign resources, refer to <a
-							href="#sec-foreign-resources"></a>.</p>
+					<p>For more information about foreign resources, refer to <a href="#sec-foreign-resources"></a>.</p>
 
 					<p>Falling between core media type resources and foreign resources are exempt resources. These are
 						most closely associated with foreign resources, as there is no guarantee that reading systems
@@ -1212,26 +1209,21 @@
 					which is not guaranteed [=reading system=] support when used in an [=EPUB content document=] or
 					[=foreign content document=].</p>
 
-				<p id="confreq-cmt">Fallbacks MUST be provided for foreign resources, where fallbacks take one of the
-					following forms:</p>
-
-				<ul>
-					<li>
-						<p>intrinsic fallback mechanisms provided by the host format (e.g., [[?html]] elements often
-							provide the ability to reference more than one media type or to display an alternate
-							embedded message when a media type cannot be rendered); or</p>
-					</li>
-					<li>
-						<p><a href="#sec-manifest-fallbacks">manifest fallback chains</a> defined on [^item^] elements
-							in the [=package document=].</p>
-					</li>
-				</ul>
+				<p id="confreq-cmt">Fallbacks MUST be provided for foreign resources. Fallbacks are typically provided
+					using the intrinsic fallback mechanisms of the host format (e.g., [[?html]] elements often provide
+					the ability to reference more than one media type or to display an alternate embedded message when a
+					media type cannot be rendered).</p>
 
 				<div class="note">
 					<p>Refer to the [[html]] and [[svg]] specifications for the intrinsic fallback capabilities their
 						elements provide.</p>
 					<p><a href="#sec-intrinsic-fallbacks"></a> also provides additional information about how fallbacks
 						are interpreted for specific elements.</p>
+				</div>
+
+				<div class="note">
+					<p>Although the [=outdated=] <a href="#content-fallbacks">content fallbacks</a> feature can be used
+						to provide fallbacks for foreign resources, its use is strongly discouraged.</p>
 				</div>
 			</section>
 
@@ -1429,9 +1421,15 @@
 								</ul>
 							</li>
 
-							<li>Otherwise, it MAY reference foreign resources in its <code>[^img/src^]</code> and
-									<code>[^img/srcset^]</code> attributes provided there is also a <a
-									href="#sec-manifest-fallbacks">manifest fallback</a> to a core media type.</li>
+							<li>
+								<p>Otherwise, it MAY reference foreign resources in its <code>[^img/src^]</code> and
+										<code>[^img/srcset^]</code> attributes provided there is also a <a
+										href="#content-fallbacks">content fallback</a> to a core media type.</p>
+								<div class="note">
+									<p>Content fallbacks are now marked as [=outdated=] and their use is strongly
+										discouraged.</p>
+								</div>
+							</li>
 						</ul>
 					</section>
 
@@ -1440,9 +1438,7 @@
 
 						<p>Although data blocks have a separate MIME media type [[rfc2046]] from their containing
 							[=XHTML content document=], it is not possible to provide intrinsic fallbacks as no such
-							mechanisms are specified for the [[html]] [^script^] element. It is also not possible to
-							provide manifest fallbacks because data blocks cannot be defined as standalone files in the
-							EPUB container but are always embedded as inline <code>script</code> elements.</p>
+							mechanisms are specified for the [[html]] [^script^] element.</p>
 
 						<p>But, as the <code>script</code> element does not represent user content — <a
 								data-cite="html#data-block">data blocks</a> are not rendered unless manipulated by
@@ -11236,11 +11232,8 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
-<<<<<<< HEAD
 					<li>29-Jan-2026: Moved manifest fallbacks for content to the outdated features. See <a
 							href="https://github.com/w3c/epub-specs/issues/2900">issue 2900</a></li>
-=======
->>>>>>> remotes/origin/main
 					<li>23-January-2026: Added JPEG XL as a core media type for images. See <a
 							href="https://github.com/w3c/epub-specs/issues/2896">issue 2896</a>.</li>
 					<li>18-Dec-2025: Renamed "obsolete but conforming features" to "outdated features". As discussed in

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1402,23 +1402,26 @@
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L280,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L285,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L290,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L296,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L302,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L308,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L313">
 						<h5>HTML <code>img</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-img">If the [[html]] [^img^] element is the child of a
-							[^picture^] element, the following fallback conditions apply to its use:</p>
-
+						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that can be referenced
+							from the [[html]] [^img^] element, the following fallback conditions apply to its use:</p>
 						<ul>
-							<li>it MUST reference core media type resources from its <code>src</code> and
-									<code>srcset</code> attributes when those attributes are set; and</li>
-							<li>each sibling [^source^] element MUST reference a [=core media type resource=] from its
-									<code>[^source/src^]</code> and <code>[^source/srcset^]</code> attributes unless it
-								specifies the MIME media type [[rfc2046]] of a [=foreign resource=] in its
-									<code>[^source/type^]</code> attribute.</li>
-						</ul>
+							<li>
+								<p>If it is the child of a [^picture^] element:</p>
+								<ul>
+									<li>it MUST reference core media type resources from its <code>src</code> and
+											<code>srcset</code> attributes when those attributes are set; and</li>
+									<li>each sibling [^source^] element MUST reference a [=core media type resource=]
+										from its <code>[^source/src^]</code> and <code>[^source/srcset^]</code>
+										attributes unless it specifies the MIME media type [[rfc2046]] of a [=foreign
+										resource=] in its <code>[^source/type^]</code> attribute.</li>
+								</ul>
+							</li>
 
-						<div class="note">
-							<p>It is not advised to reference foreign resources from an [^img^] that is not the child a
-								[^picture^] element even if it is still technically possible to use the [=outdated=] <a
-									href="#content-fallbacks">content fallbacks</a> feature to do so.</p>
-						</div>
+							<li>
+								<p>Otherwise, its <code>[^img/srcset^]</code> attribute MUST NOT be used to provide
+									fallbacks to a core media type.</p>
+							</li>
+						</ul>
 					</section>
 
 					<section>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1317,8 +1317,9 @@
 					<h5>Manifest fallbacks</h5>
 
 					<p>Manifest fallbacks are a feature of the [=package document=] that create a <dfn class="export"
-							>manifest fallback chain</dfn> for a [=publication resource=], allowing [=reading systems=]
-						to select an alternative format they can render.</p>
+							>manifest fallback chain</dfn> of alternative resources that a [=reading system=] can use in
+						place of a [=top-level content document=], allowing it to select a format it can render if the
+						default resource is not supported in the [=EPUB spine|spine=].</p>
 
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
 							attribute</a> on [=EPUB Manifest | manifest=] [^item^] elements. This attribute references
@@ -1328,54 +1329,30 @@
 								<code>item</code>'s <code>fallback</code> attribute, represents both the full and
 							preferred fallback chain for that <code>item</code>.</span></p>
 
-					<p>There are two cases for manifest fallbacks:</p>
+					<p id="spine-fallbacks"
+						data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine"
+						>A [=foreign content document=] MUST specify a fallback chain that MUST include at least one
+						[=EPUB content document=] to ensure that reading systems can always render the [=EPUB spine |
+						spine=] item.</p>
 
-					<dl>
-						<dt id="spine-fallbacks"
-							data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine"
-							>Spine fallbacks</dt>
-						<dd>
-							<p>A [=foreign content document=] MUST specify a fallback chain that MUST include at least
-								one [=EPUB content document=] to ensure that reading systems can always render the
-								[=EPUB spine | spine=] item.</p>
-							<p>EPUB content documents MAY specify a fallback. For example, to provide a <a
-									href="#confreq-cd-scripted-flbk">fallback for scripted content</a>.</p>
-							<p>When a fallback chain includes more than one EPUB content document, the <a
-									href="#attrdef-properties"><code>properties</code> attribute</a> can be used to
-								differentiate the purpose of each.</p>
-						</dd>
+					<p>EPUB content documents MAY specify a fallback. For example, to provide a <a
+							href="#confreq-cd-scripted-flbk">fallback for scripted content</a>.</p>
 
-						<dt id="content-fallbacks">Content fallbacks</dt>
-						<dd>
-							<div class="note">
-								<p>The original reason for defining a content fallback mechanism was to handle foreign
-									resource images in the [[html]] [^img^] element. As HTML now has intrinsic fallback
-									mechanisms for images, such as the [^img/srcset^] attribute and [^source^] element,
-									the use of content fallbacks is strongly discouraged.</p>
-							</div>
-							<p>When elements that reference [=foreign resources=] do not have intrinsic fallback
-								capabilities, a content fallback MUST be provided. In this case, the fallback chain MUST
-								contain at least one [=core media type resource=].</p>
-							<p>Manifest fallbacks MAY also be provided for core media type resources. For example, to
-								allow reading systems to select from more than one image format.</p>
-						</dd>
-					</dl>
+					<p>When a fallback chain includes more than one EPUB content document, the <a
+							href="#attrdef-properties"><code>properties</code> attribute</a> can be used to
+						differentiate the purpose of each.</p>
 
-					<p>Regardless of the type of manifest fallback specified, fallback chains MUST NOT contain
-						self-references or circular references to <code>item</code> elements in the chain.</p>
-
-					<div class="note">
-						<p>As it is not possible to use manifest fallbacks for resources represented in <a
-								href="#sec-data-urls">data URLs</a>, foreign resources can only be represented as data
-							URLs where an intrinsic fallback mechanism is available.</p>
-					</div>
+					<p>Manifest fallback chains MUST NOT contain self-references or circular references to
+							<code>item</code> elements in the chain.</p>
 				</section>
 
 				<section id="sec-intrinsic-fallbacks">
 					<h4>Intrinsic fallbacks</h4>
 
-					<p>The following sections provide additional clarifications about the intrinsic fallback
-						requirements of specific elements.</p>
+					<p>The use of [=manifest fallback chains=] for use in EPUB content documents and foreign content
+						documents is now [=outdated=]. The following sections provide clarifications about the intrinsic
+						fallback requirements of specific elements in [[html]] that can be used in place of manifest
+						fallbacks.</p>
 
 					<section id="sec-fallbacks-audio" data-epubcheck="true"
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L256,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L262,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L272">
@@ -10483,6 +10460,14 @@ EPUB/images/cover.png</pre>
 					conform to their referenced definitions.</p>
 
 				<dl>
+					<dt>Publication resources</dt>
+					<dd>
+						<ul>
+							<li id="content-fallbacks">
+								<a data-cite="epub-33#content-fallbacks">Content fallbacks</a> [[epub-33]]</li>
+						</ul>
+					</dd>
+
 					<dt>Open Container Format (OCF)</dt>
 					<dd>
 						<ul>
@@ -11112,6 +11097,8 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>29-Jan-2026: Moved manifest fallbacks for content to the outdated features. See <a
+							href="https://github.com/w3c/epub-specs/issues/2900">issue 2900</a></li>
 					<li>18-Dec-2025: Renamed "obsolete but conforming features" to "outdated features". As discussed in
 						the <a href="https://w3c.github.io/pm-wg/minutes/2025-12-11.html#59bf">2025-12-11 WG
 						meeting</a>.</li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -886,11 +886,9 @@
 						systems are not guaranteed to support the rendering of. As a result, similar to how using
 						foreign content documents in the spine requires fallbacks to ensure their rendering, using
 						foreign resources in content documents also requires fallbacks. These fallbacks are provided
-						using the capabilities of the host format.</p>
-
-					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
-						for example, have intrinsic fallback capabilities. One example is the [^picture^]
-						element&#160;[[html]], which allows multiple alternative image formats to be specified.</p>
+						using the capabilities of the host format. Many HTML elements, for example, have intrinsic
+						fallback capabilities. One example is the [^picture^] element&#160;[[html]], which allows
+						multiple alternative image formats to be specified.</p>
 
 					<p>For more information about foreign resources, refer to <a href="#sec-foreign-resources"></a>.</p>
 
@@ -1375,10 +1373,8 @@
 				<section id="sec-intrinsic-fallbacks">
 					<h4>Intrinsic fallbacks</h4>
 
-					<p>The use of [=manifest fallback chains=] for use in EPUB content documents and foreign content
-						documents is now [=outdated=]. The following sections provide clarifications about the intrinsic
-						fallback requirements of specific elements in [[html]] that can be used in place of manifest
-						fallbacks.</p>
+					<p>The following sections provide clarifications about the intrinsic fallback requirements of
+						specific elements in [[html]].</p>
 
 					<section id="sec-fallbacks-audio" data-epubcheck="true"
 						data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L256,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L262,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L272">
@@ -1422,13 +1418,9 @@
 							</li>
 
 							<li>
-								<p>Otherwise, it MAY reference foreign resources in its <code>[^img/src^]</code> and
-										<code>[^img/srcset^]</code> attributes provided there is also a <a
-										href="#content-fallbacks">content fallback</a> to a core media type.</p>
-								<div class="note">
-									<p>Content fallbacks are now marked as [=outdated=] and their use is strongly
-										discouraged.</p>
-								</div>
+								<p>Otherwise, it MAY reference foreign resources in its <code>[^img/srcset^]</code>
+									attribute provided there is also a reference to at least one core media type
+									resource.</p>
 							</li>
 						</ul>
 					</section>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -331,33 +331,19 @@
 					>Reading systems MAY support an arbitrary set of [=foreign resource=] types.</p>
 			</section>
 
-			<section id="sec-epub-rs-resource-fallbacks">
-				<h4>Resource fallbacks</h4>
+			<section id="sec-epub-rs-manifest-fallbacks">
+				<h4>Manifest fallbacks</h4>
 
-				<p>For [=foreign resources=], if a reading system does not support a resource's MIME media type
-					[[rfc2046]]:</p>
-
-				<ul>
-					<li>it MUST give precedence to any fallbacks provided via <a
-							data-cite="epub-34#sec-intrinsic-fallbacks">intrinsic fallback methods</a> [[epub-34]] of
-						the element the resource is referenced from;</li>
-					<li>otherwise, it SHOULD traverse the resource's <a data-cite="epub-34#sec-manifest-fallbacks"
-							>manifest fallback chain</a> [[epub-34]], when one is specified, until it identifies a
-						supported publication resource to use in place of the unsupported resource.</li>
-				</ul>
-
-				<p>When manifest fallbacks are provided for [=core media type resources=], a reading system MAY traverse
-					the fallback chain to determine if a more optimal format is available for rendering.</p>
-
-				<p  id="confreq-rendition-rs-spine-fallback" data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine">For [=foreign content documents=], if a reading system does not support the resource's MIME media
+				<p id="confreq-rendition-rs-spine-fallback"
+					data-tests="#lay-roll-images-mixed,#lay-roll-images-in-spine,#pp-roll-images-mixed,#pp-roll-images-in-spine"
+					>For [=foreign content documents=], if a reading system does not support the resource's MIME media
 					type, it MUST traverse the resource's <a data-cite="epub-34#sec-manifest-fallbacks">manifest
 						fallback chain</a> [[epub-34]] until it identifies a supported publication resource to use in
 					place of the unsupported resource.</p>
 
 				<p>When <a data-cite="epub-34#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-34]] are provided
 					for [=epub content documents=], reading systems MAY choose from the available options to find the
-					optimal version to render in a given context (e.g., by inspecting the properties attribute for
-					each).</p>
+					optimal version to render (e.g., by inspecting the properties attribute for each).</p>
 
 				<p id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple publication
 					resources in the fallback chain, it MAY select the resource to use based on the resource's <a
@@ -2655,6 +2641,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
+					<li>29-Jan-2026: Removed processing requirements for manifest fallbacks when used for content as
+						this is now marked as an outdated feature. See <a
+							href="https://github.com/w3c/epub-specs/issues/2900">issue 2900</a>.</li>
 					<li>21-Jan-2026: Clarified that the need to process fallbacks is dependent on the context in which a
 						media type is used. See <a href="https://github.com/w3c/epub-specs/issues/2893">issue
 						2893</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -946,7 +946,7 @@
 				</ul>
 
 				<div class="note">
-					<p>Refer to <a href="#sec-epub-rs-resource-fallbacks"></a> for more information on handling manifest
+					<p>Refer to <a href="#sec-epub-rs-manifest-fallbacks"></a> for more information on handling manifest
 						fallbacks.</p>
 				</div>
 


### PR DESCRIPTION
Title pretty much says it all. We've been advising that manifest fallbacks outside the spine shouldn't be used anymore since 3.3; this just got missed while we were doing the earlier roundup of outdated stuff.

I've kept the intrinsic fallback sections as they're still relevant.

Fixes #2898
Fixes #2900 

***

Reading Systems: [Preview](https://raw.githack.com/w3c/epub-specs/fix/remove-content-fallbacks/epub34/rs/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/rs/index.html&doc2=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/remove-content-fallbacks/epub34/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2902.html" title="Last updated on Feb 2, 2026, 2:50 PM UTC (aca95c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2902/99ef96d...aca95c8.html" title="Last updated on Feb 2, 2026, 2:50 PM UTC (aca95c8)">Diff</a>