### PR TITLE
fixed CSS reference targets

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -1730,7 +1730,7 @@
 						numbering on <code>nav</code> elements when presenting them outside of the spine, regardless of
 						support for CSS, as the default display style of list items is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-								none</code> property</a> [[csssnapshot]].</p>
+								none</code> property</a> [[css2]].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-hidden"
@@ -1738,7 +1738,7 @@
 						markup and styling intended to hide elements of the navigation document from rendering in the
 						spine (e.g., the [[html]] [^html-global/hidden^] attribute and CSS <a
 							href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-							property</a> [[csssnapshot]]).</p>
+							property</a> [[css2]]).</p>
 				</li>
 			</ul>
 


### PR DESCRIPTION
non-substantive, and as title.
both properties links to CSS2 spec, but spec reference points to csssnapshot but not css2.