### PR TITLE
[FXLA11Y] Move sections from note to techniques doc

### DIFF
--- a/wg-notes/fxl-a11y-tech/index.html
+++ b/wg-notes/fxl-a11y-tech/index.html
@@ -154,10 +154,10 @@
 &lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
 &lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
 &lt;meta property="schema:accessibilityHazard"&gt;none&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.2 Level A&lt;/meta&gt;
 &lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
 &lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
+This publication conforms to all the success criteria of WCAG 2.2 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
 &lt;/meta&gt;
 						</pre>
 					</aside>
@@ -179,10 +179,10 @@ This publication conforms to all the success criteria of WCAG 2.1 AA with the ex
 &lt;meta property="schema:accessibilityFeature"&gt;tableOfContents&lt;/meta&gt;
 &lt;meta property="schema:accessibilityFeature"&gt;index&lt;/meta&gt;
 &lt;meta property="schema:accessibilityHazard"&gt;none&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.2 Level A&lt;/meta&gt;
 &lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
 &lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
+This publication conforms to all the success criteria of WCAG 2.2 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
 &lt;/meta&gt;
 						</pre>
 					</aside>
@@ -204,10 +204,10 @@ This publication conforms to all the success criteria of WCAG 2.1 AA with the ex
 &lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
 &lt;meta property="schema:accessibilityFeature"&gt;synchronizedAudioText&lt;/meta&gt;
 &lt;meta property="schema:accessibilityHazard"&gt;sound&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.2 Level A&lt;/meta&gt;
 &lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
 &lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains synchronized audio along with the text. Readers should be advised that the audio for this book includes a loud bang on page 7. There are no other audio hazards in the book. 
+This publication conforms to all the success criteria of WCAG 2.2 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains synchronized audio along with the text. Readers should be advised that the audio for this book includes a loud bang on page 7. There are no other audio hazards in the book. 
 &lt;/meta&gt;
 						</pre>
 					</aside>
@@ -232,10 +232,10 @@ This publication conforms to all the success criteria of WCAG 2.1 AA with the ex
 &lt;meta property="schema:accessibilityFeature"&gt;index&lt;/meta&gt;
 &lt;meta property="schema:accessibilityHazard"&gt;flashing&lt;/meta&gt;
 &lt;meta property="schema:accessibilityHazard"&gt;motionSimulation&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.2 Level A&lt;/meta&gt;
 &lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
 &lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains video content that illustrates what is described in the text. The video content does not have audio descriptions as they are fully described in the surrounding text for each video. The video content may pose a flashing or motion simulation hazard for some readers, to reduce the risk of a hazard, all videos have been set to only play when triggered by the reader.
+This publication conforms to all the success criteria of WCAG 2.2 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains video content that illustrates what is described in the text. The video content does not have audio descriptions as they are fully described in the surrounding text for each video. The video content may pose a flashing or motion simulation hazard for some readers, to reduce the risk of a hazard, all videos have been set to only play when triggered by the reader.
 &lt;/meta&gt;
 						</pre>
 					</aside>

--- a/wg-notes/fxl-a11y-tech/index.html
+++ b/wg-notes/fxl-a11y-tech/index.html
@@ -118,6 +118,161 @@
 						href="https://www.w3.org/2021/a11y-discov-vocab/latest/">Schema.org Accessibility Properties for
 						Discoverability Vocabulary</a> [[a11y-discov-vocab]].</p>
 			</div>
+
+			<section id="sec-metadata-fallbacks">
+				<h3>Using manifest fallbacks in fixed layout EPUBs</h3>
+
+				<p>If using fallbacks, EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section. It is important to note that manifest fallbacks are most commonly used to support content that may not be supported by the reading system, such as MathML, audio, or video. Fallback support in reading systems is mixed, so fallbacks should not be relied on for providing accessible alternatives to fixed layout content or images.</p>
+
+				<aside class="issue" title="Open issues regarding fallbacks" data-number="2773">
+						<p>The Publishing Maintenance WG repository currently has an open issue regarding fallback support and their use in fixed layout content. This is part of a broader issue with fallbacks that will require discussion with the group. Anyone interested in this topic is asked to contribute to the discussion.</p>
+
+						<ul>
+							<li><a href="https://github.com/w3c/epub-specs/issues/2773">Fallback definition and authoring guidance is missing</a></li>
+						</ul>
+				</aside>
+			</section>
+
+			<section id="sec-metadata-examples">
+				<h3>Examples of accessibility metadata</h3>
+
+				<p>Books with accessible elements require metadata to indicate how they are accessible, and if they present any hazards to the reader. A full description of accessibility metadata in EPUB can be found in <a href="https://www.w3.org/TR/epub-a11y-11/#sec-discovery">section 2</a> of EPUB Accessibility 1.1 [[epub-a11y-11]] and the <a href="https://www.w3.org/community/reports/a11y-discov-vocab/CG-FINAL-vocabulary-20230718/">Schema.org Accessibility Properties for Discoverability Vocabulary</a>.</p>
+
+				<p>The <a href="https://kb.daisy.org/publishing/docs/metadata/schema.org/index.html">DAISY Knowledge Base</a> also provides excellent guidance on the usage and definitions of Schema.org metadata in an EPUB file. In this section, we have provided some examples of what this metadata might look like depending on different fixed layout use cases.</p>
+
+				<section id="a11y-metadata-childrens-book">
+					<h4>Accessibility metadata for a children's picture book</h4>
+
+					<p>A common use for fixed layout is children's picture books, which feature expressive illustrations and small amounts of text. In this example, this is a book where the EPUB creator has done everything needed for accessibility.</p>
+
+					<aside class="example" title="Accessibility metadata for a children's book">
+						<pre>
+&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;textual&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
+&lt;meta property="schema:accessibilityHazard"&gt;none&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
+&lt;meta property="schema:accessibilitySummary"&gt;
+This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
+&lt;/meta&gt;
+						</pre>
+					</aside>
+				</section>
+
+				<section id="a11y-metadata-cookbook">
+					<h4>Accessibility metadata for a cookbook</h4>
+
+					<p>Cookbooks are commonly formatted using fixed layout, due to their highly visual layout. In this example, the publisher has created a cookbook that meets accessibility requirements, including providing a detailed table of contents and index.</p>
+
+					<aside class="example" title="Accessibility metadata for a cookbook">
+						<pre>
+&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;textual&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;tableOfContents&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;index&lt;/meta&gt;
+&lt;meta property="schema:accessibilityHazard"&gt;none&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
+&lt;meta property="schema:accessibilitySummary"&gt;
+This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
+&lt;/meta&gt;
+						</pre>
+					</aside>
+				</section>
+
+				<section id="a11y-metadata-mo-hazard">
+					<h4>Accessibility metadata for a children's book with media overlays</h4>
+
+					<p>This example is for a children's book that uses media overlays. The audio for the book contains a potential sound hazard, so it is declared in <code>accessibilityHazard</code> and further detail is provided in the <code>accessibilitySummary</code>.</p>
+
+					<aside class="example" title="Accessibility metadata for a children's book with media overlays">
+						<pre>
+&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
+&lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual,textual,auditory&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;textual, auditory&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;synchronizedAudioText&lt;/meta&gt;
+&lt;meta property="schema:accessibilityHazard"&gt;sound&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
+&lt;meta property="schema:accessibilitySummary"&gt;
+This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains synchronized audio along with the text. Readers should be advised that the audio for this book includes a loud bang on page 7. There are no other audio hazards in the book. 
+&lt;/meta&gt;
+						</pre>
+					</aside>
+				</section>
+
+				<section id="a11y-metadata-textbook">
+					<h4>Accessibility metadata for a textbook with video</h4>
+
+					<p>This example features a textbook that includes video content. The video content does not include audio descriptions, but as described in <code>accessibilitySummary</code>, the EPUB creator fully describes the video content in surrounding text. There are potential hazards due to the type of video content.</p>
+
+					<aside class="example" title="Accessibility metadata for a textbook with video">
+						<pre>
+&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
+&lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual,textual,auditory&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual,auditory&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;tableOfContents&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;index&lt;/meta&gt;
+&lt;meta property="schema:accessibilityHazard"&gt;flashing&lt;/meta&gt;
+&lt;meta property="schema:accessibilityHazard"&gt;motionSimulation&lt;/meta&gt;
+&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
+&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
+&lt;meta property="schema:accessibilitySummary"&gt;
+This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains video content that illustrates what is described in the text. The video content does not have audio descriptions as they are fully described in the surrounding text for each video. The video content may pose a flashing or motion simulation hazard for some readers, to reduce the risk of a hazard, all videos have been set to only play when triggered by the reader.
+&lt;/meta&gt;
+						</pre>
+					</aside>
+				</section>
+
+				<section id="a11y-metadata-unremediated">
+					<h4>Accessibility metadata for a book that has not been remediated yet</h4>
+
+					<p>As EPUB creators work on remediating their catalogues, some books may not be fully accessible or tested against WCAG requirements. It is helpful for readers to know the status of a book, even if it is not yet accessible, so they can make informed decisions when buying or borrowing.</p>
+
+					<aside class="example" title="Accessibility metadata for a book that is not remediated">
+						<pre>
+&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;unknown&lt;/meta&gt;
+&lt;meta property="schema:accessibilityHazard"&gt;unknown&lt;/meta&gt;
+&lt;meta property="schema:accessibilitySummary"&gt;
+This publication has not been accessibility tested, or had remediation work done. If there are any questions about this book's content, or an urgent need for an accessible edition of this book, please contact us at [help]@[publisher].com.
+						</pre>
+					</aside>
+				</section>
+
+				<section id="a11y-metadata-manga">
+					<h4>Accessibility metadata for a manga EPUB</h4>
+
+					<p>Manga is commonly distributed in fixed layout EPUB format, either with images as spine items or embedded in individual XHTML files for each page. Most manga features images where the text is part of the image and not provided separately.</p>
+
+					<aside class="example" title="Accessibility metadata for a manga EPUB">
+						<pre>
+&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessModeSufficient"&gt;visual&lt;/meta&gt;
+&lt;meta property="schema:accessibilityFeature"&gt;none&lt;/meta&gt;
+&lt;meta property="schema:accessibilityHazard"&gt;none&lt;/meta&gt;
+						</pre>
+					</aside>
+				</section>			
+			</section>
 		</section>
 
 		<section id="sec-wcag-techniques">

--- a/wg-notes/fxl-a11y/index.html
+++ b/wg-notes/fxl-a11y/index.html
@@ -676,158 +676,7 @@
             </pre>
         </aside>
 
-        <section id="using-fallbacks">
-            <h3>Using manifest fallbacks in fixed layout EPUBs</h3>
-
-            <p>If using fallbacks, EPUB creators should follow the guidance provided in the EPUB 3.3 <a href="https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks">Manifest Fallbacks</a> section. It is important to note that manifest fallbacks are most commonly used to support content that may not be supported by the reading system, such as MathML, audio, or video. Fallback support in reading systems is mixed, so fallbacks should not be relied on for providing accessible alternatives to fixed layout content or images.</p>
-
-            <aside class="issue" title="Open issues regarding fallbacks" data-number="2773">
-                    <p>The Publishing Maintenance WG repository currently has an open issue regarding fallback support and their use in fixed layout content. This is part of a broader issue with fallbacks that will require discussion with the group. Anyone interested in this topic is asked to contribute to the discussion.</p>
-
-                    <ul>
-                        <li><a href="https://github.com/w3c/epub-specs/issues/2773">Fallback definition and authoring guidance is missing</a></li>
-                    </ul>
-            </aside>
-        </section>
-
-        <section id="a11y-metadata">
-            <h3>Examples of accessibility metadata</h3>
-
-            <p>Books with accessible elements require metadata to indicate how they are accessible, and if they present any hazards to the reader. A full description of accessibility metadata in EPUB can be found in <a href="https://www.w3.org/TR/epub-a11y-11/#sec-discovery">section 2</a> of EPUB Accessibility 1.1 [[epub-a11y-11]] and the <a href="https://www.w3.org/community/reports/a11y-discov-vocab/CG-FINAL-vocabulary-20230718/">Schema.org Accessibility Properties for Discoverability Vocabulary</a>.</p>
-
-            <p>The <a href="https://kb.daisy.org/publishing/docs/metadata/schema.org/index.html">DAISY Knowledge Base</a> also provides excellent guidance on the usage and definitions of Schema.org metadata in an EPUB file. In this section, we have provided some examples of what this metadata might look like depending on different fixed layout use cases.</p>
-
-            <section id="a11y-metadata-childrens-book">
-                <h4>Accessibility metadata for a children's picture book</h4>
-
-                <p>A common use for fixed layout is children's picture books, which feature expressive illustrations and small amounts of text. In this example, this is a book where the EPUB creator has done everything needed for accessibility.</p>
-
-                <aside class="example" title="Accessibility metadata for a children's book">
-                    <pre>
-&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;textual&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
-&lt;meta property="schema:accessibilityHazard"&gt;none&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
-&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
-&lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
-&lt;/meta&gt;
-                    </pre>
-                </aside>
-            </section>
-
-            <section id="a11y-metadata-cookbook">
-                <h4>Accessibility metadata for a cookbook</h4>
-
-                <p>Cookbooks are commonly formatted using fixed layout, due to their highly visual layout. In this example, the publisher has created a cookbook that meets accessibility requirements, including providing a detailed table of contents and index.</p>
-
-                <aside class="example" title="Accessibility metadata for a cookbook">
-                    <pre>
-&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;textual&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;tableOfContents&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;index&lt;/meta&gt;
-&lt;meta property="schema:accessibilityHazard"&gt;none&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
-&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
-&lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow.
-&lt;/meta&gt;
-                    </pre>
-                </aside>
-            </section>
-
-            <section id="a11y-metadata-mo-hazard">
-                <h4>Accessibility metadata for a children's book with media overlays</h4>
-
-                <p>This example is for a children's book that uses media overlays. The audio for the book contains a potential sound hazard, so it is declared in <code>accessibilityHazard</code> and further detail is provided in the <code>accessibilitySummary</code>.</p>
-
-                <aside class="example" title="Accessibility metadata for a children's book with media overlays">
-                    <pre>
-&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
-&lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual,textual,auditory&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;textual, auditory&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;synchronizedAudioText&lt;/meta&gt;
-&lt;meta property="schema:accessibilityHazard"&gt;sound&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
-&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
-&lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains synchronized audio along with the text. Readers should be advised that the audio for this book includes a loud bang on page 7. There are no other audio hazards in the book. 
-&lt;/meta&gt;
-                    </pre>
-                </aside>
-            </section>
-
-            <section id="a11y-metadata-textbook">
-                <h4>Accessibility metadata for a textbook with video</h4>
-
-                <p>This example features a textbook that includes video content. The video content does not include audio descriptions, but as described in <code>accessibilitySummary</code>, the EPUB creator fully describes the video content in surrounding text. There are potential hazards due to the type of video content.</p>
-
-                <aside class="example" title="Accessibility metadata for a textbook with video">
-                    <pre>
-&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
-&lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual,textual&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual,textual,auditory&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual,auditory&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;tableOfContents&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;index&lt;/meta&gt;
-&lt;meta property="schema:accessibilityHazard"&gt;flashing&lt;/meta&gt;
-&lt;meta property="schema:accessibilityHazard"&gt;motionSimulation&lt;/meta&gt;
-&lt;meta property="dcterms:conformsTo" id="conf"&gt;EPUB Accessibility 1.1 - WCAG 2.1 Level A&lt;/meta&gt;
-&lt;meta property="a11y:certifiedBy" refines="#conf"&gt;Acme Publishing Inc.&lt;/meta&gt;
-&lt;meta property="schema:accessibilitySummary"&gt;
-This publication conforms to all the success criteria of WCAG 2.1 AA with the exception of success criteria that cannot be met using fixed layout formatting. This includes text resizing and text reflow. This publication contains video content that illustrates what is described in the text. The video content does not have audio descriptions as they are fully described in the surrounding text for each video. The video content may pose a flashing or motion simulation hazard for some readers, to reduce the risk of a hazard, all videos have been set to only play when triggered by the reader.
-&lt;/meta&gt;
-                    </pre>
-                </aside>
-            </section>
-
-            <section id="a11y-metadata-unremediated">
-                <h4>Accessibility metadata for a book that has not been remediated yet</h4>
-
-                <p>As EPUB creators work on remediating their catalogues, some books may not be fully accessible or tested against WCAG requirements. It is helpful for readers to know the status of a book, even if it is not yet accessible, so they can make informed decisions when buying or borrowing.</p>
-
-                <aside class="example" title="Accessibility metadata for a book that is not remediated">
-                    <pre>
-&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;unknown&lt;/meta&gt;
-&lt;meta property="schema:accessibilitySummary"&gt;
-This publication has not been accessibility tested, or had remediation work done. If there are any questions about this book's content, or an urgent need for an accessible edition of this book, please contact us at [help]@[publisher].com.
-                    </pre>
-                </aside>
-            </section>
-
-            <section id="a11y-metadata-manga">
-                <h4>Accessibility metadata for a manga EPUB</h4>
-
-                <p>Manga is commonly distributed in fixed layout EPUB format, either with images as spine items or embedded in individual XHTML files for each page. Most manga features images where the text is part of the image and not provided separately.</p>
-
-                <aside class="example" title="Accessibility metadata for a manga EPUB">
-                    <pre>
-&lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessModeSufficient"&gt;visual&lt;/meta&gt;
-&lt;meta property="schema:accessibilityFeature"&gt;none&lt;/meta&gt;
-                    </pre>
-                </aside>
-            </section>
-        </section>
+        <p>Examples of accessibility metadata for different publication types can be found in the <a href="https://w3c.github.io/epub-specs/wg-notes/fxl-a11y-tech/#sec-metadata-examples">EPUB Accessibility - Fixed Layout Techniques</a> document.</p>
     </section>
 
     <section id="rs-a11y">
@@ -1008,6 +857,16 @@ This publication has not been accessibility tested, or had remediation work done
             </section>
 
         </section>
+    </section>
+
+    <section id="change-log" class="appendix informative">
+        <h2>Change Log</h2>
+
+        <p>This change log identifies any substantive or notable changes made to this document since it's initial publication.</p>
+
+        <ul>
+            <li><strong>2026-03-06</strong>: Moved sections 3.1 and 3.2 on the use of manifest fallbacks and metadata examples to the Fixed Layout Techniques document. See <a href="https://github.com/w3c/epub-specs/issues/2908">issue 2908</a>.</li>
+        </ul>
     </section>
 
     <section id="ack" class="appendix informative">


### PR DESCRIPTION
Moved metadata sections from the main FXL A11y document to the Techniques document as discussed in issue #2908. Also addressed a minor issue in the metadata raised by issue #2777. 

This PR closes issues #2908 and #2777. 

Previews: 
* For EPUB Fixed Layout Accessibility:
    * [Preview](https://raw.githack.com/w3c/epub-specs/fxl-a11y-metadata-update/wg-notes/fxl-a11y/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fwg-notes%2Ffxl-a11y%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Ffxl-a11y-metadata-update%2Fwg-notes%2Ffxl-a11y%2Findex.html)
* For EPUB Fixed Layout Accessibility Techniques:
    * [Preview](https://raw.githack.com/w3c/epub-specs/fxl-a11y-metadata-update/wg-notes/fxl-a11y-tech/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fwg-notes%2Ffxl-a11y-tech%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Ffxl-a11y-metadata-update%2Fwg-notes%2Ffxl-a11y-tech%2Findex.html)