### PR TITLE
Clarify exemptions can apply to some conforming content

### DIFF
--- a/wg-notes/a11y-exemption/index.html
+++ b/wg-notes/a11y-exemption/index.html
@@ -5,6 +5,7 @@
 		<meta name="color-scheme" content="light dark" />
 		<title>The EPUB Accessibility exemption property</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../../common/js/add-caution-hd.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
@@ -34,6 +35,7 @@
 					branch: "main"
 				},
 				preProcess:[inlineCustomCSS],
+                postProcess:[addCautionHeaders],
 				xref: {
 					profile: "web-platform",
 					specs: ["epub-33"]

--- a/wg-notes/a11y-exemption/index.html
+++ b/wg-notes/a11y-exemption/index.html
@@ -62,9 +62,8 @@
 	<body>
 		<h1 id="title">The EPUB Accessibility <code>exemption</code> property</h1>
 		<section id="abstract">
-			<p>The <code>exemption</code> property allows EPUB creators to indicate that an EPUB publication that does
-				not meet accessibility conformance requirements has an exemption under the applicable jurisdiction's
-				laws.</p>
+			<p>The <code>exemption</code> property indicates that an EPUB publication that does not meet a
+				jurisdiction's mimimum accessibility conformance requirements has an exemption under its laws.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="sec-intro">
@@ -107,10 +106,9 @@
 		<section id="sec-evaluator-name">
 			<h3>Accessibility conformance exemptions</h3>
 
-			<p>When a jurisdiction provides specific legal exemptions for [=EPUB publications=], [=EPUB creators=] whose
-				content fails to meet the requirements of the EPUB Accessibility standard [[epub-a11y]] (or any other
-				standard), can use <a href="#exemption-property">the <code>exemption</code> property</a> to indicate
-				when their publications fall under one of these provisions.</p>
+			<p>When a jurisdiction provides exemptions for [=EPUB publications=] that do not meet its minimum legal
+				accessibility requirements, <a href="#exemption-property">the <code>exemption</code> property</a> can be
+				used, when applicable, to indicate a publication falls under one of the provisions.</p>
 
 			<aside class="example"
 				title="An EPUB publication exempt from the European Accessibility Act's conformance requirements">
@@ -119,10 +117,14 @@
 			</aside>
 
 			<div class="note">
-				<p>EPUB creators do not have to include an accessibility conformance claim of "<code>none</code>" when
-					listing that a publication has an exemption from accessibility requirements, but it is best practice
-					to also provide this information. Reading systems that do not recognize the exemption might
-					otherwise list the accessibility status as unknown.</p>
+				<p>An accessibility conformance claim of "<code>none</code>" is not required when listing that an EPUB
+					publication has an exemption from accessibility requirements, but it is best practice to also
+					provide this information if no standard has been met. Reading systems that do not recognize the
+					exemption might otherwise list the accessibility status as unknown.</p>
+
+				<p>An EPUB publication claiming an exemption does not always mean that no standard has been met. A
+					publication could make a conformance claim at WCAG Level A, for example, and also have to claim an
+					exemption because Level AA is required by law.</p>
 			</div>
 
 			<p>The property MAY be repeated to list exemptions for multiple jurisdictions and/or for multiple exemptions
@@ -144,8 +146,8 @@
 
 			<div class="note">
 				<p>The EPUB Accessibility standard [[epub-a11y]] reserves the prefix "<code>a11y:</code>" for use with
-					properties in the <code>http://idpf.org/epub/vocab/package/a11y/#</code> namespace. [=EPUB
-					creators=] do not have to declare a prefix in the [=package document=].</p>
+					properties in the <code>http://idpf.org/epub/vocab/package/a11y/#</code> namespace. The prefix does
+					not have to be declared in the [=package document=].</p>
 			</div>
 
 			<section id="exemption">
@@ -199,6 +201,11 @@
 			<section id="exemption-values">
 				<h2>Exemption values</h2>
 
+				<div class="caution">
+					<p>It is strongly advised to seek legal guidance when unsure whether an EPUB publication meets the
+						legal requirements for these exemptions.</p>
+				</div>
+
 				<table class="zebra">
 					<tr>
 						<th>Value</th>
@@ -206,7 +213,9 @@
 					</tr>
 					<tr>
 						<td class="top" id="eaa-disproportionate-burden">
-							<p><code>eaa-disproportionate-burden</code></p>
+							<p>
+								<code>eaa-disproportionate-burden</code>
+							</p>
 						</td>
 						<td>
 							<p><a
@@ -218,13 +227,13 @@
 							<p>Use of the <code>eaa-disproportionate-burden</code> value indicates an EPUB publication
 								is exempt because it would require such a disproportionate burden to make
 								accessible.</p>
-							<p>EPUB creators are responsible for ensuring their publications meet the legal requirements
-								for this exemption.</p>
 						</td>
 					</tr>
 					<tr>
 						<td class="top" id="eaa-fundamental-alteration">
-							<p><code>eaa-fundamental-alteration</code></p>
+							<p>
+								<code>eaa-fundamental-alteration</code>
+							</p>
 						</td>
 						<td>
 							<p><a
@@ -235,13 +244,13 @@
 									fundamental alteration of its basic nature</q> [[directive-2019/882]].</p>
 							<p>Use of the <code>eaa-fundamental-alteration</code> value indicates an EPUB publication is
 								exempt because it would require such a fundamental alteration to make accessible.</p>
-							<p>EPUB creators are responsible for ensuring their publications meet the legal requirements
-								for this exemption.</p>
 						</td>
 					</tr>
 					<tr>
 						<td class="top" id="eaa-microenterprise">
-							<p><code>eaa-microenterprise</code></p>
+							<p>
+								<code>eaa-microenterprise</code>
+							</p>
 						</td>
 						<td>
 							<p>The <a href="https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019L0882"
@@ -258,8 +267,6 @@
 							<p>Use of the <code>eaa-microenterprise</code> value indicates that the publisher of an
 								[=EPUB publication=] that does not meet accessibility standards qualifies under the
 								definition of a microenterprise.</p>
-							<p>[=EPUB creators=] are responsible for ensuring they meet the legal requirements of a
-								microenterprise when using this value.</p>
 						</td>
 					</tr>
 				</table>

--- a/wg-notes/a11y-exemption/index.html
+++ b/wg-notes/a11y-exemption/index.html
@@ -119,14 +119,13 @@
 			</aside>
 
 			<div class="note">
-				<p>An accessibility conformance claim of "<code>none</code>" is not required when listing that an EPUB
-					publication has an exemption from accessibility requirements, but it is best practice to also
-					provide this information if no standard has been met. Reading systems that do not recognize the
-					exemption might otherwise list the accessibility status as unknown.</p>
+				<p>An EPUB publication that meets accessibility standards might also claim exemptions. A publication
+					could indicate conformance to [[wcag22]] Level A, for example, and also have to claim an exemption
+					because Level AA conformance is required by law.</p>
 
-				<p>An EPUB publication claiming an exemption does not always mean that no standard has been met. A
-					publication could make a conformance claim at WCAG Level A, for example, and also have to claim an
-					exemption because Level AA is required by law.</p>
+				<p>An accessibility conformance claim of "<code>none</code>" is not required when an EPUB publication
+					fails to meet the requirements of [[[epub-a11y]]] [[epub-a11y]] but the accessibility status could
+					be presented as unknown if it is not set and the exemption is not recognized.</p>
 			</div>
 
 			<p>The property MAY be repeated to list exemptions for multiple jurisdictions and/or for multiple exemptions


### PR DESCRIPTION
The primary fix in this pull request is to reword the first paragraph and note in section 2 so that we aren't inferring that all content that needs an exemption fails accessibility standards. A Level A-conformant publication would need an EAA exemption, for example.

I also got rid of "epub creator" from the document. There weren't many instances, but the one notable change I made was to put a caution before the EAA value definitions to seek legal advice when unsure if they apply. I don't think we need to have a paragraph in every description saying it's the epub creator's responsibility to check.

Fixes #2849 

***

[Preview](https://raw.githack.com/w3c/epub-specs/editorial/issue-2849/wg-notes/a11y-exemption/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/wg-notes/a11y-exemption/index.html&doc2=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/editorial/issue-2849/wg-notes/a11y-exemption/index.html)

