### PR TITLE
Adding new test references to pp and roll with svg in the spine

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1154,7 +1154,7 @@
 					</section>
 
 					<section id="sec-roll-layouts"
-						data-tests="#lay-roll-embedded-images,#lay-roll-images-in-spine,#lay-roll-images-mixed">
+						data-tests="#lay-roll-embedded-images,#lay-roll-images-in-spine,#lay-roll-images-mixed,#lay-roll-embedded-images-svg">
 						<h5>Roll layouts</h5>
 
 						<p class="support">[=Reading systems=] SHOULD support the rendering of roll layouts.</p>
@@ -1348,7 +1348,7 @@
 				<h3>Fixed-layout documents</h3>
 
 				<p id="confreq-rs-epub3-fxl"
-					data-tests="#lay-pp-spread-none,#lay-pp-embedded-images,#lay-pp-images-in-spine,#lay-pp-images-mixed,#lay-roll-embedded-images,#lay-roll-images-in-spine,#lay-roll-images-mixed"
+					data-tests="#lay-pp-spread-none,#lay-pp-embedded-images,#lay-pp-images-in-spine,#lay-pp-images-mixed,#lay-roll-embedded-images,#lay-roll-images-in-spine,#lay-roll-images-mixed,#lay-pp-embedded-images-svg,#lay-roll-embedded-images-svg"
 					class="support">[=Reading systems=] MUST support the rendering of EPUB content documents in
 					[=spine=] items whose layout is designated as <a href="#sec-pre-paginated-layouts"
 							><code>pre-paginated</code></a> or <a href="#sec-roll-layouts"><code>roll</code></a>. They


### PR DESCRIPTION
This is the counterpart to https://github.com/w3c/epub-tests/pull/313