### PR TITLE
Support for `<img>` in SMIL

### DIFF
--- a/epub34/authoring/biblio.js
+++ b/epub34/authoring/biblio.js
@@ -84,6 +84,11 @@ var biblio = {
 		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c040833_ISO_IEC_19757-3_2006(E).zip",
 		"date": "2006-06-01"
 	},
+	"media-frags": {
+		"title": "Media Fragments URI 1.0 (basic)",
+		"href": "https://www.w3.org/TR/media-frags/",
+		"date": "2012-09-25"
+	},
 	"nvdl": {
 		"title": "ISO/IEC 19757-4: NVDL (Namespace-based Validation Dispatching Language)",
 		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c038615_ISO_IEC_19757-4_2006(E).zip",

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -8325,6 +8325,10 @@ No Entry</pre>
 											<p> [^audio^] <code>[0 or 1]</code>
 											</p>
 										</li>
+										<li>
+											<p> [^img^] <code>[0 or 1]</code>
+											</p>
+										</li>
 									</ul>
 								</dd>
 							</dl>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -8481,6 +8481,58 @@ No Entry</pre>
 								</dd>
 							</dl>
 						</section>
+
+						<section id="sec-smil-img-elem">
+							<h6>The <code>img</code> element</h6>
+
+							<p>The <code>image</code> element references an image listed as a [=core media type resource=].</p>
+
+							<dl class="elemdef" id="elemdef-smil-img">
+								<dt>Element Name:</dt>
+								<dd>
+									<p>
+										<dfn class="export" data-lt-no-plural="" data-dfn-type="element">
+											<code>img</code>
+										</dfn>
+									</p>
+								</dd>
+
+								<dt>Usage:</dt>
+								<dd>
+									<p>An OPTIONAL child of the [^par^] element.</p>
+								</dd>
+
+								<dt>Attributes:</dt>
+								<dd>
+									<dl>
+										<dt>
+											<code>src</code>
+											<code>[required]</code>
+										</dt>
+										<dd>
+											<p>Refers to the associated [=core media type resource=] and, optionally,
+												identifies a specific part of it.</p>
+											<p>The value MUST be a [=path-relative-scheme-less-URL string=], optionally
+												followed by <code>U+0023&#160;(#)</code> and a spatial dimension fragment from [[media-frags]].</p>
+										</dd>
+
+										<dt>
+											<code>id</code>
+											<code>[optional]</code>
+										</dt>
+										<dd>
+											<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be
+												unique within the document scope.</p>
+										</dd>
+									</dl>
+								</dd>
+
+								<dt>Content Model:</dt>
+								<dd>
+									<p>Empty</p>
+								</dd>
+							</dl>
+						</section>
 					</section>
 				</section>
 
@@ -8600,8 +8652,8 @@ No Entry</pre>
 
 							<p>The <code>par</code> element represents a segment of content, such as a word, phrase,
 								sentence, table cell, list item, image, or other identifiable piece of content in the
-								markup. Each element identifies both the content to display (in the [^text^] element)
-								and audio to synchronize (in the [^audio^] element) during playback.</p>
+								markup. Each element identifies both the content to display (in the [^text^] element or
+								[^img^] element) and audio to synchronize (in the [^audio^] element) during playback.</p>
 
 							<p>The <code>seq</code> element represents sequences — sets of <code>seq</code> and/or
 									<code>par</code> elements that together represent a logical component of the
@@ -8780,6 +8832,10 @@ No Entry</pre>
 									href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
 									Identifier</a> [[svg]], respectively.</p>
 
+							<p>In addition the [^img^] element's <code>src</code> attribute can contain a spatial dimension 
+							fragment from [[media-frags]] that references a specific part of the associated 
+						 	[=core media type resource=].</p>
+
 							<p>Other fragment identifier schemes MAY be used but [=reading systems=] might not support
 								such identifiers.</p>
 						</section>
@@ -8871,6 +8927,50 @@ No Entry</pre>
                 clipBegin="0:24:38.530"
                 clipEnd="0:25:00.515"/&gt;
          &lt;/par&gt;
+      &lt;/seq&gt;
+   &lt;/body&gt;
+&lt;/smil&gt;</pre>
+						</aside>
+
+						<aside class="example" title="Semantic markup for comics with panels and balloons">
+							<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL"
+    xmlns:epub="http://www.idpf.org/2007/ops"
+    version="3.0"&gt;
+   &lt;body&gt;
+      &lt;seq id="id1" epub:textref="page1.xhtml#image" epub:type="page"&gt;
+         &lt;par id="id2" epub:type="panel"&gt;
+            &lt;img
+                src="page1.jpg#xywh=76,19,814,635"/&gt;
+            &lt;text
+                src="script.html#page1-panel1-description"/&gt;
+            &lt;audio
+                src="page1_audio.mp3"
+                clipBegin="0:00:00.000"
+                clipEnd="0:00:10.123"/&gt;
+         &lt;/par&gt;
+         &lt;seq id="id3" epub:type="panel"&gt;&gt;
+            &lt;par id="id4"&gt;
+                &lt;img
+                    src="page1.jpg#xywh=356,695,584,296"/&gt;
+                &lt;text
+                    src="script.html#page1-panel2-description"/&gt;
+                &lt;audio
+                    src="page1_audio.mp3"
+                    clipBegin="0:00:10.123"
+                    clipEnd="0:00:28.530"/&gt;
+            &lt;/par&gt;
+            &lt;par id="id5" epub:type="balloon"&gt;
+                &lt;img
+                    src="page1.jpg#xywh=406,695,200,50"/&gt;
+                &lt;text
+                    src="script.html#page1-panel2-balloon"/&gt;
+                &lt;audio
+                    src="page1_audio.mp3"
+                    clipBegin="0:00:28.530"
+                    clipEnd="0:00:37.920"/&gt;
+            &lt;/par&gt;
+         &lt;/seq&gt;
       &lt;/seq&gt;
    &lt;/body&gt;
 &lt;/smil&gt;</pre>
@@ -11251,6 +11351,8 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>05-February-2026: Added support for <code>&lt;img&gt;</code> in Media Overlays. See <a
+							href="https://github.com/w3c/epub-specs/issues/2883">issue 2883</a>.</li>
 					<li>23-January-2026: Added JPEG XL as a core media type for images. See <a
 							href="https://github.com/w3c/epub-specs/issues/2896">issue 2896</a>.</li>
 					<li>18-Dec-2025: Renamed "obsolete but conforming features" to "outdated features". As discussed in


### PR DESCRIPTION
This PR closes #2883.

It's currently a draft PR and not ready to be reviewed yet.

Changes:

- Added a new section for the `img` element
- Added `img` to the content model for `par` (set to 0 or 1)
- Added Media Fragment URI to normative references
- Added a new paragraph in "Referencing document fragments"
- Added new example for comics in "Structural semantics in overlays"
- Added new entry in changelog

Links:

- [Preview](https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2919.html)
- [Example](https://github.com/HadrienGardeur/accessible-epub-comics)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2919.html" title="Last updated on Feb 11, 2026, 2:49 PM UTC (0cc7491)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2919/9c8617b...0cc7491.html" title="Last updated on Feb 11, 2026, 2:49 PM UTC (0cc7491)">Diff</a>