### PR TITLE
Move page list destination to an example

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -6751,7 +6751,6 @@ No Entry</pre>
 					</div>
 				</section>
 
-
 				<section id="sec-fxl-content-dimensions" data-epubcheck="true"
 					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L457,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L212,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L217,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L222,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L227,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L233,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L239,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L245,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L251,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L257,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L263,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L269,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L275,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L283,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L297,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L303,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L309">
 					<h4>Fixed-layout document dimensions</h4>
@@ -7572,6 +7571,41 @@ No Entry</pre>
 								documents=].</p>
 						</li>
 					</ul>
+
+					<aside class="example" title="Simple table of contents">
+						<pre>&lt;nav epub:type="toc">
+   &lt;h2>Table of contents&lt;/h2>
+   &lt;ol>
+      &lt;li>&lt;a href="preface.html#p01">Preface&lt;/a>&lt;/li>
+      &lt;li>&lt;a href="chapter01.html#h01">Chapter 1&lt;/a>&lt;/li>
+      &lt;li>&lt;a href="chapter02.html#h02">Chapter 2&lt;/a>&lt;/li>
+      &#8230;
+   &lt;/ol>
+&lt;/nav></pre>
+					</aside>
+
+					<aside class="example" title="Structured table of contents">
+						<pre>&lt;nav epub:type="toc">
+   &lt;h2>Table of contents&lt;/h2>
+   &lt;ol>
+      &lt;li>
+         &lt;a href="part01.html#p01">Part I&lt;/a>
+         &lt;ol>
+            &lt;li>
+               &lt;a href="section01.html#s01">Section 1&lt;/a>
+               &lt;ol>
+                  &lt;li>&lt;a href="section01.html#s01-01">Section 1.1&lt;/a>&lt;/li>
+                  &lt;li>&lt;a href="section01.html#s01-02">Section 1.2&lt;/a>&lt;/li>
+                  &#8230;
+               &lt;/ol>
+            &lt;/li>
+            &#8230;
+         &lt;/ol>
+      &lt;/li>
+      &#8230;
+   &lt;/ol>
+&lt;/nav></pre>
+					</aside>
 				</section>
 
 				<section id="sec-nav-pagelist" data-epubcheck="true"
@@ -7592,9 +7626,33 @@ No Entry</pre>
 					<p>The <code>page-list nav</code> element SHOULD contain only a single <code>ol</code> descendant
 						(i.e., no nested sublists).</p>
 
-					<p>The destinations of the <code>page-list</code> references MAY be identified in their respective
-						[=EPUB content documents=] using the <a data-cite="epub-ssv-11/#pagebreak"
-								><code>pagebreak</code> term</a> [[epub-ssv-11]].</p>
+					<aside class="example" title="Page list with destination">
+						<p>Page list markup in the EPUB navigation document:</p>
+
+						<pre>&lt;nav epub:type="page-list">
+   &lt;h2>Page list&lt;/h2>
+   &lt;ol>
+      &lt;li>&lt;a href="chapter01.html#p001">1&lt;/a>&lt;/li>
+      &#8230;
+   &lt;/ol>
+&lt;/nav></pre>
+
+						<p>The destination for the first page in <code>chapter01.html</code> identified by [[html]]
+							[^/role^] attribute value <a data-cite="dpub-aria#doc-pagebreak"
+								><code>doc-pagebreak</code></a> [[dpub-aria]] and the [^/epub:type^] value <a
+								data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code></a> [[epub-ssv-11]]:</p>
+
+						<pre>&lt;html &#8230;>
+   &#8230;
+   &lt;body>
+      &lt;div epub:type="pagebreak" role="doc-pagebreak">1&lt;/div>
+      &#8230;
+   &lt;/body>
+&lt;/html></pre>
+
+						<p>Refer to the <a href="#type-attr-syntax"><code>epub:type</code> attribute syntax</a> for more
+							information about the use of these attributes.</p>
+					</aside>
 				</section>
 
 				<section id="sec-nav-landmarks" data-epubcheck="true"


### PR DESCRIPTION
This pull request removes the normative suggestion to use epub:type for pagebreak identification, replacing it with an example that shows both epub:type and role identification. It also adds a couple of examples of toc navs.

Fixes #2916


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2920.html" title="Last updated on Feb 5, 2026, 6:13 PM UTC (6365031)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2920/9c8617b...6365031.html" title="Last updated on Feb 5, 2026, 6:13 PM UTC (6365031)">Diff</a>