### PR TITLE
Restore example indenting

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1799,8 +1799,8 @@
 							<th>Example:</th>
 							<td>
 								<pre>&lt;meta
-property="a11y:certifiedBy">
-Accessibility Testers Group
+    property="a11y:certifiedBy">
+   Accessibility Testers Group
 &lt;/meta></pre>
 							</td>
 						</tr>
@@ -1845,14 +1845,14 @@ Accessibility Testers Group
 							<th>Example:</th>
 							<td>
 								<pre>&lt;meta
-property="a11y:certifiedBy"
-id="certifier">
-Accessibility Testers Group
+    property="a11y:certifiedBy"
+    id="certifier">
+   Accessibility Testers Group
 &lt;/meta>
 &lt;meta
-property="a11y:certifierCredential"
-refines="#certifier">
-DAISY OK
+    property="a11y:certifierCredential"
+    refines="#certifier">
+   DAISY OK
 &lt;/meta></pre>
 							</td>
 						</tr>
@@ -1897,14 +1897,14 @@ DAISY OK
 							<th>Example:</th>
 							<td>
 								<pre>&lt;meta
-property="a11y:certifiedBy"
-id="certifier">
-Accessibility Testers Group
+    property="a11y:certifiedBy"
+    id="certifier">
+   Accessibility Testers Group
 &lt;/meta>
 &lt;link
-rel="a11y:certifierReport"
-refines="#certifier"
-href="https://example.com/a11y-report/"/></pre>
+    rel="a11y:certifierReport"
+    refines="#certifier"
+    href="https://example.com/a11y-report/"/></pre>
 							</td>
 						</tr>
 					</table>


### PR DESCRIPTION
Adds back the indenting that was lost in the a11y property definition table examples.

Fixes #2858
