### PR TITLE
Fix the links and names of the metadata guide

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -177,8 +177,8 @@
 			<div class="note">
 				<p>Accessibility metadata techniques are no longer covered by this guide. For information on how to
 					apply accessibility metadata, please refer to the <a
-						href="https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/">EPUB Accessibility
-						Metadata Guide</a>.</p>
+						href="https://w3c.github.io/publ-a11y/package-metadata-authoring-guide/">Expressing
+						Accessibility Metadata in the EPUB Package Document</a> guide.</p>
 			</div>
 		</section>
 		<section id="sec-wcag">

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -367,11 +367,10 @@
 				</div>
 
 				<div class="note">
-					<p>Refer to the <a
-							href="https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/#sec-discovery">EPUB
-							Accessibility Metadata Guidelines</a> for more information on these properties and how to
-						include them in different versions of EPUB. See also <a
-							data-cite="epub-a11y-tech-12#dist-a11y-metadata">Include accessibility metadata in
+					<p>Refer to the <a href="https://w3c.github.io/publ-a11y/package-metadata-authoring-guide/"
+							>Expressing Accessibility Metadata in the EPUB Package Document</a> guide for more
+						information on these properties and how to include them in different versions of EPUB. See also
+							<a data-cite="epub-a11y-tech-12#dist-a11y-metadata">Include accessibility metadata in
 							distribution records</a> [[epub-a11y-tech-12]] for more information on including
 						accessibility metadata in other formats.</p>
 				</div>


### PR DESCRIPTION
Noticed that we had 404s to the old editor's draft location. (Final stable links to be added once we publish the document.)