### PR TITLE
[epub34] fixed missing blacket for reference link

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -4068,7 +4068,7 @@
 
 							<div class="note">
 								<p>It is advised to use <a href="https://url.spec.whatwg.org/#absolute-url-string"
-										>absolute-URL strings</a> [url] for identifiers whenever possible. The inclusion
+										>absolute-URL strings</a> [[url]] for identifiers whenever possible. The inclusion
 									of a domain can improve the uniqueness of the identifier, for example, while the use
 									of a URN with a <a href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1"
 										>namespace identifier</a> [[rfc8141]] improves processing by reading


### PR DESCRIPTION
as title, non-substantive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2947.html" title="Last updated on Mar 5, 2026, 7:24 AM UTC (df30ef9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2947/e0f98fd...df30ef9.html" title="Last updated on Mar 5, 2026, 7:24 AM UTC (df30ef9)">Diff</a>