### PR TITLE
Annotation selectors, second draft

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -380,7 +380,7 @@
                         An annotation refers to a segment of a resource, which is identified by one or more
                         <a data-cite="annotation-model#selectors">Selectors</a>.
                         The nature of the Selectors and methods to describe segments depend on
-                        the resource type. Providing more than one Selectors allows an annotation software to
+                        the resource type. Providing more than one Selector allows an annotation software to
                         choose the most accurate selector from those it can handle and helps to accommodate
                         evolutions on the annotated resource.
                     </p>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -40,6 +40,7 @@
                     branch: "main"
                 },
                 preProcess: [inlineCustomCSS],
+                postProcess: [addCautionHeaders],
                 testSuiteURL: "https://w3c.github.io/epub-tests/index.html",
                 xref: {
                     profile: "web-platform",

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="color-scheme" content="light dark" />
-        <title> EPUB Annotations 3.4 </title>
+        <title>EPUB Annotations 1.0</title>
         <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove">
         </script>
         <script src="../../common/js/css-inline.js" class="remove"></script>
@@ -15,7 +15,7 @@
                 group: "pm",
                 wgPublicList: "public-pm-wg",
                 specStatus: "ED",
-                shortName: "epub-ann",
+                shortName: "epub-anno",
                 noRecTrack: false,
                 edDraftURI: "https://w3c.github.io/epub-specs/epub34/annotations/",
                 copyrightStart: "2026",
@@ -48,7 +48,7 @@
                 },
                 lint: { "no-unused-dfns": false },
                 localBiblio: {
-                    "epub-ann-ucr": {
+                    "epub-anno-ucr": {
                         "authors": [
                             "Laurent Le Meur"
                         ],
@@ -74,7 +74,7 @@
         <section id="abstract">
             <p> This document defines a profile of the [[[annotation-model]]] [[annotation-model]]
                 by specifying a subset of the properties allowed in this model, and adding
-                properties deemed useful to satisfy the [[[epub-ann-ucr]]] [[epub-ann-ucr]].
+                properties deemed useful to satisfy the [[[epub-anno-ucr]]] [[epub-anno-ucr]].
             </p>
         </section>
         <section id="sotd"></section>
@@ -460,7 +460,8 @@
                             [^conformsTo^] property. Other URLs MUST NOT be used.
                         </p>
 
-                        <table id="#tbl-core-media-types">
+                        <!-- cheating: I reuse a common css entry done for media types, hence the choice of the ID -->
+                        <table id="tbl-core-media-types">
                             <thead>
                                 <th>Name</th>
                                 <th>Fragment Specification</th>
@@ -492,7 +493,6 @@
                             </tbody>
                         </table>
 
-                        <p>The integration of text fragments into the specification is AT RISK.</p>
 
                         <div class="caution">
                             <p>
@@ -501,10 +501,10 @@
                             </p>
                         </div>
 
-                        <div class="issue">
-                            <p>
-                                The reason the integration of text fragments into the specification is at risk is
-                                two-fold.
+                        <div class="note">
+
+                            <p>The integration of text fragments into the specification is AT RISK.
+                                The reason is two-fold:
                             </p>
 
                             <ol>
@@ -567,7 +567,7 @@
                         </table>
                     </section>
 
-                    <section class="informative">
+                    <!-- <section class="informative">
                         <h5>Text Quote Selector</h5>
                         <p>
                             This Selector describes a range of text by copying it, and including some of the text
@@ -649,7 +649,7 @@
                             See the caveats on using text fragments in the section on <a
                                 href="#fragment-selector">Fragment Selectors</a>.
                         </p>
-                    </section>
+                    </section> -->
 
                     <section class="informative">
                         <h5>Text Position Selector</h5>
@@ -664,21 +664,10 @@
                             as defined in the [[[annotation-model]]] specification, but lists it here for an easier
                             readability.
                         </p>
-                        <p>
-                            For HTML content, the stream of characters correspond to the output
-                            of the <a
-                                href="https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute"><code>innerText</code>
-                                attribute</a> on the <code>body</code> element. The selection of the text must be in
-                            terms of unicode code points (the "character number").
-                            Selections should not start or end in the middle of a grapheme cluster.
-                            The selection must be based on the logical order of the text, rather than the visual
-                            order, especially for bidirectional text.
-                        </p>
 
-                        <p class="issue">
-                            The last paragraph is more of a placeholder rather than anything else. The original specification does not
-                            say what "stream" is, and the exact specification is also dependent on whether the selector serves as a refinement or not.
-                            In any case, if indeed this must be specified here, the section should become normative.
+                        <p>
+                            The text must be selected and normalized in the same way as for the <a href="annotation-model#text-quote-selector">Text Quote Selector</a> before counting the number of
+                            characters to determine the start and end positions.
                         </p>
                         <table class="zebra">
                             <thead>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -22,6 +22,13 @@
                     company: "EDRLab",
                     companyURL: "https://www.edrlab.org",
                     "w3cid": 91888
+                },{
+                    name: "Ivan Herman",
+                    url: "https://www.w3.org/People/Ivan/",
+                    company: "W3C",
+                    w3cid: 7382,
+                    orcid: "0000-0003-0782-2704",
+                    companyURL: "https://www.w3.org",
                 }],
                 includePermalinks: true,
                 permalinkEdge: true,

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -657,7 +657,7 @@
                             selection in the stream.
                             Position 0 would be immediately before the first character, position 1 would be immediately
                             before the second character, and so on.
-                           
+
                             This specification reuses the <a
                                 data-cite="annotation-model#text-position-selector"><code>TextPositionSelector</code></a>,
                             as defined in the [[[annotation-model]]] specification, but lists it here for an easier
@@ -672,6 +672,12 @@
                             Selections should not start or end in the middle of a grapheme cluster.
                             The selection must be based on the logical order of the text, rather than the visual
                             order, especially for bidirectional text.
+                        </p>
+
+                        <p class="issue">
+                            The last paragraph is more of a placeholder rather than anything else. The original specification does not
+                            say what "stream" is, and the exact specification is also dependent on whether the selector serves as a refinement or not.
+                            In any case, if indeed this must be specified here, the section should become normative.
                         </p>
                         <table class="zebra">
                             <thead>
@@ -1338,8 +1344,8 @@
                 <section>
                     <h2 id="4-2-using-multiple-selectors"> Using multiple selectors </h2>
                     <p> It is recommended that Reading Systems export multiple selectors, including at least
-                        one precise selector (e.g. CssSelector + TextPositionSelector).
-                        <!-- and one selector resistant to content modifications (e.g. ProgressionSelector). -->
+                        one precise selector (e.g. CssSelector + TextPositionSelector),
+                        and one selector resistant to content modifications (e.g., based on text fragments).
                     </p>
                     <p> When displaying an annotation, a Reading System is free to use the most precise
                         Selector available. It will select an alternative Selector as a fallback in case the

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -787,7 +787,7 @@
                     </pre>
                         </aside>
                         <p>This selects "q" from "quick" as start position and
-                            "x" from the first instance of "fox" as end position in the following HTML snippet: </p>
+                            "x" from "fox" as end position in the following HTML snippet: </p>
                         <pre>
 &lt;div id="intro">
     &lt;p>Some text.&lt;/p>
@@ -1452,4 +1452,5 @@
 		</section> -->
         <section id="index"></section>
     </body>
+
 </html>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
 <html lang="en-US">
-	<head>
-		<meta charset="utf-8" />
-		<meta name="color-scheme" content="light dark" />
-		<title> EPUB Annotations 3.4 </title>
-		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove">
-		</script>
-		<script src="../../common/js/css-inline.js" class="remove"></script>
+
+    <head>
+        <meta charset="utf-8" />
+        <meta name="color-scheme" content="light dark" />
+        <title> EPUB Annotations 3.4 </title>
+        <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove">
+        </script>
+        <script src="../../common/js/css-inline.js" class="remove"></script>
         <script src="../../common/js/add-caution-hd.js" class="remove"></script>
-		</script>
-		<script class="remove">
+        </script>
+        <script class="remove">
             var respecConfig = {
                 group: "pm",
                 wgPublicList: "public-pm-wg",
@@ -38,11 +39,11 @@
                     repoURL: "https://github.com/w3c/epub-specs",
                     branch: "main"
                 },
-                preProcess:[inlineCustomCSS],
+                preProcess: [inlineCustomCSS],
                 testSuiteURL: "https://w3c.github.io/epub-tests/index.html",
                 xref: {
                     profile: "web-platform",
-                    specs:[ "epub-34"]
+                    specs: ["epub-34"]
                 },
                 lint: { "no-unused-dfns": false },
                 localBiblio: {
@@ -55,44 +56,47 @@
                         "date": "26 November 2025",
                         "publisher": "W3C"
                     },
-                    "scroll-to-text-fragment" : {
+                    "scroll-to-text-fragment": {
                         "authors": [
                             "Nick Burris",
                             "David Bokan"
                         ],
-                        "title" : "URL Fragment Text Directives",
-                        "publisher" : "W3C",
-                        "href" : "https://wicg.github.io/scroll-to-text-fragment/"
+                        "title": "URL Fragment Text Directives",
+                        "publisher": "W3C",
+                        "href": "https://wicg.github.io/scroll-to-text-fragment/"
                     }
                 }
             };</script>
-	</head>
-	<body>
-		<section id="abstract">
-			<p> This document defines a profile of the [[[annotation-model]]] [[annotation-model]]
+    </head>
+
+    <body>
+        <section id="abstract">
+            <p> This document defines a profile of the [[[annotation-model]]] [[annotation-model]]
                 by specifying a subset of the properties allowed in this model, and adding
-				properties deemed useful to satisfy the [[[epub-ann-ucr]]] [[epub-ann-ucr]].
-			</p>
-		</section>
-		<section id="sotd"></section>
+                properties deemed useful to satisfy the [[[epub-ann-ucr]]] [[epub-ann-ucr]].
+            </p>
+        </section>
+        <section id="sotd"></section>
         <section id="conformance">
             <!-- <p>All algorithm explanations are <em>non-normative</em>.</p> -->
         </section>
 
-		<section id="1-profile-of-the-w3c-annotation-data-model" class="informative">
-			<h1> Subset of the Web Annotation Data Model </h1>
-			<p> This section defines a profile of the [[[annotation-model]]] [[annotation-model]], as used for EPUB
-				Annotations.</p>
+        <section id="1-profile-of-the-w3c-annotation-data-model" class="informative">
+            <h1> Subset of the Web Annotation Data Model </h1>
+            <p> This section defines a profile of the [[[annotation-model]]] [[annotation-model]], as used for EPUB
+                Annotations.</p>
             <p> In the Web Annotation model, the core structure is the
                 <a data-cite="annotation-model#annotations">Annotation object</a>,
                 which contains properties defining the annotation's
                 <a data-cite="annotation-model#bodies-and-targets">Body and Target</a>.
-                EPUB Annotations reuse the <a href="#1-1-annotation-object">same model</a> with some restrictions listed below.
+                EPUB Annotations reuse the <a href="#1-1-annotation-object">same model</a> with some restrictions listed
+                below.
                 Subsequent sections provide more formal definitions for the terms used by this
                 specification.
             </p>
-           <ul>
-                 <li> Web Annotations may have 0 or more Bodies, whereas this document requires to have a single <a href="#1-4-body">Body</a>
+            <ul>
+                <li> Web Annotations may have 0 or more Bodies, whereas this document requires to have a single <a
+                        href="#1-4-body">Body</a>
                     per annotation. Furthermore, in the [[annotation-model]], such Body can be remote or embedded,
                     whereas only embedded Bodies are used in EPUB Annotation
                     for textual comments .
@@ -100,130 +104,145 @@
                     <p class="issue">The inclusion mechanism is to be defined for audiovisual comments</p>
 
                 </li>
-                <li> Web Annotations have 1 or more Targets, while only a single <a href="#1-3-target">Target</a> is allowed for an
-                    EPUB Annotation.  The Target of an EPUB Annotation is the content being annotated, which is
+                <li> Web Annotations have 1 or more Targets, while only a single <a href="#1-3-target">Target</a> is
+                    allowed for an
+                    EPUB Annotation. The Target of an EPUB Annotation is the content being annotated, which is
                     a specific segment in a document within the EPUB package defined by its relative
-                    <a href="#1-3-1-source">Source</a> URL and a <a href="#1-3-2-selector">Selector</a>. </li>
-                <li> Web Annotations may have multiple motivations, while only a single motivation is allowed for EPUB annotations. </li>
-                <li> Web Annotations may have multiple creators, while only a single creator is allowed for EPUB annotations.</li>
+                    <a href="#1-3-1-source">Source</a> URL and a <a href="#1-3-2-selector">Selector</a>.
+                </li>
+                <li> Web Annotations may have multiple motivations, while only a single motivation is allowed for EPUB
+                    annotations. </li>
+                <li> Web Annotations may have multiple creators, while only a single creator is allowed for EPUB
+                    annotations.</li>
                 <li> Web Annotations may have additional properties that are not accepted for EPUB Annotations (see the
                     definitions of the properties in later sections). For example,
                     a specific generator application and generated date may exist for a Web Annotation,
-                    whereas this document only defines these properties for <a href="#2-annotation-set">Annotation Sets</a>.
-                    Web Annotations also define additional property values and types than are not usable for EPUB Annotations. </li>
-                <li> Web Annotations define an <code>AnnotationCollection</code> structure to handle paginated requests, whereas this document
+                    whereas this document only defines these properties for <a href="#2-annotation-set">Annotation
+                        Sets</a>.
+                    Web Annotations also define additional property values and types than are not usable for EPUB
+                    Annotations. </li>
+                <li> Web Annotations define an <code>AnnotationCollection</code> structure to handle paginated requests,
+                    whereas this document
                     defines an [=AnnotationSet=] structure to group multiple annotations for sharing purposes.
-                    Implementers MUST support [=AnnotationSet=] and MAY support both structures for maximum compatibility.
+                    Implementers MUST support [=AnnotationSet=] and MAY support both structures for maximum
+                    compatibility.
                 </li>
             </ul>
-			<p class="note">This document does not define how annotations are created, stored, or
-				synchronized in a reading system. </p>
-		</section>
+            <p class="note">This document does not define how annotations are created, stored, or
+                synchronized in a reading system. </p>
+        </section>
         <section>
-			<h2 id="1-annotation"> Annotation </h2>
+            <h2 id="1-annotation"> Annotation </h2>
             <section>
-			<h3 id="1-1-annotation-object"> Annotation Object </h3>
-			<p> The <dfn>Annotation object</dfn> retains the following annotation properties from the
-                <a data-cite="annotation-model#annotations">Web Annotation object</a> [[annotation-model]]:
-             </p>
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th> Name </th>
-						<th> Description </th>
-						<th> Format </th>
-						<th> Required? </th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code> id </code>
-						</td>
-						<td>The identity of the annotation. A uuid formatted as a URN is RECOMMENDED.</td>
-						<td>URL</td>
-						<td>Yes</td>
-					</tr>
-					<tr>
-						<td>
-							<code> type </code>
-						</td>
-						<td>The RDF structure type. It MUST be "Annotation".</td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>motivation</dfn> </code>
-						</td>
-						<td>The motivation for the annotation's creation.</td>
-						<td>"bookmarking" | "commenting" | "highlighting"</td>
-						<td>No</td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>created</dfn> </code>
-						</td>
-						<td>The time when the annotation was created.</td>
-						<td> ISO 8601 datetime </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>modified</dfn> </code>
-						</td>
-						<td>The time the annotation was modified after creation.</td>
-						<td> ISO 8601 datetime </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>creator</dfn> </code>
-						</td>
-						<td>The creator of the annotation. This may be a human, an
-							organization or a software agent.<br></td>
-						<td> [=Creator object=] </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>target</dfn> </code>
-						</td>
-						<td>The target content of the annotation.</td>
-						<td> [=Target object=] </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>body</dfn> </code>
-						</td>
-						<td>The annotation body.</td>
-						<td> [=Body object=] </td>
-						<td> No </td>
-					</tr>
-				</tbody>
-			</table>
+                <h3 id="1-1-annotation-object"> Annotation Object </h3>
+                <p> The <dfn>Annotation object</dfn> retains the following annotation properties from the
+                    <a data-cite="annotation-model#annotations">Web Annotation object</a> [[annotation-model]]:
+                </p>
+                <table class="zebra">
+                    <thead>
+                        <tr>
+                            <th> Name </th>
+                            <th> Description </th>
+                            <th> Format </th>
+                            <th> Required? </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <code> id </code>
+                            </td>
+                            <td>The identity of the annotation. A uuid formatted as a URN is RECOMMENDED.</td>
+                            <td>URL</td>
+                            <td>Yes</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> type </code>
+                            </td>
+                            <td>The RDF structure type. It MUST be "Annotation".</td>
+                            <td> string </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>motivation</dfn> </code>
+                            </td>
+                            <td>The motivation for the annotation's creation.</td>
+                            <td>"bookmarking" | "commenting" | "highlighting"</td>
+                            <td>No</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>created</dfn> </code>
+                            </td>
+                            <td>The time when the annotation was created.</td>
+                            <td> ISO 8601 datetime </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>modified</dfn> </code>
+                            </td>
+                            <td>The time the annotation was modified after creation.</td>
+                            <td> ISO 8601 datetime </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>creator</dfn> </code>
+                            </td>
+                            <td>The creator of the annotation. This may be a human, an
+                                organization or a software agent.<br></td>
+                            <td> [=Creator object=] </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>target</dfn> </code>
+                            </td>
+                            <td>The target content of the annotation.</td>
+                            <td> [=Target object=] </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>body</dfn> </code>
+                            </td>
+                            <td>The annotation body.</td>
+                            <td> [=Body object=] </td>
+                            <td> No </td>
+                        </tr>
+                    </tbody>
+                </table>
 
-            <p class="note">The [[annotation-model]] specification is fairly open ended as for the value of, for example, the
-                <code>body</code> property. This specification restricts the value by defining specific classes that must be used, see the definitions for
-                [=Creator=], [=Target=], and [=Body=] below.
-            </p>
+                <p class="note">The [[annotation-model]] specification is fairly open ended as for the value of, for
+                    example, the
+                    <code>body</code> property. This specification restricts the value by defining specific classes that
+                    must be used, see the definitions for
+                    [=Creator=], [=Target=], and [=Body=] below.
+                </p>
 
-			<p class="note">The type of annotation should be considered when determining the value of the <code>motivation</code> property.
-				An annotation with a Body structure corresponds to a "comment".
-				An annotation without Body structure corresponds to a "highlight" if its Selector defines a range of characters, a space in an image
-				or a time period, and a "bookmark" if it does not.</p>
+                <p class="note">The type of annotation should be considered when determining the value of the
+                    <code>motivation</code> property.
+                    An annotation with a Body structure corresponds to a "comment".
+                    An annotation without Body structure corresponds to a "highlight" if its Selector defines a range of
+                    characters, a space in an image
+                    or a time period, and a "bookmark" if it does not.</p>
 
-			<p class="issue">Question: should we add a "replying" motivation for annotations that are replies to other annotations?</p>
+                <p class="issue">Question: should we add a "replying" motivation for annotations that are replies to
+                    other annotations?</p>
 
-            <p class="ednote">We should specify whether a property may appear at most once (body, target) because that is also part of
-                the profile definition. This can be a separate column ("cardinality") or be added to the description. This remark may be valid
-                for all the tables in the document.
-            </p>
+                <p class="ednote">We should specify whether a property may appear at most once (body, target) because
+                    that is also part of
+                    the profile definition. This can be a separate column ("cardinality") or be added to the
+                    description. This remark may be valid
+                    for all the tables in the document.
+                </p>
 
 
-            <aside class="example" title="Core structure of an EPUB annotation">
-			<pre>
+                <aside class="example" title="Core structure of an EPUB annotation">
+                    <pre>
                 {
                     "@context": "https://www.w3.org/ns/epub-anno.jsonld",
                     "id": "urn:uuid:123-123-123-123",
@@ -238,103 +257,105 @@
                     }
                 }
 			</pre>
-            </aside>
+                </aside>
 
             </section>
             <section>
-			<h3 id="1-2-creator"> Creator </h3>
-			<p> The <dfn>Creator object</dfn> of an annotation is a person, an organization or a software agent. </p>
- 			<p> This document defines the following creator properties: </p>
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th> Name </th>
-						<th> Description </th>
-						<th> Format </th>
-						<th> Required? </th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code> id </code>
-						</td>
-						<td> The identity of the creator. </td>
-						<td> URL </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> type </code>
-						</td>
-						<td> Type of the creator. It MUST be "Person", "Organization" or "Software". </td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> name </code>
-						</td>
-						<td> The name of the creator. </td>
-						<td> string </td>
-						<td> No </td>
-					</tr>
-				</tbody>
-			</table>
+                <h3 id="1-2-creator"> Creator </h3>
+                <p> The <dfn>Creator object</dfn> of an annotation is a person, an organization or a software agent.
+                </p>
+                <p> This document defines the following creator properties: </p>
+                <table class="zebra">
+                    <thead>
+                        <tr>
+                            <th> Name </th>
+                            <th> Description </th>
+                            <th> Format </th>
+                            <th> Required? </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <code> id </code>
+                            </td>
+                            <td> The identity of the creator. </td>
+                            <td> URL </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> type </code>
+                            </td>
+                            <td> Type of the creator. It MUST be "Person", "Organization" or "Software". </td>
+                            <td> string </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> name </code>
+                            </td>
+                            <td> The name of the creator. </td>
+                            <td> string </td>
+                            <td> No </td>
+                        </tr>
+                    </tbody>
+                </table>
             </section>
 
             <section>
-			<h3 id="1-3-target"> Target </h3>
-			<p>The <dfn>Target object</dfn> of an annotation associates the annotation with a specific segment of a
-				resource in the current publication.</p>
-			<p> This document defines three target sub-properties: </p>
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th> Name </th>
-						<th> Description </th>
-						<th> Format </th>
-						<th> Required? </th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code> <dfn>source</dfn> </code>
-						</td>
-						<td> The identity of the target EPUB resource. </td>
-						<td> URL </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>selector</dfn> </code>
-						</td>
-						<td> The segment of the target EPUB resource that is annotated. </td>
-						<td> Array of Selector objects </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>meta</dfn> </code>
-						</td>
-						<td> Indications that help locate the segment in the resource. </td>
-						<td> Meta </td>
-						<td> No </td>
-					</tr>
-				</tbody>
-			</table>
-			<p> A Target with no Selector indicates that the annotation applies to the entire
-				target resource. </p>
-            <section>
+                <h3 id="1-3-target"> Target </h3>
+                <p>The <dfn>Target object</dfn> of an annotation associates the annotation with a specific segment of a
+                    resource in the current publication.</p>
+                <p> This document defines three target sub-properties: </p>
+                <table class="zebra">
+                    <thead>
+                        <tr>
+                            <th> Name </th>
+                            <th> Description </th>
+                            <th> Format </th>
+                            <th> Required? </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <code> <dfn>source</dfn> </code>
+                            </td>
+                            <td> The identity of the target EPUB resource. </td>
+                            <td> URL </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>selector</dfn> </code>
+                            </td>
+                            <td> The segment of the target EPUB resource that is annotated. </td>
+                            <td> Array of Selector objects </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>meta</dfn> </code>
+                            </td>
+                            <td> Indications that help locate the segment in the resource. </td>
+                            <td> Meta </td>
+                            <td> No </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p> A Target with no Selector indicates that the annotation applies to the entire
+                    target resource. </p>
+                <section>
 
-			<h4 id="1-3-1-source"> Source </h4>
-			<p> The target resource MUST be identified by the URL of an existing resource in the
-				EPUB package. It MUST be one of the `item/@href` values of the [^manifest^] element as
-                defined in [[epub-34]].</p>
+                    <h4 id="1-3-1-source"> Source </h4>
+                    <p> The target resource MUST be identified by the URL of an existing resource in the
+                        EPUB package. It MUST be one of the `item/@href` values of the [^manifest^] element as
+                        defined in [[epub-34]].</p>
 
-                <aside class="example" title=" the source of the annotation is the relative URL identifying an HTML document in an EPUB">
-				<pre>
+                    <aside class="example"
+                        title=" the source of the annotation is the relative URL identifying an HTML document in an EPUB">
+                        <pre>
                 {
                     "@context": "https://www.w3.org/ns/epub-anno.jsonld",
                     "type": "Annotation",
@@ -349,371 +370,405 @@
                     }
                 }
 				</pre>
-                </aside>
-            </section>
+                    </aside>
+                </section>
 
-            <section>
-			<h4 id="1-3-2-selector">Selector</h4>
+                <section>
+                    <h4 id="1-3-2-selector">Selector</h4>
 
-			<p>
-                An annotation refers to a segment of a resource, which is identified by one or more
-                <a data-cite="annotation-model#selectors">Selectors</a>.
-				The nature of the Selectors and methods to describe segments depend on
-				the resource type. Providing more than one Selectors allows an annotation software to
-				choose the most accurate selector from those it can handle and helps to accommodate
-				evolutions on the annotated resource.
-            </p>
-			<p>
-                Several annotation selectors are specified in the
-                <a data-cite="annotation-model#selectors">Web Annotation Data Model</a>.
-				This specification retains selectors (with possible restrictions) deemed useful for
-                annotating EPUB publications, and details on how to use these selectors.
-                <!-- It also defines new selectors as needed. -->
-            </p>
-			<!-- <p class="note">
+                    <p>
+                        An annotation refers to a segment of a resource, which is identified by one or more
+                        <a data-cite="annotation-model#selectors">Selectors</a>.
+                        The nature of the Selectors and methods to describe segments depend on
+                        the resource type. Providing more than one Selectors allows an annotation software to
+                        choose the most accurate selector from those it can handle and helps to accommodate
+                        evolutions on the annotated resource.
+                    </p>
+                    <p>
+                        Several annotation selectors are specified in the
+                        <a data-cite="annotation-model#selectors">Web Annotation Data Model</a>.
+                        This specification retains selectors (with possible restrictions) deemed useful for
+                        annotating EPUB publications, and details on how to use these selectors.
+                        <!-- It also defines new selectors as needed. -->
+                    </p>
+                    <!-- <p class="note">
                 New selectors will undoubtedly be defined in the coming months after
 				discussion with members of the W3C Publishing Maintenance Working Group.
             </p> -->
 
-            <section>
-                <h5>Fragment Selector</h5>
-                <p>
-                    The <dfn>Fragment Selector object</dfn> uses the fragment part of an URL defined by the
-                    representation's media type. This object is identical in structure to the
-                    <a data-cite="annotation-model#fragment-selector">Fragment Selector</a> defined by [[[annotation-model]]],
-                    except that it restricts the media types it uses.
-                </p>
+                    <section>
+                        <h5>Fragment Selector</h5>
+                        <p>
+                            The <dfn>Fragment Selector object</dfn> uses the fragment part of an URL defined by the
+                            representation's media type. This object is identical in structure to the
+                            <a data-cite="annotation-model#fragment-selector">Fragment Selector</a> defined by
+                            [[[annotation-model]]],
+                            except that it restricts the media types it uses.
+                        </p>
 
-                <table class="zebra">
-                    <thead>
-                        <tr>
-                            <th> Name </th>
-                            <th> Description </th>
-                            <th> Format </th>
-                            <th> Required? </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <code> type </code>
-                            </td>
-                            <td>The RDF structure type. It MUST be "FragmentSelector".</td>
-                            <td> string </td>
-                            <td> Yes </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <code>value</code> </code>
-                            </td>
-                            <td>The contents of the fragment component of an URL that describes the selection.
-                            The selector MUST have exactly 1 <code>value</code> property.</td>
-                            <td> string </td>
-                            <td> Yes </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <dfn>conformsTo</dfn> </code>
-                            </td>
-                            <td>
-                                Provides the reference to the specification that defines the syntax of the URL fragment in the
-                                <code>value</code> property. The selector SHOULD have exactly 1 conformsTo link to
-                                the specification that defines the syntax of the fragment and MUST NOT have more than 1.
-                            </td>
-                            <td>
-                                One of the URL strings listed in the table below.
-                            </td>
-                            <td> No </td>
-                        </tr>
-                    </tbody>
-                </table>
+                        <table class="zebra">
+                            <thead>
+                                <tr>
+                                    <th> Name </th>
+                                    <th> Description </th>
+                                    <th> Format </th>
+                                    <th> Required? </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <code> type </code>
+                                    </td>
+                                    <td>The RDF structure type. It MUST be "FragmentSelector".</td>
+                                    <td> string </td>
+                                    <td> Yes </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <code>value</code> </code>
+                                    </td>
+                                    <td>The contents of the fragment component of an URL that describes the selection.
+                                        The selector MUST have exactly 1 <code>value</code> property.</td>
+                                    <td> string </td>
+                                    <td> Yes </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <dfn>conformsTo</dfn> </code>
+                                    </td>
+                                    <td>
+                                        Provides the reference to the specification that defines the syntax of the URL
+                                        fragment in the
+                                        <code>value</code> property. The selector SHOULD have exactly 1 conformsTo link
+                                        to
+                                        the specification that defines the syntax of the fragment and MUST NOT have more
+                                        than 1.
+                                    </td>
+                                    <td>
+                                        One of the URL strings listed in the table below.
+                                    </td>
+                                    <td> No </td>
+                                </tr>
+                            </tbody>
+                        </table>
 
-                <p>
-                    The following URLs are the specifications that define the semantics of fragments, and hence may be used with the
-                    [^conformsTo^] property. Other URLs MUST NOT be used.
-                </p>
+                        <p>
+                            The following URLs are the specifications that define the semantics of fragments, and hence
+                            may be used with the
+                            [^conformsTo^] property. Other URLs MUST NOT be used.
+                        </p>
 
-                <table id="#tbl-core-media-types">
-                    <thead>
-                        <th>Name</th>
-                        <th>Fragment Specification</th>
-                        <th>Description</th>
-                    </thead>
-                    <tbody>
-                        <tr id="HTML_fragment_format">
-                            <td>HTML</td>
-                            <td>http://tools.ietf.org/rfc/rfc3236</td>
-                            <td>[[rfc3236]]. Example: <code>namedSection</code></td>
-                        </tr>
-                        <tr id="media_fragment_format">
-                            <td>Media</td>
-                            <td>http://www.w3.org/TR/media-frags/</td>
-                            <td>[[media-frags]]. Example: <code>xywh=50,50,640,480</code> or <code>t=10,20</code></td>
-                        </tr>
-                        <tr id="SVG_fragment_format">
-                            <td>SVG</td>
-                            <td>http://www.w3.org/TR/SVG/</td>
-                            <td>[[svg11]]. Example: <code>svgView(viewBox(50,50,640,480))</code></td>
-                        </tr>
-                        <tr id="text_fragment_format">
-                            <td>Text fragment</td>
-                            <td>https://wicg.github.io/scroll-to-text-fragment/</td>
-                            <td>[[scroll-to-text-fragment]]. Example: <code>:~:text=an%20example,text%20fragment</code></td>
-                        </tr>
-                     </tbody>
-                </table>
+                        <table id="#tbl-core-media-types">
+                            <thead>
+                                <th>Name</th>
+                                <th>Fragment Specification</th>
+                                <th>Description</th>
+                            </thead>
+                            <tbody>
+                                <tr id="HTML_fragment_format">
+                                    <td>HTML</td>
+                                    <td>http://tools.ietf.org/rfc/rfc3236</td>
+                                    <td>[[rfc3236]]. Example: <code>namedSection</code></td>
+                                </tr>
+                                <tr id="media_fragment_format">
+                                    <td>Media</td>
+                                    <td>http://www.w3.org/TR/media-frags/</td>
+                                    <td>[[media-frags]]. Example: <code>xywh=50,50,640,480</code> or
+                                        <code>t=10,20</code></td>
+                                </tr>
+                                <tr id="SVG_fragment_format">
+                                    <td>SVG</td>
+                                    <td>http://www.w3.org/TR/SVG/</td>
+                                    <td>[[svg11]]. Example: <code>svgView(viewBox(50,50,640,480))</code></td>
+                                </tr>
+                                <tr id="text_fragment_format">
+                                    <td>Text fragment</td>
+                                    <td>https://wicg.github.io/scroll-to-text-fragment/</td>
+                                    <td>[[scroll-to-text-fragment]]. Example:
+                                        <code>:~:text=an%20example,text%20fragment</code></td>
+                                </tr>
+                            </tbody>
+                        </table>
 
-                <p>The integration of text fragments into the specification is AT RISK.</p>
+                        <p>The integration of text fragments into the specification is AT RISK.</p>
 
-                <div class="caution">
-                    <p>
-                        This selector, used with text fragments, must be used with great care when the number
-                        of characters that can be copied from the publication is constrained by the publisher.
-                    </p>
-                </div>
+                        <div class="caution">
+                            <p>
+                                This selector, used with text fragments, must be used with great care when the number
+                                of characters that can be copied from the publication is constrained by the publisher.
+                            </p>
+                        </div>
 
-                <div class="issue">
-                    <p>
-                        The reason the integration of text fragments into the specification is at risk is two-fold.
-                    </p>
+                        <div class="issue">
+                            <p>
+                                The reason the integration of text fragments into the specification is at risk is
+                                two-fold.
+                            </p>
 
-                    <ol>
-                        <li>
-                            The specification is currently a Draft Community Group Report. While there is an activity to include it into
-                            the HTML Standard [[html]], this is still ongoing. In may not be finalized by the time this specification goes
-                            to Recommendation.
-                            See also <a href="https://github.com/whatwg/html/pull/11895">whatwg#11895</a>.
-                        </li>
-                        <li>
-                            The integration of text fragments selector in reading systems is very challenging:
-                            the absence of a standard API in web browsers makes mapping a text fragment to a DOM Range difficult.
-                            Rebuilding a DOM range from a textual range using tree walking is suboptimal,
-                            and the existing polyfills are not well-maintained. This fragment specification cannot be
-                            retained unless a public API is defined and implemented in major web browsers.
-                            See also <a href="https://github.com/whatwg/html/issues/8282">whatwg#8282</a>
-                        </li>
-                    </ol>
-                </div>
-            </section>
+                            <ol>
+                                <li>
+                                    The specification is currently a Draft Community Group Report. While there is an
+                                    activity to include it into the HTML Standard [[html]], this is still ongoing.
+                                    It may not be finalized by the time this specification goes to Recommendation.
+                                    See also <a href="https://github.com/whatwg/html/pull/11895">whatwg#11895</a>.
+                                </li>
+                                <li>
+                                    The integration of text fragments selector in reading systems is very challenging:
+                                    the absence of a standard API in web browsers makes mapping a text fragment to
+                                    a DOM Range difficult.
+                                    Rebuilding a DOM range from a textual range using tree walking is suboptimal,
+                                    and the existing polyfills are not well-maintained. This fragment specification
+                                    cannot be retained unless a public API is defined and implemented in major web browsers.
+                                    See also <a href="https://github.com/whatwg/html/issues/8282">whatwg#8282</a>
+                                </li>
+                            </ol>
+                        </div>
+                    </section>
 
-            <section class="informative">
-                <h5>CSS Selector</h5>
-                <p>
-                    One of the most common ways to select elements in the HTML Document Object Model is to use CSS Selectors
-                    [[CSS3-selectors]]. This specification reuses the <a data-cite="annotation-model#css-selector"><code>CssSelector</code></a>, as defined in the [[[annotation-model]]] specification, but lists it here for an easier readability.
-                </p>
+                    <section class="informative">
+                        <h5>CSS Selector</h5>
+                        <p>
+                            One of the most common ways to select elements in the HTML Document Object Model is to use
+                            CSS Selectors [[CSS3-selectors]]. This specification reuses the <a
+                                data-cite="annotation-model#css-selector"><code>CssSelector</code></a>, as defined in
+                            the [[[annotation-model]]] specification, but lists it here for an easier readability.
+                        </p>
 
-                <table class="zebra">
-                    <thead>
-                        <tr>
-                            <th> Name </th>
-                            <th> Description </th>
-                            <th> Format </th>
-                            <th> Required? </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <code> type </code>
-                            </td>
-                            <td>The RDF structure type. It must be "CssSelector".</td>
-                            <td> string </td>
-                            <td> Yes </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <code>value</code> </code>
-                            </td>
-                            <td>The CSS selection path to the target.
-                                The selector must have exactly 1 <code>value</code> property.</td>
-                            <td> string </td>
-                            <td> Yes </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
+                        <table class="zebra">
+                            <thead>
+                                <tr>
+                                    <th> Name </th>
+                                    <th> Description </th>
+                                    <th> Format </th>
+                                    <th> Required? </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <code> type </code>
+                                    </td>
+                                    <td>The RDF structure type. It must be "CssSelector".</td>
+                                    <td> string </td>
+                                    <td> Yes </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <code>value</code> </code>
+                                    </td>
+                                    <td>The CSS selection path to the target.
+                                        The selector must have exactly 1 <code>value</code> property.</td>
+                                    <td> string </td>
+                                    <td> Yes </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
 
-            <section class="informative">
-                <h5>Text Quote Selector</h5>
-                <p>
-                    This Selector describes a range of text by copying it, and including some of the text immediately before (a prefix) and
-                    after (a suffix) it to distinguish between multiple copies of the same sequence of characters.
-                    This specification reuses the <a data-cite="annotation-model#text-quote-selector"><code>TextQuoteSelector</code></a>,
-                    as defined in the [[[annotation-model]]] specification, but lists it here for an easier readability.
-                </p>
-                <p>
-                    The selection of the text must be in terms of unicode code points (the "character number").
-                </p>
-                <table class="zebra">
-                    <thead>
-                        <tr>
-                            <th> Name </th>
-                            <th> Description </th>
-                            <th> Format </th>
-                            <th> Required? </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <code> type </code>
-                            </td>
-                            <td>The RDF structure type. It must be "TextQuoteSelector".</td>
-                            <td> string </td>
-                            <td> Yes </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <code>exact</code> </code>
-                            </td>
-                            <td>
-                                A copy of the text which is being selected, after normalization.
-                                Each <code>TextQuoteSelector</code> must have exactly 1 <code>exact</code> property.
-                            </td>
-                            <td> string </td>
-                            <td> Yes </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <code>prefix</code> </code>
-                            </td>
-                            <td>
-                                A snippet of text that occurs immediately before the text which is being selected.
-                                Each <code>TextQuoteSelector</code> should have exactly 1 <code>prefix</code> property, and must not have more than 1.
-                            </td>
-                            <td> string </td>
-                            <td> No </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <code>suffix</code> </code>
-                            </td>
-                            <td>
-                                A snippet of text that occurs immediately after the text which is being selected.
-                                Each <code>TextQuoteSelector</code> SHOULD have exactly 1 <code>suffix</code> property, and MUST NOT have more
-                                than 1.
-                            </td>
-                            <td> string </td>
-                            <td> No </td>
-                        </tr>
-                    </tbody>
-                </table>
+                    <section class="informative">
+                        <h5>Text Quote Selector</h5>
+                        <p>
+                            This Selector describes a range of text by copying it, and including some of the text
+                            immediately before (a prefix) and after (a suffix) it to distinguish between multiple
+                            copies of the same sequence of characters.
+                            This specification reuses the <a
+                                data-cite="annotation-model#text-quote-selector"><code>TextQuoteSelector</code></a>,
+                            as defined in the [[[annotation-model]]] specification, but lists it here for an easier
+                            readability.
+                        </p>
+                        <p>
+                            The selection of the text must be in terms of unicode code points (the "character number").
+                        </p>
+                        <table class="zebra">
+                            <thead>
+                                <tr>
+                                    <th> Name </th>
+                                    <th> Description </th>
+                                    <th> Format </th>
+                                    <th> Required? </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <code> type </code>
+                                    </td>
+                                    <td>The RDF structure type. It must be "TextQuoteSelector".</td>
+                                    <td> string </td>
+                                    <td> Yes </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <code>exact</code> </code>
+                                    </td>
+                                    <td>
+                                        A copy of the text which is being selected, after normalization.
+                                        Each <code>TextQuoteSelector</code> must have exactly 1 <code>exact</code>
+                                        property.
+                                    </td>
+                                    <td> string </td>
+                                    <td> Yes </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <code>prefix</code> </code>
+                                    </td>
+                                    <td>
+                                        A snippet of text that occurs immediately before the text which is being
+                                        selected.
+                                        Each <code>TextQuoteSelector</code> should have exactly 1 <code>prefix</code>
+                                        property, and must not have more than 1.
+                                    </td>
+                                    <td> string </td>
+                                    <td> No </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <code>suffix</code> </code>
+                                    </td>
+                                    <td>
+                                        A snippet of text that occurs immediately after the text which is being
+                                        selected.
+                                        Each <code>TextQuoteSelector</code> SHOULD have exactly 1 <code>suffix</code>
+                                        property, and MUST NOT have more than 1.
+                                    </td>
+                                    <td> string </td>
+                                    <td> No </td>
+                                </tr>
+                            </tbody>
+                        </table>
 
-                <p class="note">
-                    This selector is equivalent to the usage of a [^Fragment Selector object^] conforming to <a href="#text_fragment_format">Text Fragments</a>. The advantage of using this selector
-                    is that there is no need for the percent-encoding of the exact, prefix, and suffix texts.
-                </p>
-                <p class="issue">
-                    See the caveats on using text fragments in the section on <a href="#fragment-selector">Fragment Selectors</a>.
-                </p>
-            </section>
+                        <p class="note">
+                            This selector is equivalent to the usage of a [^Fragment Selector object^] conforming to <a
+                                href="#text_fragment_format">Text Fragments</a>. The advantage of using this selector
+                            is that there is no need for the percent-encoding of the exact, prefix, and suffix texts.
+                        </p>
+                        <p class="issue">
+                            See the caveats on using text fragments in the section on <a
+                                href="#fragment-selector">Fragment Selectors</a>.
+                        </p>
+                    </section>
 
-            <section class="informative">
-                <h5>Text Position Selector</h5>
-                <p>
-                    This Selector describes a range of text by recording the start and end positions of the selection in the stream.
-                    Position 0 would be immediately before the first character, position 1 would be immediately before the second character,
-                    and so on. The start character is thus included in the list, but the end character is not.
-                    This specification reuses the <a data-cite="annotation-model#text-position-selector"><code>TextPositionSelector</code></a>,
-                    as defined in the [[[annotation-model]]] specification, but lists it here for an easier readability.
-                </p>
-                <p>
-                    For HTML content, the stream of characters correspond to the output
-                    of the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute"><code>innerText</code>
-                    attribute</a> on the <code>body</code> element. The selection of the text must be in terms of unicode code points (the "character number").
-                    Selections should not start or end in the middle of a grapheme cluster.
-                    The selection must be based on the logical order of the text, rather than the visual
-                    order, especially for bidirectional text.
-                </p>
-                <table class="zebra">
-                    <thead>
-                        <tr>
-                            <th> Name </th>
-                            <th> Description </th>
-                            <th> Format </th>
-                            <th> Required? </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <code> type </code>
-                            </td>
-                            <td>The RDF structure type. It must be "TextPositionSelector".</td>
-                            <td> string </td>
-                            <td> Yes </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <code>start</code> </code>
-                            </td>
-                            <td>
-                                The starting position of the segment of text. The first character in the full text is character position 0, and the
-                                character is included within the segment.
-                                Each <code>TextPositionSelector</code> must have exactly 1 <code>start</code> property, and the value must be a non-negative integer.
-                            </td>
-                            <td> non-negative integer </td>
-                            <td> Yes </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> <code>end</code> </code>
-                            </td>
-                            <td>
-                                The end position of the segment of text. The character is not included within the segment.
-                                Each <code>TextPositionSelector</code> must have exactly 1 <code>end</code> property, and the value must be a
-                                non-negative integer.
-                            </td>
-                            <td> non-negative integer </td>
-                            <td> Yes </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
+                    <section class="informative">
+                        <h5>Text Position Selector</h5>
+                        <p>
+                            This Selector describes a range of text by recording the start and end positions of the
+                            selection in the stream.
+                            Position 0 would be immediately before the first character, position 1 would be immediately
+                            before the second character, and so on.
+                            The start character is thus included in the list, but the end character is not.
+                            This specification reuses the <a
+                                data-cite="annotation-model#text-position-selector"><code>TextPositionSelector</code></a>,
+                            as defined in the [[[annotation-model]]] specification, but lists it here for an easier
+                            readability.
+                        </p>
+                        <p>
+                            For HTML content, the stream of characters correspond to the output
+                            of the <a
+                                href="https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute"><code>innerText</code>
+                                attribute</a> on the <code>body</code> element. The selection of the text must be in
+                            terms of unicode code points (the "character number").
+                            Selections should not start or end in the middle of a grapheme cluster.
+                            The selection must be based on the logical order of the text, rather than the visual
+                            order, especially for bidirectional text.
+                        </p>
+                        <table class="zebra">
+                            <thead>
+                                <tr>
+                                    <th> Name </th>
+                                    <th> Description </th>
+                                    <th> Format </th>
+                                    <th> Required? </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <code> type </code>
+                                    </td>
+                                    <td>The RDF structure type. It must be "TextPositionSelector".</td>
+                                    <td> string </td>
+                                    <td> Yes </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <code>start</code> </code>
+                                    </td>
+                                    <td>
+                                        The starting position of the segment of text. The first character in the full
+                                        text is character position 0, and the character is included within the segment.
+                                        Each <code>TextPositionSelector</code> must have exactly 1 <code>start</code>
+                                        property, and the value must be a non-negative integer.
+                                    </td>
+                                    <td> non-negative integer </td>
+                                    <td> Yes </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <code> <code>end</code> </code>
+                                    </td>
+                                    <td>
+                                        The end position of the segment of text. The character is not included within
+                                        the segment.
+                                        Each <code>TextPositionSelector</code> must have exactly 1 <code>end</code>
+                                        property, and the value must be a non-negative integer.
+                                    </td>
+                                    <td> non-negative integer </td>
+                                    <td> Yes </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
 
-            <section>
-                <h5>Refinement of Selection</h5>
-                <p>
-                    It may be easier, more reliable, or more accurate to specify the segment of interest of a resource as a selection of a
-                    selection, rather than as a selection of the complete resource. This is accomplished by having selectors chained together,
-                    where each refines the results of the previous one.
-                </p>
-                <p>
-                    The [[[annotation-model]]] specification defines the <a data-cite="annotation-model#refinement-of-selection"><code>refinedBy</code></a> property. This specification restricts the possible values of the property to include only those selectors that are specified by, or listed in this specification.
-                </p>
-                <table class="zebra">
-                    <thead>
-                        <tr>
-                            <th> Name </th>
-                            <th> Description </th>
-                            <th> Format </th>
-                            <th> Required? </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <dfn>refinedBy</dfn>
-                            </td>
-                            <td>
-                                The relationship between a broader selector and the more specific selector that SHOULD be applied to the results of the
-                                first. A Selector MAY be refined by 1 or more other Selectors. If more than 1 is given, then they are considered to be
-                                alternatives that will result in the same selection.
-                            </td>
-                            <td> "FragmentSelector" | <br/>
-                                "CssSelector" | <br/>
-                                "TextQuoteSelector" | <br/>
-                                "TextPositionSelector"<br/>
-                            </td>
-                            <td> No </td>
-                        </tr>
-                    </tbody>
-                </table>
+                    <section>
+                        <h5>Refinement of Selection</h5>
+                        <p>
+                            It may be easier, more reliable, or more accurate to specify the segment of interest of a
+                            resource as a selection of a selection, rather than as a selection of the complete resource.
+                            This is accomplished by having selectors chained together, where each refines the results
+                            of the previous one.
+                        </p>
+                        <p>
+                            The [[[annotation-model]]] specification defines the <a
+                                data-cite="annotation-model#refinement-of-selection"><code>refinedBy</code></a>
+                            property. This specification restricts the possible values of the property to include only
+                            those selectors that are specified by, or listed in this specification.
+                        </p>
+                        <table class="zebra">
+                            <thead>
+                                <tr>
+                                    <th> Name </th>
+                                    <th> Description </th>
+                                    <th> Format </th>
+                                    <th> Required? </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <dfn>refinedBy</dfn>
+                                    </td>
+                                    <td>
+                                        The relationship between a broader selector and the more specific selector that
+                                        SHOULD be applied to the results of the first.
+                                        A Selector MAY be refined by 1 or more other Selectors. If more than 1 is
+                                        given, then they are considered to be alternatives that will result in
+                                        the same selection.
+                                    </td>
+                                    <td> "FragmentSelector" | <br />
+                                        "CssSelector" | <br />
+                                        "TextQuoteSelector" | <br />
+                                        "TextPositionSelector"<br />
+                                    </td>
+                                    <td> No </td>
+                                </tr>
+                            </tbody>
+                        </table>
 
 
-                <aside class="example" title=" a CSS Selector refined by a Text Position Selector">
-                    <pre>
+                        <aside class="example" title=" a CSS Selector refined by a Text Position Selector">
+                            <pre>
                         <code class="lang-json">
                             {
                                 "selector": [
@@ -730,10 +785,10 @@
                             }
                         </code>
                     </pre>
-                </aside>
-			<p>This selects "q" from "quick" as start position and
-				"x" from "fox" as end position in the following HTML snippet: </p>
-<pre>
+                        </aside>
+                        <p>This selects "q" from "quick" as start position and
+                            "x" from "fox" as end position in the following HTML snippet: </p>
+                        <pre>
 &lt;div id="intro">
     &lt;p>Some text.&lt;/p>
     &lt;p>The quick &lt;em>brown&lt;/em> fox jumps over the lazy dog.&lt;/p>
@@ -741,10 +796,10 @@
 &lt;/div>
 </pre>
 
-            </section>
+                    </section>
 
 
-			<!-- <h5 id="1-3-2-3-progressionselector"> ProgressionSelector </h5>
+                    <!-- <h5 id="1-3-2-3-progressionselector"> ProgressionSelector </h5>
 			<p>A ProgressionSelector contains a decimal value representing the annotation's
 				position as a percentage of the total size of the resource.</p>
 			<p>While such positioning is imprecise and does not correctly identify a fragment, it
@@ -772,7 +827,7 @@
 				 This would help synchronize annotations with publications distributed in a format
 				 different from reflowable EPUB, such as PDF. It would make sense to define it as Meta information (still to be defined)</p>  -->
 
-			<!--
+                    <!--
 			<h4 id="1-3-3-meta"> Meta </h4>
 			<p>Meta information MAY be added to an annotation as “breadcrumbs”, to ease the display
 				of contextual information relative to the global position of the annotation in the
@@ -869,96 +924,96 @@
 				</code>
 			</pre>
 			-->
-            </section>
+                </section>
             </section>
 
             <section>
 
-			<h3 id="1-4-body"> Body </h3>
-			<p>The <dfn>Body object</dfn> of an annotation contains plain text, style, and optional tags.</p>
-			<p>This document specifies the following sub-properties:</p>
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th> Name </th>
-						<th> Description </th>
-						<th> Format </th>
-						<th> Required? </th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code> type </code>
-						</td>
-						<td> The body type. It MUST be “TextualBody”. </td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> value </code>
-						</td>
-						<td> The textual content of the annotation. </td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> format </code>
-						</td>
-						<td> The media-type of the annotation value; "text/plain" by
-							default; "text/markdown" is recommended. </td>
-						<td> [[RFC6838]], [[RFC7763]] </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>color</dfn> </code>
-						</td>
-						<td> The color of the annotation; yellow by default. </td>
-						<td> "pink" | "orange" | "yellow" | "green" | "blue" | "purple" </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>highlight</dfn> </code>
-						</td>
-						<td> The style of the annotation; solid background by default. </td>
-						<td> "solid" | "underline" | "strikethrough" | "outline" </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> language </code>
-						</td>
-						<td> The language of the annotation. </td>
-						<td> [[BCP47]] </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> textDirection </code>
-						</td>
-						<td> The direction of the text; left-to-right by default. </td>
-						<td> "ltr" | "rtl" </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> <dfn>tags</dfn> </code>
-						</td>
-						<td> Free text categorizing the annotation. </td>
-						<td> Array of string </td>
-						<td> No </td>
-					</tr>
-				</tbody>
-			</table>
-			<p class="note">Read “Best practices for Reading Systems” about using tags in an
-				annotation. </p>
+                <h3 id="1-4-body"> Body </h3>
+                <p>The <dfn>Body object</dfn> of an annotation contains plain text, style, and optional tags.</p>
+                <p>This document specifies the following sub-properties:</p>
+                <table class="zebra">
+                    <thead>
+                        <tr>
+                            <th> Name </th>
+                            <th> Description </th>
+                            <th> Format </th>
+                            <th> Required? </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <code> type </code>
+                            </td>
+                            <td> The body type. It MUST be “TextualBody”. </td>
+                            <td> string </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> value </code>
+                            </td>
+                            <td> The textual content of the annotation. </td>
+                            <td> string </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> format </code>
+                            </td>
+                            <td> The media-type of the annotation value; "text/plain" by
+                                default; "text/markdown" is recommended. </td>
+                            <td> [[RFC6838]], [[RFC7763]] </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>color</dfn> </code>
+                            </td>
+                            <td> The color of the annotation; yellow by default. </td>
+                            <td> "pink" | "orange" | "yellow" | "green" | "blue" | "purple" </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>highlight</dfn> </code>
+                            </td>
+                            <td> The style of the annotation; solid background by default. </td>
+                            <td> "solid" | "underline" | "strikethrough" | "outline" </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> language </code>
+                            </td>
+                            <td> The language of the annotation. </td>
+                            <td> [[BCP47]] </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> textDirection </code>
+                            </td>
+                            <td> The direction of the text; left-to-right by default. </td>
+                            <td> "ltr" | "rtl" </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> <dfn>tags</dfn> </code>
+                            </td>
+                            <td> Free text categorizing the annotation. </td>
+                            <td> Array of string </td>
+                            <td> No </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p class="note">Read “Best practices for Reading Systems” about using tags in an
+                    annotation. </p>
 
-            <aside class="example" title="An annotation Body">
-			<pre>
+                <aside class="example" title="An annotation Body">
+                    <pre>
 					{
                       "@context": "https://www.w3.org/ns/epub-anno.jsonld",,
 					  "type": "Annotation",
@@ -972,215 +1027,217 @@
 					  }
 					}
 			</pre>
-            </aside>
+                </aside>
             </section>
-		</section>
+        </section>
 
-		<section>
-			<h2 id="2-annotation-set"> Annotation Set </h2>
-			<p>An Annotation Set is an unordered collection of annotations.</p>
+        <section>
+            <h2 id="2-annotation-set"> Annotation Set </h2>
+            <p>An Annotation Set is an unordered collection of annotations.</p>
 
-			<p>An Annotation does not contain information about its associated publication. If a
-				set of annotations is shared as a detached file, it is mandatory to also export
-				information that will help find the associated publication even if the publication
-				is not adequately identified.</p>
+            <p>An Annotation does not contain information about its associated publication. If a
+                set of annotations is shared as a detached file, it is mandatory to also export
+                information that will help find the associated publication even if the publication
+                is not adequately identified.</p>
 
-			<p class="note">The <a data-cite="annotation-model#annotation-collection"><code>AnnotationCollection</code></a> defined
+            <p class="note">The <a
+                    data-cite="annotation-model#annotation-collection"><code>AnnotationCollection</code></a> defined
                 in the [[[annotation-model]]] does not provide an adequate
-				structure for sharing annotations either as a detached file or as a file embedded in
-				a Zip package. The <code>AnnotationCollection</code> provides a
-				way to retrieve annotations via a REST API and is, therefore, intrinsically paginated.</p>
+                structure for sharing annotations either as a detached file or as a file embedded in
+                a Zip package. The <code>AnnotationCollection</code> provides a
+                way to retrieve annotations via a REST API and is, therefore, intrinsically paginated.</p>
 
-			<p> The <dfn>AnnotationSet</dfn> contains: </p>
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th> Name </th>
-						<th> Description </th>
-						<th> Format </th>
-						<th> Required? </th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code> id </code>
-						</td>
-						<td> The identity of the annotation set. A uuid formatted as a URN is
-							RECOMMENDED. </td>
-						<td> URL </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> type </code>
-						</td>
-						<td> It MUST be <code>AnnotationSet</code>. </td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code><dfn>generator</dfn></code>
-						</td>
-						<td> The agent responsible for the generation of the object serialization. </td>
-						<td> [=Generator=] </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code><dfn>about</dfn></code>
-						</td>
-						<td> Information relative to the publication. </td>
-						<td> [=About=] </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code>generated</code>
-						</td>
-						<td> The time when the set was generated. </td>
-						<td> ISO 8601 datetime </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code><dfn>title</dfn></code>
-						</td>
-						<td> A title to help identifying the set. </td>
-						<td> string </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code><dfn>items</dfn></code>
-						</td>
-						<td> The annotations of the set. </td>
-						<td> Array of Annotation objects </td>
-						<td> Yes </td>
-					</tr>
-				</tbody>
-			</table>
+            <p> The <dfn>AnnotationSet</dfn> contains: </p>
+            <table class="zebra">
+                <thead>
+                    <tr>
+                        <th> Name </th>
+                        <th> Description </th>
+                        <th> Format </th>
+                        <th> Required? </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <code> id </code>
+                        </td>
+                        <td> The identity of the annotation set. A uuid formatted as a URN is
+                            RECOMMENDED. </td>
+                        <td> URL </td>
+                        <td> Yes </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code> type </code>
+                        </td>
+                        <td> It MUST be <code>AnnotationSet</code>. </td>
+                        <td> string </td>
+                        <td> Yes </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code><dfn>generator</dfn></code>
+                        </td>
+                        <td> The agent responsible for the generation of the object serialization. </td>
+                        <td> [=Generator=] </td>
+                        <td> No </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code><dfn>about</dfn></code>
+                        </td>
+                        <td> Information relative to the publication. </td>
+                        <td> [=About=] </td>
+                        <td> Yes </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>generated</code>
+                        </td>
+                        <td> The time when the set was generated. </td>
+                        <td> ISO 8601 datetime </td>
+                        <td> No </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code><dfn>title</dfn></code>
+                        </td>
+                        <td> A title to help identifying the set. </td>
+                        <td> string </td>
+                        <td> No </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code><dfn>items</dfn></code>
+                        </td>
+                        <td> The annotations of the set. </td>
+                        <td> Array of Annotation objects </td>
+                        <td> Yes </td>
+                    </tr>
+                </tbody>
+            </table>
 
             <section>
-			<h3 id="2-1-generator"> Generator </h3>
-			<p>The <dfn>Generator object</dfn> contains information relative to the software from which the
-				serialized annotation has been produced.</p>
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th> Name </th>
-						<th> Description </th>
-						<th> Format </th>
-						<th> Required? </th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code> id </code>
-						</td>
-						<td> The identity of the generator software. The recommended value is the
-							GitHub URL of the application source code. </td>
-						<td> URL </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> type </code>
-						</td>
-						<td> The RDF type. It MUST be "Software". </td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> name </code>
-						</td>
-						<td> The name of the generator software. </td>
-						<td> string </td>
-						<td> Yes </td>
-					</tr>
-					<tr>
-						<td>
-							<code> homepage </code>
-						</td>
-						<td> The home page presenting the generator software. </td>
-						<td> URL </td>
-						<td> No </td>
-					</tr>
-				</tbody>
-			</table>
+                <h3 id="2-1-generator"> Generator </h3>
+                <p>The <dfn>Generator object</dfn> contains information relative to the software from which the
+                    serialized annotation has been produced.</p>
+                <table class="zebra">
+                    <thead>
+                        <tr>
+                            <th> Name </th>
+                            <th> Description </th>
+                            <th> Format </th>
+                            <th> Required? </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <code> id </code>
+                            </td>
+                            <td> The identity of the generator software. The recommended value is the
+                                GitHub URL of the application source code. </td>
+                            <td> URL </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> type </code>
+                            </td>
+                            <td> The RDF type. It MUST be "Software". </td>
+                            <td> string </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> name </code>
+                            </td>
+                            <td> The name of the generator software. </td>
+                            <td> string </td>
+                            <td> Yes </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> homepage </code>
+                            </td>
+                            <td> The home page presenting the generator software. </td>
+                            <td> URL </td>
+                            <td> No </td>
+                        </tr>
+                    </tbody>
+                </table>
             </section>
             <section>
-			<h3 id="2-2-about"> About </h3>
-			<p> The <dfn>About object</dfn> contains information relative to the publication. Such metadata is
-				intended to help associate an annotation set with a publication: </p>
-			<table class="zebra">
-				<thead>
-					<tr>
-						<th> Name </th>
-						<th> Description </th>
-						<th> Format </th>
-						<th> Required? </th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code> dc:identifier </code>
-						</td>
-						<td> Publication identifiers. An ISBN is preferred. </td>
-						<td> Array of strings </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> dc:title </code>
-						</td>
-						<td> The title of the publication. </td>
-						<td> string </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> dc:format </code>
-						</td>
-						<td> The media type of the publication. </td>
-						<td> string </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> dc:publisher </code>
-						</td>
-						<td> The name of the publisher. </td>
-						<td> string </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> dc:creator </code>
-						</td>
-						<td> The author(s) of the publication. </td>
-						<td> array of strings </td>
-						<td> No </td>
-					</tr>
-					<tr>
-						<td>
-							<code> dc:date </code>
-						</td>
-						<td> The release year. </td>
-						<td> calendar year using four digits </td>
-						<td> No </td>
-					</tr>
-				</tbody>
-			</table>
-			<p class="note"> All properties are from the Dublin Core Vocabulary [[dcterms]], also referenced
-				in the [[[annotation-model]]] as well as in the EPUB <a data-cite="epub-34#sec-pkg-metadata">package document metadata</a>. </p>
+                <h3 id="2-2-about"> About </h3>
+                <p> The <dfn>About object</dfn> contains information relative to the publication. Such metadata is
+                    intended to help associate an annotation set with a publication: </p>
+                <table class="zebra">
+                    <thead>
+                        <tr>
+                            <th> Name </th>
+                            <th> Description </th>
+                            <th> Format </th>
+                            <th> Required? </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <code> dc:identifier </code>
+                            </td>
+                            <td> Publication identifiers. An ISBN is preferred. </td>
+                            <td> Array of strings </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> dc:title </code>
+                            </td>
+                            <td> The title of the publication. </td>
+                            <td> string </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> dc:format </code>
+                            </td>
+                            <td> The media type of the publication. </td>
+                            <td> string </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> dc:publisher </code>
+                            </td>
+                            <td> The name of the publisher. </td>
+                            <td> string </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> dc:creator </code>
+                            </td>
+                            <td> The author(s) of the publication. </td>
+                            <td> array of strings </td>
+                            <td> No </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <code> dc:date </code>
+                            </td>
+                            <td> The release year. </td>
+                            <td> calendar year using four digits </td>
+                            <td> No </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p class="note"> All properties are from the Dublin Core Vocabulary [[dcterms]], also referenced
+                    in the [[[annotation-model]]] as well as in the EPUB <a data-cite="epub-34#sec-pkg-metadata">package
+                        document metadata</a>. </p>
 
-			<aside class="example" title="An AnnotationSet containing one annotation">
-			<pre>
+                <aside class="example" title="An AnnotationSet containing one annotation">
+                    <pre>
     {
         "@context": "https://www.w3.org/ns/epub-anno.jsonld",
         "id": "urn:uuid:123-123-123-123",
@@ -1209,17 +1266,19 @@
             }
         ]
     }</pre>
-            </aside>
+                </aside>
             </section>
         </section>
         <section>
 
-			<h3 id="2-3-serialization"> Serialization </h3>
+            <h3 id="2-3-serialization"> Serialization </h3>
             <p>
                 Following the [[[annotation-model]]] [[annotation-model]] specification, EPUB Annotations are
                 expressed as a "shape" of JSON-LD [[json-ld11]] (a variant of JSON [[ecma-404]] for linked data).
-                The shape is informally defined through a JSON Schema [[json-schema]]; see <a href="#5-json-schema"></a> for further details.
-                The media type of this format is <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>
+                The shape is informally defined through a JSON Schema [[json-schema]]; see <a href="#5-json-schema"></a>
+                for further details.
+                The media type of this format is
+                <code>application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"</code>
             </p>
 
             <p> This specification introduces a dedicated file extension for serialized
@@ -1227,11 +1286,12 @@
             </p>
 
             <p>
-                Following the requirements of JSON-LD, each annotation file (whether a single annotation or an annotation set) MUST
-                start with a context declaration referring to the following, EPUB Annotation specific context:
-                <code>https://www.w3.org/ns/epub-anno.jsonld</code>.
-                This context file imports (using the <a data-cite="json-ld11#imported-contexts">imported contexts</a> feature of JSON-LD)
-                the "core" context file of the [[[annotation-model]]] [[annotation-model]], i.e., <code>https://www.w3.org/ns/anno.jsonld</code>.
+                Following the requirements of JSON-LD, each annotation file (whether a single annotation or an
+                annotation set) MUST start with a context declaration referring to the following, EPUB Annotation
+                specific context: <code>https://www.w3.org/ns/epub-anno.jsonld</code>.
+                This context file imports (using the <a data-cite="json-ld11#imported-contexts">imported contexts</a>
+                feature of JSON-LD) the "core" context file of the [[[annotation-model]]] [[annotation-model]], i.e.,
+                <code>https://www.w3.org/ns/anno.jsonld</code>.
                 The EPUB Annotation specific context file contains terms extending, an sometimes overriding the terms
                 in the core annotation context file, as defined in this specification.
             </p>
@@ -1247,111 +1307,112 @@
             </aside>
 
             <p class="note">
-                Implementations that do not rely on the linked data aspects of annotations may rely on bespoke processing
-                based on the shape of the annotation or the annotation set. Such implementations may safely ignore the context
+                Implementations that do not rely on the linked data aspects of annotations may rely on bespoke
+                processing based on the shape of the annotation or the annotation set.
+                Such implementations may safely ignore the context
                 declarations and are not required to dereference the respective URLs.
             </p>
-         </section>
+        </section>
 
-		<section>
-			<h1 id="3-embedding-annotations-in-publications"> Embedding annotations in
-				EPUB </h1>
+        <section>
+            <h1 id="3-embedding-annotations-in-publications"> Embedding annotations in
+                EPUB </h1>
 
-			<p> The OPTIONAL <code> my.annotation </code> file in the META-INF directory holds an
-				[=AnnotationSet=]. </p>
+            <p> The OPTIONAL <code> my.annotation </code> file in the META-INF directory holds an
+                [=AnnotationSet=]. </p>
             <section class="informative">
-			<h1 id="4-best-practices-for-reading-systems"> Best Practices for Reading Systems </h1>
+                <h1 id="4-best-practices-for-reading-systems"> Best Practices for Reading Systems </h1>
 
-            <p class="ednote">This section being informative, the MUST, SHOULD, etc, keyword are not appropriate here. At the minimum, they should be
-                turned into lower case.
-            </p>
+                <p class="ednote">This section being informative, the MUST, SHOULD, etc, keyword are not appropriate
+                    here. At the minimum, they should be turned into lower case.
+                </p>
 
-            <section>
-    			<h2 id="4-1-displaying-filtered-annotations"> Displaying filtered annotations </h2>
-    			<p> Reading systems should enable filtering by motivation, color, highlight mode, tag and
-    				creator. For instance, a user can display &quot;blue&quot; annotations only or
-    				“teacher” annotations only. Filtering on multiple criteria is a plus. </p>
+                <section>
+                    <h2 id="4-1-displaying-filtered-annotations"> Displaying filtered annotations </h2>
+                    <p> Reading systems should enable filtering by motivation, color, highlight mode, tag and
+                        creator. For instance, a user can display &quot;blue&quot; annotations only or
+                        “teacher” annotations only. Filtering on multiple criteria is a plus. </p>
 
-            </section>
+                </section>
 
-            <section>
-    			<h2 id="4-2-using-multiple-selectors"> Using multiple selectors </h2>
-    			<p> It is recommended that Reading Systems export multiple selectors, including at least
-    				one precise selector (e.g. CssSelector + TextPositionSelector)
-    				and one selector resistant to content modifications (e.g. ProgressionSelector). </p>
-    			<p> When displaying an annotation, a Reading System is free to use the most precise
-    				Selector available. It will select an alternative Selector as a fallback in case the
-    				preferred one does not return a correct position in the publication: this can happen
-    				if the publication has been modified after the annotation has been created. </p>
-    			<p> Not all selectors are equally easy to implement. Reading Systems MAY choose to
-    				support only a subset of the selectors defined in this specification. </p>
-    			<p> The W3C Publishing Maintenance Working Group is expected to define one or more selectors
-    				reading systems are required to implement, as a <i>lingua franca</i>. </p>
+                <section>
+                    <h2 id="4-2-using-multiple-selectors"> Using multiple selectors </h2>
+                    <p> It is recommended that Reading Systems export multiple selectors, including at least
+                        one precise selector (e.g. CssSelector + TextPositionSelector).
+                        <!-- and one selector resistant to content modifications (e.g. ProgressionSelector). -->
+                    </p>
+                    <p> When displaying an annotation, a Reading System is free to use the most precise
+                        Selector available. It will select an alternative Selector as a fallback in case the
+                        preferred one does not return a correct position in the publication: this can happen
+                        if the publication has been modified after the annotation has been created. </p>
+                    <p> Not all selectors are equally easy to implement. Reading Systems MAY choose to
+                        support only a subset of the selectors defined in this specification. </p>
+                    <p> The W3C Publishing Maintenance Working Group is expected to define one or more selectors
+                        reading systems are required to implement, as a <i>lingua franca</i>. </p>
 
-            </section>
+                </section>
 
-            <section>
-    			<h2 id="4-3-exporting-annotations-as-a-detached-file"> Exporting annotations as a
-    				detached file </h2>
-    			<p> When a user decides to export an annotation set from a reading system, he SHOULD be
-    				proposed to filter the annotations by tags (multiple choice). “Annotations with
-    				no tag” and “All annotations” SHOULD be proposed as options. The advantage of
-    				this practice is that, for instance, a user can export personal annotations (usually
-    				with no tag) and leave “teacher” annotations unexported. </p>
-    			<p> They MAY enter a title for the annotation set (empty by default). Such a title SHOULD
-    				become the exported filename. </p>
-    			<p> They MUST be able to choose the directory in which the annotation set will be stored. </p>
-    			<p> The file extension MUST be <code> .annotation </code> . </p>
-    			<p> The application may propose alternative formats at export time: an HTML or markdown format
-    				with human-friendly references to the location of each annotation may be handy. </p>
+                <section>
+                    <h2 id="4-3-exporting-annotations-as-a-detached-file"> Exporting annotations as a
+                        detached file </h2>
+                    <p> When a user decides to export an annotation set from a reading system, they SHOULD be
+                        proposed to filter the annotations by tags (multiple choice). “Annotations with
+                        no tag” and “All annotations” SHOULD be proposed as options. The advantage of
+                        this practice is that, for instance, a user can export personal annotations (usually
+                        with no tag) and leave “teacher” annotations unexported. </p>
+                    <p> They MAY enter a title for the annotation set (empty by default). Such a title SHOULD
+                        become the exported filename. </p>
+                    <p> They MUST be able to choose the directory in which the annotation set will be stored. </p>
+                    <p> The file extension MUST be <code> .annotation </code> . </p>
+                    <p> The application may propose alternative formats at export time: an HTML or markdown format
+                        with human-friendly references to the location of each annotation may be handy. </p>
 
-            </section>
-            <section>
-    			<h2 id="4-4-exporting-annotations-in-a-publication"> Exporting annotations in a
-    				publication </h2>
-    			<p> When a user decides to export a publication from the Reading System, he SHOULD be
-    				prompted to embed the annotations associated with the publication. </p>
-    			<p> If the user decides to embed annotations in a publication, he SHOULD be prompted to
-    				filter the annotations by tags (multiple choice). </p>
+                </section>
+                <section>
+                    <h2 id="4-4-exporting-annotations-in-a-publication"> Exporting annotations in a
+                        publication </h2>
+                    <p> When a user decides to export a publication from the Reading System, they SHOULD be
+                        prompted to embed the annotations associated with the publication. </p>
+                    <p> If the user decides to embed annotations in a publication, they SHOULD be prompted to
+                        filter the annotations by tags (multiple choice). </p>
 
-            </section>
-            <section>
-    			<h2 id="4-5-importing-annotations"> Importing annotations </h2>
-    			<p> To simplify associating annotations with a publication, a Reading System MUST
-    				offer a way to select a publication before selecting an annotation set. The drag and
-    				drop of an annotation set into a Reading System MAY also be proposed, but
-    				identifying the proper publication from the metadata in the annotation set is more
-    				complicated. </p>
-    			<p> When importing an annotation set, a Reading System SHOULD display a message with the
-    				title of the annotation set and the number of annotations in the set. The Reading
-    				System MUST offer the user the choice to abort the import. </p>
-    			<p> Each annotation is uniquely identified. If during the import of an annotation set,
-    				one or more annotations are re-imported, the Reading System MUST offer to the user
-    				the choice to override existing annotations or abort the import of the annotation
-    				set. </p>
+                </section>
+                <section>
+                    <h2 id="4-5-importing-annotations"> Importing annotations </h2>
+                    <p> To simplify associating annotations with a publication, a Reading System MUST
+                        offer a way to select a publication before selecting an annotation set. The drag and
+                        drop of an annotation set into a Reading System MAY also be proposed, but
+                        identifying the proper publication from the metadata in the annotation set is more
+                        complicated. </p>
+                    <p> When importing an annotation set, a Reading System SHOULD display a message with the
+                        title of the annotation set and the number of annotations in the set. The Reading
+                        System MUST offer the user the choice to abort the import. </p>
+                    <p> Each annotation is uniquely identified. If during the import of an annotation set,
+                        one or more annotations are re-imported, the Reading System MUST offer to the user
+                        the choice to override existing annotations or abort the import of the annotation
+                        set. </p>
 
-            </section>
-            <section>
-    			<h2 id="4-6-dealing-with-colors"> Dealing with colors </h2>
-    			<p> This document specifies a closed set of six colors chosen because of their
-    				extensive support in well-known reading systems. However, most existing reading apps
-    				offer a smaller set to their users. </p>
-    			<p> If an application imports annotations with a color it does not support, it should
-    				display them with a neutral color. The recommended neutral color is grey. </p>
-    			<p> Some applications may support colors not in the set defined by this specification
-    				(e.g. brown). In this case, a 1-to-1 substitution at export time is required (e.g.
-    				brown to orange). </p>
-    			<p> Note: we didn't spot applications with more than six annotation colors. </p>
-
-            </section>
+                </section>
+                <section>
+                    <h2 id="4-6-dealing-with-colors"> Dealing with colors </h2>
+                    <p> This document specifies a closed set of six colors chosen because of their
+                        extensive support in well-known reading systems. However, most existing reading apps
+                        offer a smaller set to their users. </p>
+                    <p> If an application imports annotations with a color it does not support, it should
+                        display them with a neutral color. The recommended neutral color is grey. </p>
+                    <p> Some applications may support colors not in the set defined by this specification
+                        (e.g. brown). In this case, a 1-to-1 substitution at export time is required (e.g.
+                        brown to orange). </p>
+                    <p class="note">We didn't spot applications with more than six annotation colors. </p>
+                </section>
             </section>
         </section>
 
-		<section>
-			<h1 id="5-json-schema"> JSON Schema </h1>
+        <section>
+            <h1 id="5-json-schema"> JSON Schema </h1>
 
             <p>T.B.D.</p>
-		</section>
+        </section>
 
         <section>
             <h1>Security and Privacy Considerations</h1>
@@ -1360,7 +1421,7 @@
         </section>
 
 
-		<!-- <section class="appendix">
+        <!-- <section class="appendix">
 			<h1 id="6-references">Further readings </h1>
 			<p> Open Annotation in EPUB, 2015: <a href="https://idpf.org/epub/oa/">
 					https://idpf.org/epub/oa/ </a>
@@ -1390,5 +1451,5 @@
 			</p>
 		</section> -->
         <section id="index"></section>
-	</body>
+    </body>
 </html>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -787,7 +787,7 @@
                     </pre>
                         </aside>
                         <p>This selects "q" from "quick" as start position and
-                            "x" from "fox" as end position in the following HTML snippet: </p>
+                            "x" from the first instance of "fox" as end position in the following HTML snippet: </p>
                         <pre>
 &lt;div id="intro">
     &lt;p>Some text.&lt;/p>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -657,7 +657,7 @@
                             selection in the stream.
                             Position 0 would be immediately before the first character, position 1 would be immediately
                             before the second character, and so on.
-                            The start character is thus included in the list, but the end character is not.
+                           
                             This specification reuses the <a
                                 data-cite="annotation-model#text-position-selector"><code>TextPositionSelector</code></a>,
                             as defined in the [[[annotation-model]]] specification, but lists it here for an easier


### PR DESCRIPTION
In agreement with @llemeurfr (who is on vacations) I created a version of the annotation spec with selectors, based on the previous draft (see #2892) plus the discussions on that PR as well as the [discussion on the WG](https://w3c.github.io/pm-wg/minutes/2026-01-22.html#7e88). I hope I have not forgotten or misunderstood anything.

Some comments:

- I have added, as ***informative*** sections, the definitions of selectors that we just "take over" from the Open Annotation specification (e.g., CssSelector). I did this to make the document more self-contained and to make it easier for implementers. I hope that is the right choice.
- Text fragments appear now at two places: referred to from Fragment Selectors, and noted as a possible implementors' vehicle for text quote selectors. I was not sure which of the two we should retain and, actually, there is room for both. The second option has the advantage that we are not normatively dependent on the text fragment specification. To be discussed.

---

See:

* For EPUB 3 Annotations:
    * [Preview](https://raw.githack.com/w3c/epub-specs/ann-selectors-2/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub34/annotations/index.html&doc2=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/ann-selectors-2/epub34/annotations/index.html)
