### PR TITLE
Harmonize location of nav doc requirements

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -7281,8 +7281,20 @@ No Entry</pre>
 								href="#sec-nav-def-model"></a>;</p>
 					</li>
 					<li>
-						<p id="confreq-navdoc-toc">MUST include exactly one <code>toc nav</code> element as defined in
-								<a href="#sec-nav-toc"></a>.</p>
+						<p id="confreq-navdoc-toc">MUST include exactly one <a href="#sec-nav-toc"><code>toc nav</code>
+								element</a>.</p>
+					</li>
+					<li>
+						<p id="confreq-navdoc-pagelist">MAY include exactly one <a href="#sec-nav-pagelist"
+									><code>page-list nav</code> element</a>.</p>
+					</li>
+					<li>
+						<p id="confreq-navdoc-landmarks">MAY include exactly one <a href="#sec-nav-landmarks"
+									><code>landmarks nav</code> element</a>.</p>
+					</li>
+					<li>
+						<p id="confreq-navdoc-other">MAY contain one or more additional <a
+								href="#sec-nav-def-types-other"><code>nav</code> elements</a>.</p>
 					</li>
 				</ul>
 			</section>
@@ -7581,9 +7593,6 @@ No Entry</pre>
 						the value "<a data-cite="epub-ssv-11#page-list">page-list</a>" [[epub-ssv-11]] (i.e., the
 							<code>page-list nav</code> element).</p>
 
-					<p>The <code>page-list nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT
-						occur more than once.</p>
-
 					<p>The <code>page-list nav</code> element SHOULD contain only a single <code>ol</code> descendant
 						(i.e., no nested sublists).</p>
 
@@ -7627,9 +7636,6 @@ No Entry</pre>
 					<p>Landmarks are defined in a [^nav^] element [[html]] whose [^/epub:type^] attribute is set to the
 						value "<a data-cite="epub-ssv-11#landmarks">landmarks</a>" [[epub-ssv-11]] (i.e., the
 							<code>landmarks nav</code> element).</p>
-
-					<p>The <code>landmarks nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT
-						occur more than once.</p>
 
 					<p>The <code>landmarks nav</code> element SHOULD contain only a single <code>ol</code> descendant
 						(i.e., no nested sublists).</p>
@@ -7697,11 +7703,13 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L245,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L251,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L259">
 					<h4>Other <code>nav</code> elements</h4>
 
-					<p>[=EPUB navigation documents=] MAY contain one or more <code>nav</code> elements in addition to
-						the <code>toc</code>, <code>page-list</code>, and <code>landmarks nav</code> elements defined in
-						the preceding sections. If these <code>nav</code> elements are intended for [=reading system=]
-						processing, they MUST have an [^/epub:type^] attribute and are subject to the content model
-						restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
+					<p>If additional <code>nav</code> elements are needed in the EPUB navigation document for [=reading
+						system=] processing, they:</p>
+
+					<ul>
+						<li>MUST specify an [^/epub:type^] attribute;</li>
+						<li>MUST adhere to the content model restrictions in <a href="#sec-nav-def-model"></a>.</li>
+					</ul>
 
 					<p>This specification imposes no restrictions on the semantics of any additional <code>nav</code>
 						elements: they MAY represent navigational semantics for any information domain, and they MAY


### PR DESCRIPTION
Shuffles the page-list, landmarks, and other nav presence requirements up to s. 8.2. Also modifies the start of s. 8.4.5 to make a list of the two remaining requirements in the first paragraph. Does not add any new requirements.

Fixes #2921


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2923.html" title="Last updated on Feb 6, 2026, 4:40 PM UTC (154afd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2923/d4cb518...154afd6.html" title="Last updated on Feb 6, 2026, 4:40 PM UTC (154afd6)">Diff</a>