### PR TITLE
Add script to generate caution headers in reading system spec

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -7,6 +7,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
+		<script src="../../common/js/add-caution-hd.js" class="remove"></script>
 		<script src="../../common/js/data-test-display.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
@@ -107,7 +108,7 @@
 					},
 				},
 				preProcess:[inlineCustomCSS],
-				postProcess: [data_test_display, fixErrataField],
+				postProcess: [addCautionHeaders, data_test_display, fixErrataField],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
 				xref: {
 					profile: "web-platform",


### PR DESCRIPTION
Noticed it was missing while updating the exemption note. Affects the one caution about sha-1 being retired.