### PR TITLE
Fix a few more references to css snapshot for specific properties

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -4068,11 +4068,11 @@
 
 							<div class="note">
 								<p>It is advised to use <a href="https://url.spec.whatwg.org/#absolute-url-string"
-										>absolute-URL strings</a> [[url]] for identifiers whenever possible. The inclusion
-									of a domain can improve the uniqueness of the identifier, for example, while the use
-									of a URN with a <a href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1"
-										>namespace identifier</a> [[rfc8141]] improves processing by reading
-									systems.</p>
+										>absolute-URL strings</a> [[url]] for identifiers whenever possible. The
+									inclusion of a domain can improve the uniqueness of the identifier, for example,
+									while the use of a URN with a <a
+										href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1">namespace
+										identifier</a> [[rfc8141]] improves processing by reading systems.</p>
 							</div>
 
 							<p>The <a href="#identifier-type"><code>identifier-type</code> property</a> MAY be used to
@@ -5904,7 +5904,7 @@ No Entry</pre>
 					spine, the default rendering for their [[!html]] <a data-cite="html#the-body-element"
 							><code>body</code></a> elements is consistent with the <a
 						href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-							><code>page-break-before</code> property</a> [[!csssnapshot]] having been set to
+							><code>page-break-before</code> property</a> [[!css2]] having been set to
 						<code>always</code>. This behavior MAY be overridden through an appropriate style sheet
 					declaration if the reading system supports such overrides.</p>
 			</section>
@@ -7773,7 +7773,7 @@ No Entry</pre>
 
 				<div class="note">
 					<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-							property</a> [[csssnapshot]] controls the visual rendering of EPUB navigation documents in
+							property</a> [[css2]] controls the visual rendering of EPUB navigation documents in
 						[=reading systems=] with [=viewports=], reading systems without viewports might not support CSS.
 						The <code>hidden</code> attribute can be used together with the <code>display</code> property to
 						maximize interoperability across all reading systems.</p>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1496,8 +1496,8 @@
 					<h4>Author styling overrides</h4>
 
 					<p id="confreq-css-overrides">A reading system MAY override parts of an [=EPUB publication|EPUB
-						publication's=] styling (e.g., for ergonomic or user interface reasons). Morevoer, they MAY allow
-						users to set default themes and style preferences (e.g., for more accessible reading) that
+						publication's=] styling (e.g., for ergonomic or user interface reasons). Morevoer, they MAY
+						allow users to set default themes and style preferences (e.g., for more accessible reading) that
 						further alter the original design of a publication.</p>
 
 					<!-- <p id="confreq-css-user-styles">These changes often make it impractical to render an EPUB
@@ -1730,7 +1730,7 @@
 						numbering on <code>nav</code> elements when presenting them outside of the spine, regardless of
 						support for CSS, as the default display style of list items is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-								none</code> property</a> [[csssnapshot]].</p>
+								none</code> property</a> [[css2]].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-hidden"
@@ -1738,7 +1738,7 @@
 						markup and styling intended to hide elements of the navigation document from rendering in the
 						spine (e.g., the [[html]] [^html-global/hidden^] attribute and CSS <a
 							href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-							property</a> [[csssnapshot]]).</p>
+							property</a> [[css2]]).</p>
 				</li>
 			</ul>
 


### PR DESCRIPTION
(Picked up a bit of line length reformatting but the text in those spots hasn't changed.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2956.html" title="Last updated on Mar 18, 2026, 5:50 PM UTC (cf5c802)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2956/5ee08b1...cf5c802.html" title="Last updated on Mar 18, 2026, 5:50 PM UTC (cf5c802)">Diff</a>