### PR TITLE
[epub34-rs] fixed referenced spec ID

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1126,7 +1126,7 @@
 									<code>rendition:page-spread-*</code> properties and their unprefixed equivalents
 								MUST take precedence over whatever value of the <a
 									href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-										><code>page-break-before</code> property</a> [[csssnapshot]] has been set for an
+										><code>page-break-before</code> property</a> [[css2]] has been set for an
 								[=XHTML content document=].</p>
 
 							<p id="fxl-page-spread-combined" data-tests="#lay-pp-page-spread-combined">When a reading


### PR DESCRIPTION
non-substantive, and as title.
link target of property is CSS2 spec, but specref points csssnapshot which is non rec-track and cannot appear in normative part.