### PR TITLE
alternate version for use json-ld keywords for language and direction

### DIFF
--- a/epub34/annotations-vocab/index.context.jsonld
+++ b/epub34/annotations-vocab/index.context.jsonld
@@ -3,8 +3,6 @@
         "@protected": true,
         "id": "@id",
         "type": "@type",
-        "language": "@language",
-        "direction": "@direction",
         "About": "http://www.w3.org/ns/ea#About",
         "Annotation": {
             "@id": "http://www.w3.org/ns/ea#Annotation",

--- a/epub34/annotations-vocab/index.context.jsonld
+++ b/epub34/annotations-vocab/index.context.jsonld
@@ -5,7 +5,7 @@
         "type": "@type",
         "language": "@language",
         "direction": "@direction",
-        "stringValue": "@value",
+        "text": "@value",
         "About": "http://www.w3.org/ns/ea#About",
         "Annotation": {
             "@id": "http://www.w3.org/ns/ea#Annotation",

--- a/epub34/annotations-vocab/index.context.jsonld
+++ b/epub34/annotations-vocab/index.context.jsonld
@@ -45,10 +45,7 @@
                     "@type": "@id",
                     "@container": "@set"
                 },
-                "title": {
-                    "@id": "http://www.w3.org/ns/ea#setTitle",
-                    "@type": "http://www.w3.org/2001/XMLSchema#string"
-                }
+                "title": "http://www.w3.org/ns/ea#setTitle"
             }
         },
         "Body": {
@@ -90,10 +87,7 @@
             "@id": "http://www.w3.org/ns/ea#Creator",
             "@context": {
                 "@protected": true,
-                "name": {
-                    "@id": "http://www.w3.org/ns/ea#name",
-                    "@type": "http://www.w3.org/2001/XMLSchema#string"
-                }
+                "name": "http://www.w3.org/ns/ea#name"
             }
         },
         "FragmentSelector": {
@@ -121,10 +115,7 @@
                     "@id": "http://www.w3.org/ns/ea#homepage",
                     "@type": "@id"
                 },
-                "name": {
-                    "@id": "http://www.w3.org/ns/ea#name",
-                    "@type": "http://www.w3.org/2001/XMLSchema#string"
-                }
+                "name": "http://www.w3.org/ns/ea#name"
             }
         },
         "Meta": "http://www.w3.org/ns/ea#Meta",

--- a/epub34/annotations-vocab/index.context.jsonld
+++ b/epub34/annotations-vocab/index.context.jsonld
@@ -3,6 +3,9 @@
         "@protected": true,
         "id": "@id",
         "type": "@type",
+        "language": "@language",
+        "direction": "@direction",
+        "stringValue": "@value",
         "About": "http://www.w3.org/ns/ea#About",
         "Annotation": {
             "@id": "http://www.w3.org/ns/ea#Annotation",

--- a/epub34/annotations-vocab/index.html
+++ b/epub34/annotations-vocab/index.html
@@ -602,7 +602,7 @@
                     <dt>Domain:</dt>
                     <dd><a href="#Creator"><code>Creator</code></a> ⊔&nbsp;<a href="#Generator"><code>Generator</code></a></dd>
                     <dt>Range:</dt>
-                    <dd><code>rdf:langString</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
+                    <dd><code>rdf:langString</code> ⊔&nbsp;<code>xsd:string</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
                 </dl>
                 <dl class="terms">
                     <dt>Relevant <code>@context</code>:</dt>
@@ -715,7 +715,7 @@
                     <dt>Domain:</dt>
                     <dd><a href="#AnnotationSet"><code>AnnotationSet</code></a></dd>
                     <dt>Range:</dt>
-                    <dd><code>rdf:langString</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
+                    <dd><code>rdf:langString</code> ⊔&nbsp;<code>xsd:string</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
                 </dl>
                 <dl class="terms">
                     <dt>Relevant <code>@context</code>:</dt>

--- a/epub34/annotations-vocab/index.html
+++ b/epub34/annotations-vocab/index.html
@@ -714,7 +714,7 @@
                     <dt>Domain:</dt>
                     <dd><a href="#AnnotationSet"><code>AnnotationSet</code></a></dd>
                     <dt>Range:</dt>
-                    <dd><code>xsd:string</code></dd>
+                    <dd><code>xsd:string</code> ⊔&nbsp;<code>rdf:langString</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
                 </dl>
                 <dl class="terms">
                     <dt>Relevant <code>@context</code>:</dt>

--- a/epub34/annotations-vocab/index.html
+++ b/epub34/annotations-vocab/index.html
@@ -593,7 +593,7 @@
                 <h4><code>name</code></h4>
                 <p><em>Name</em></p>
                 <p>See the <a href="https://www.w3.org/TR/epub-anno-10/#dfn-name">formal definition of the term</a>.</p>
-                <div>This property is available on some classes, see domain definition.</div>
+                <div>This property is available on some classes, see domain definition.<br><br>The property's value should be a natural language string.</div>
                 <dl class="terms">
                     <dt>Subproperty of:</dt>
                     <dd><span><a href="http://xmlns.com/foaf/0.1/name"><code>foaf:name</code></a></span><br></dd>
@@ -602,7 +602,7 @@
                     <dt>Domain:</dt>
                     <dd><a href="#Creator"><code>Creator</code></a> ⊔&nbsp;<a href="#Generator"><code>Generator</code></a></dd>
                     <dt>Range:</dt>
-                    <dd><code>xsd:string</code></dd>
+                    <dd><code>rdf:langString</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
                 </dl>
                 <dl class="terms">
                     <dt>Relevant <code>@context</code>:</dt>
@@ -709,12 +709,13 @@
                 <h4><code>setTitle</code></h4>
                 <p><em>Title of the Annotation Set</em></p>
                 <p>See the <a href="https://www.w3.org/TR/epub-anno-10/#dfn-title">formal definition of the term</a>.</p>
+                <p>The property's value should be a natural language string.</p>
                 <p>In the generated JSON-LD context file this term appears as "<code>title</code>".</p>
                 <dl class="terms">
                     <dt>Domain:</dt>
                     <dd><a href="#AnnotationSet"><code>AnnotationSet</code></a></dd>
                     <dt>Range:</dt>
-                    <dd><code>xsd:string</code> ⊔&nbsp;<code>rdf:langString</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
+                    <dd><code>rdf:langString</code> ⊔&nbsp;<code>rdf:dirLangString</code></dd>
                 </dl>
                 <dl class="terms">
                     <dt>Relevant <code>@context</code>:</dt>

--- a/epub34/annotations-vocab/index.html
+++ b/epub34/annotations-vocab/index.html
@@ -593,7 +593,7 @@
                 <h4><code>name</code></h4>
                 <p><em>Name</em></p>
                 <p>See the <a href="https://www.w3.org/TR/epub-anno-10/#dfn-name">formal definition of the term</a>.</p>
-                <div>This property is available on some classes, see domain definition.<br><br>The property's value should be a natural language string.</div>
+                <div>This property is available on some classes, see domain definition.<br><br>The property's value is expected to be a natural language string.</div>
                 <dl class="terms">
                     <dt>Subproperty of:</dt>
                     <dd><span><a href="http://xmlns.com/foaf/0.1/name"><code>foaf:name</code></a></span><br></dd>
@@ -709,7 +709,7 @@
                 <h4><code>setTitle</code></h4>
                 <p><em>Title of the Annotation Set</em></p>
                 <p>See the <a href="https://www.w3.org/TR/epub-anno-10/#dfn-title">formal definition of the term</a>.</p>
-                <p>The property's value should be a natural language string.</p>
+                <p>The property's value is expected to be a natural language string.</p>
                 <p>In the generated JSON-LD context file this term appears as "<code>title</code>".</p>
                 <dl class="terms">
                     <dt>Domain:</dt>

--- a/epub34/annotations-vocab/index.jsonld
+++ b/epub34/annotations-vocab/index.jsonld
@@ -79,7 +79,7 @@
         "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/epub-anno-vocab-10/",
-    "dc:date": "2026-03-06",
+    "dc:date": "2026-03-10",
     "rdfs_properties": [{
         "@id": "ea:about",
         "@type": ["rdf:Property", "owl:ObjectProperty"],
@@ -347,7 +347,10 @@
         "@id": "ea:setTitle",
         "@type": ["rdf:Property", "owl:DatatypeProperty"],
         "rdfs:domain": "ea:AnnotationSet",
-        "rdfs:range": "xsd:string",
+        "rdfs:range": {
+            "@type": "ows:Class",
+            "owl:unionOf": ["xsd:string", "rdf:langString", "rdf:dirLangString"]
+        },
         "rdfs:label": "Title of the Annotation Set",
         "rdfs:isDefinedBy": "https://www.w3.org/TR/epub-anno-10/#dfn-title",
         "vs:term_status": "stable",

--- a/epub34/annotations-vocab/index.jsonld
+++ b/epub34/annotations-vocab/index.jsonld
@@ -79,7 +79,7 @@
         "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/epub-anno-vocab-10/",
-    "dc:date": "2026-03-14",
+    "dc:date": "2026-03-23",
     "rdfs_properties": [{
         "@id": "ea:about",
         "@type": ["rdf:Property", "owl:ObjectProperty"],
@@ -262,7 +262,7 @@
         },
         "rdfs:range": {
             "@type": "ows:Class",
-            "owl:unionOf": ["rdf:langString", "rdf:dirLangString"]
+            "owl:unionOf": ["rdf:langString", "xsd:string", "rdf:dirLangString"]
         },
         "rdfs:label": "Name",
         "rdfs:comment": {
@@ -352,7 +352,7 @@
         "rdfs:domain": "ea:AnnotationSet",
         "rdfs:range": {
             "@type": "ows:Class",
-            "owl:unionOf": ["rdf:langString", "rdf:dirLangString"]
+            "owl:unionOf": ["rdf:langString", "xsd:string", "rdf:dirLangString"]
         },
         "rdfs:label": "Title of the Annotation Set",
         "rdfs:isDefinedBy": "https://www.w3.org/TR/epub-anno-10/#dfn-title",

--- a/epub34/annotations-vocab/index.jsonld
+++ b/epub34/annotations-vocab/index.jsonld
@@ -79,7 +79,7 @@
         "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/epub-anno-vocab-10/",
-    "dc:date": "2026-03-10",
+    "dc:date": "2026-03-12",
     "rdfs_properties": [{
         "@id": "ea:about",
         "@type": ["rdf:Property", "owl:ObjectProperty"],
@@ -254,13 +254,16 @@
         }]
     }, {
         "@id": "ea:name",
-        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "@type": "rdf:Property",
         "rdfs:subPropertyOf": ["foaf:name"],
         "rdfs:domain": {
             "@type": "owl:Class",
             "owl:unionOf": ["ea:Creator", "ea:Generator"]
         },
-        "rdfs:range": "xsd:string",
+        "rdfs:range": {
+            "@type": "ows:Class",
+            "owl:unionOf": ["rdf:langString", "rdf:dirLangString"]
+        },
         "rdfs:label": "Name",
         "rdfs:comment": {
             "@value": "<div>This property is available on some classes, see domain definition.</div>",
@@ -345,11 +348,11 @@
         }]
     }, {
         "@id": "ea:setTitle",
-        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "@type": "rdf:Property",
         "rdfs:domain": "ea:AnnotationSet",
         "rdfs:range": {
             "@type": "ows:Class",
-            "owl:unionOf": ["xsd:string", "rdf:langString", "rdf:dirLangString"]
+            "owl:unionOf": ["rdf:langString", "rdf:dirLangString"]
         },
         "rdfs:label": "Title of the Annotation Set",
         "rdfs:isDefinedBy": "https://www.w3.org/TR/epub-anno-10/#dfn-title",

--- a/epub34/annotations-vocab/index.jsonld
+++ b/epub34/annotations-vocab/index.jsonld
@@ -79,7 +79,7 @@
         "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/epub-anno-vocab-10/",
-    "dc:date": "2026-03-12",
+    "dc:date": "2026-03-14",
     "rdfs_properties": [{
         "@id": "ea:about",
         "@type": ["rdf:Property", "owl:ObjectProperty"],

--- a/epub34/annotations-vocab/index.jsonld
+++ b/epub34/annotations-vocab/index.jsonld
@@ -79,7 +79,7 @@
         "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/epub-anno-vocab-10/",
-    "dc:date": "2026-03-23",
+    "dc:date": "2026-04-07",
     "rdfs_properties": [{
         "@id": "ea:about",
         "@type": ["rdf:Property", "owl:ObjectProperty"],

--- a/epub34/annotations-vocab/index.ttl
+++ b/epub34/annotations-vocab/index.ttl
@@ -15,7 +15,7 @@ ea: a owl:Ontology ;
     dc:title """EPUB Annotations Vocabulary 1.0"""@en ;
     dc:description """RDFS [[rdf-schema]] vocabulary formalizing the terms defined in the [[[epub-anno-10]]] specification. The vocabulary is a "profile" of the W3C [[[annotation-vocab]]]"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/epub-anno-vocab-10/> ;
-    dc:date "2026-03-14"^^xsd:date ;
+    dc:date "2026-03-23"^^xsd:date ;
 .
 
 # Property definitions
@@ -120,7 +120,7 @@ ea:motivation a rdf:Property ;
 ea:name a rdf:Property ;
     rdfs:subPropertyOf foaf:name ;
     rdfs:domain [ a owl:Class; owl:unionOf (ea:Creator ea:Generator) ] ;
-    rdfs:range [ a owl:Class; owl:unionOf (rdf:langString rdf:dirLangString) ] ;
+    rdfs:range [ a owl:Class; owl:unionOf (rdf:langString xsd:string rdf:dirLangString) ] ;
     rdfs:label "Name" ;
     rdfs:comment """<div>This property is available on some classes, see domain definition.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://www.w3.org/TR/epub-anno-10/#dfn-name>, <http://www.w3.org/ns/ea#> ;
@@ -174,7 +174,7 @@ ea:target a rdf:Property, owl:ObjectProperty ;
 
 ea:setTitle a rdf:Property ;
     rdfs:domain ea:AnnotationSet ;
-    rdfs:range [ a owl:Class; owl:unionOf (rdf:langString rdf:dirLangString) ] ;
+    rdfs:range [ a owl:Class; owl:unionOf (rdf:langString xsd:string rdf:dirLangString) ] ;
     rdfs:label "Title of the Annotation Set" ;
     rdfs:isDefinedBy <https://www.w3.org/TR/epub-anno-10/#dfn-title>, <http://www.w3.org/ns/ea#> ;
     vs:term_status "stable" ;

--- a/epub34/annotations-vocab/index.ttl
+++ b/epub34/annotations-vocab/index.ttl
@@ -15,7 +15,7 @@ ea: a owl:Ontology ;
     dc:title """EPUB Annotations Vocabulary 1.0"""@en ;
     dc:description """RDFS [[rdf-schema]] vocabulary formalizing the terms defined in the [[[epub-anno-10]]] specification. The vocabulary is a "profile" of the W3C [[[annotation-vocab]]]"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/epub-anno-vocab-10/> ;
-    dc:date "2026-03-06"^^xsd:date ;
+    dc:date "2026-03-10"^^xsd:date ;
 .
 
 # Property definitions
@@ -174,7 +174,7 @@ ea:target a rdf:Property, owl:ObjectProperty ;
 
 ea:setTitle a rdf:Property, owl:DatatypeProperty ;
     rdfs:domain ea:AnnotationSet ;
-    rdfs:range xsd:string ;
+    rdfs:range [ a owl:Class; owl:unionOf (xsd:string rdf:langString rdf:dirLangString) ] ;
     rdfs:label "Title of the Annotation Set" ;
     rdfs:isDefinedBy <https://www.w3.org/TR/epub-anno-10/#dfn-title>, <http://www.w3.org/ns/ea#> ;
     vs:term_status "stable" ;

--- a/epub34/annotations-vocab/index.ttl
+++ b/epub34/annotations-vocab/index.ttl
@@ -15,7 +15,7 @@ ea: a owl:Ontology ;
     dc:title """EPUB Annotations Vocabulary 1.0"""@en ;
     dc:description """RDFS [[rdf-schema]] vocabulary formalizing the terms defined in the [[[epub-anno-10]]] specification. The vocabulary is a "profile" of the W3C [[[annotation-vocab]]]"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/epub-anno-vocab-10/> ;
-    dc:date "2026-03-23"^^xsd:date ;
+    dc:date "2026-04-07"^^xsd:date ;
 .
 
 # Property definitions

--- a/epub34/annotations-vocab/index.ttl
+++ b/epub34/annotations-vocab/index.ttl
@@ -15,7 +15,7 @@ ea: a owl:Ontology ;
     dc:title """EPUB Annotations Vocabulary 1.0"""@en ;
     dc:description """RDFS [[rdf-schema]] vocabulary formalizing the terms defined in the [[[epub-anno-10]]] specification. The vocabulary is a "profile" of the W3C [[[annotation-vocab]]]"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/epub-anno-vocab-10/> ;
-    dc:date "2026-03-12"^^xsd:date ;
+    dc:date "2026-03-14"^^xsd:date ;
 .
 
 # Property definitions

--- a/epub34/annotations-vocab/index.ttl
+++ b/epub34/annotations-vocab/index.ttl
@@ -15,7 +15,7 @@ ea: a owl:Ontology ;
     dc:title """EPUB Annotations Vocabulary 1.0"""@en ;
     dc:description """RDFS [[rdf-schema]] vocabulary formalizing the terms defined in the [[[epub-anno-10]]] specification. The vocabulary is a "profile" of the W3C [[[annotation-vocab]]]"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/epub-anno-vocab-10/> ;
-    dc:date "2026-03-10"^^xsd:date ;
+    dc:date "2026-03-12"^^xsd:date ;
 .
 
 # Property definitions
@@ -117,10 +117,10 @@ ea:motivation a rdf:Property ;
     vs:term_status "stable" ;
 .
 
-ea:name a rdf:Property, owl:DatatypeProperty ;
+ea:name a rdf:Property ;
     rdfs:subPropertyOf foaf:name ;
     rdfs:domain [ a owl:Class; owl:unionOf (ea:Creator ea:Generator) ] ;
-    rdfs:range xsd:string ;
+    rdfs:range [ a owl:Class; owl:unionOf (rdf:langString rdf:dirLangString) ] ;
     rdfs:label "Name" ;
     rdfs:comment """<div>This property is available on some classes, see domain definition.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://www.w3.org/TR/epub-anno-10/#dfn-name>, <http://www.w3.org/ns/ea#> ;
@@ -172,9 +172,9 @@ ea:target a rdf:Property, owl:ObjectProperty ;
     vs:term_status "stable" ;
 .
 
-ea:setTitle a rdf:Property, owl:DatatypeProperty ;
+ea:setTitle a rdf:Property ;
     rdfs:domain ea:AnnotationSet ;
-    rdfs:range [ a owl:Class; owl:unionOf (xsd:string rdf:langString rdf:dirLangString) ] ;
+    rdfs:range [ a owl:Class; owl:unionOf (rdf:langString rdf:dirLangString) ] ;
     rdfs:label "Title of the Annotation Set" ;
     rdfs:isDefinedBy <https://www.w3.org/TR/epub-anno-10/#dfn-title>, <http://www.w3.org/ns/ea#> ;
     vs:term_status "stable" ;

--- a/epub34/annotations-vocab/index.yml
+++ b/epub34/annotations-vocab/index.yml
@@ -2,6 +2,9 @@ json_ld:
     alias:
         "id"          : "@id"
         "type"        : "@type"
+        "language"    : "@language"
+        "direction"   : "@direction"
+        "stringValue" : "@value"
     import: "https://www.w3.org/ns/anno.jsonld"        # Note the 'https' some JSON-LD environments require that...
 
 vocab:
@@ -189,7 +192,8 @@ property:
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-name
       upper_value: foaf:name
       domain: [Creator, Generator]
-      range: rdf:langString
+      range: [rdf:langString, xsd:string]
+      range_union: true
 
     - id: refinedBy
       label: Selector refinement
@@ -234,7 +238,8 @@ property:
       label: Title of the Annotation Set
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-title
       domain: AnnotationSet
-      range: rdf:langString
+      range: [rdf:langString, xsd:string]
+      range_union: true
 
 individual:
     - id: pink

--- a/epub34/annotations-vocab/index.yml
+++ b/epub34/annotations-vocab/index.yml
@@ -2,10 +2,8 @@
 
 json_ld:
     alias:
-        "id"        : "@id"
-        "type"      : "@type"
-        "language"  : "@language"
-        "direction" : "@direction"
+        "id"          : "@id"
+        "type"        : "@type"
     import: "https://www.w3.org/ns/anno.jsonld"        # Note the 'https' some JSON-LD environments require that...
 
 vocab:
@@ -238,7 +236,8 @@ property:
       label: Title of the Annotation Set
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-title
       domain: AnnotationSet
-      range: xsd:string
+      range: [xsd:string, rdf:langString, rdf:dirLangString]
+      range_union: true
 
 individual:
     - id: pink

--- a/epub34/annotations-vocab/index.yml
+++ b/epub34/annotations-vocab/index.yml
@@ -189,7 +189,7 @@ property:
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-name
       upper_value: foaf:name
       domain: [Creator, Generator]
-      range: langString
+      range: rdf:langString
 
     - id: refinedBy
       label: Selector refinement
@@ -234,7 +234,7 @@ property:
       label: Title of the Annotation Set
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-title
       domain: AnnotationSet
-      range: langString
+      range: rdf:langString
 
 individual:
     - id: pink

--- a/epub34/annotations-vocab/index.yml
+++ b/epub34/annotations-vocab/index.yml
@@ -1,10 +1,10 @@
 json_ld:
     alias:
-        "id"          : "@id"
-        "type"        : "@type"
-        "language"    : "@language"
-        "direction"   : "@direction"
-        "stringValue" : "@value"
+        "id"        : "@id"
+        "type"      : "@type"
+        "language"  : "@language"
+        "direction" : "@direction"
+        "text"      : "@value"
     import: "https://www.w3.org/ns/anno.jsonld"        # Note the 'https' some JSON-LD environments require that...
 
 vocab:

--- a/epub34/annotations-vocab/index.yml
+++ b/epub34/annotations-vocab/index.yml
@@ -1,5 +1,3 @@
-# TODO: All the back links to the specification must be finalized.
-
 json_ld:
     alias:
         "id"          : "@id"
@@ -191,7 +189,7 @@ property:
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-name
       upper_value: foaf:name
       domain: [Creator, Generator]
-      range: xsd:string
+      range: langString
 
     - id: refinedBy
       label: Selector refinement
@@ -236,8 +234,7 @@ property:
       label: Title of the Annotation Set
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-title
       domain: AnnotationSet
-      range: [xsd:string, rdf:langString, rdf:dirLangString]
-      range_union: true
+      range: langString
 
 individual:
     - id: pink

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -305,7 +305,7 @@
                                 <code> name </code>
                             </td>
                             <td> The name of the creator. </td>
-                            <td> string </td>
+                            <td> natural language string </td>
                             <td> No </td>
                         </tr>
                     </tbody>
@@ -840,7 +840,7 @@
                                 <code> value </code>
                             </td>
                             <td> The textual content of the annotation. </td>
-                            <td> string </td>
+                            <td> natural language string </td>
                             <td> Yes </td>
                         </tr>
                         <tr>
@@ -870,22 +870,6 @@
                         </tr>
                         <tr>
                             <td>
-                                <code> language </code>
-                            </td>
-                            <td> The language of the annotation. </td>
-                            <td> [[BCP47]] </td>
-                            <td> No </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code> textDirection </code>
-                            </td>
-                            <td> The direction of the text; left-to-right by default. </td>
-                            <td> "ltr" | "rtl" </td>
-                            <td> No </td>
-                        </tr>
-                        <tr>
-                            <td>
                                 <code> <dfn>tags</dfn> </code>
                             </td>
                             <td> Free text categorizing the annotation. </td>
@@ -896,8 +880,6 @@
                 </table>
 
                 <p class="note">Read “Best practices for Reading Systems” about using tags in an annotation. </p>
-                <p class="issue" data-number="2854"></p>
-
                 <aside class="example" title="An annotation Body">
                     <pre>
    {
@@ -990,7 +972,7 @@
                             <code><dfn>title</dfn></code>
                         </td>
                         <td> A title to help identifying the set. </td>
-                        <td> string </td>
+                        <td> natural language string </td>
                         <td> No </td>
                     </tr>
                     <tr>
@@ -1042,7 +1024,7 @@
                                 <code> name </code>
                             </td>
                             <td> The name of the generator software. </td>
-                            <td> string </td>
+                            <td> natural language string </td>
                             <td> Yes </td>
                         </tr>
                         <tr>
@@ -1083,7 +1065,7 @@
                                 <code> dc:title </code>
                             </td>
                             <td> The title of the publication. </td>
-                            <td> string </td>
+                            <td> natural language string </td>
                             <td> No </td>
                         </tr>
                         <tr>
@@ -1099,7 +1081,7 @@
                                 <code> dc:publisher </code>
                             </td>
                             <td> The name of the publisher. </td>
-                            <td> string </td>
+                            <td> natural language string </td>
                             <td> No </td>
                         </tr>
                         <tr>
@@ -1107,7 +1089,7 @@
                                 <code> dc:creator </code>
                             </td>
                             <td> The author(s) of the publication. </td>
-                            <td> array of strings </td>
+                            <td> array of natural language strings </td>
                             <td> No </td>
                         </tr>
                         <tr>
@@ -1298,6 +1280,140 @@
             <h1> JSON Schema </h1>
 
             <p>T.B.D.</p>
+        </section>
+
+        <section>
+            <h1>Internationalization Considerations</h1>
+
+            <section class="informative">
+                <h2>Natural language strings</h2>
+
+                <p>
+                    The EPUB Annotation model inherits the <a data-cite="json-ld11#string-internationalization">string internationalization</a> features
+                    defined by [[[json-ld11]]]. The <a data-cite="json-ld11#dfn-default-language">default language</a> and
+                    <a data-cite="json-ld11#dfn-base-direction">base direction</a>
+                    of a natural language string can be set with the `@language` and `@direction` keywords, respectively.
+                    The value for `@language` is a string representing a [[BCP47]] language tag.
+                    The value for `@direction` is a string whose value must be `"ltr"`, `"rtl"`.
+                    Using these keywords, the language and the direction of natural language strings can be set either globally,
+                    e.g., for all annotations in an [=AnnotationSet=], or for a specific like, for example a [=Body object=].
+                </p>
+
+                <p>
+                    For a global setting, the language and direction may be set by adding an extra, dedicated context object to
+                    `@context` (using the JSON array notation) setting the necessary values.
+                </p>
+
+                <aside class="example" title="Setting language and direction globally">
+                    <pre>
+                    {
+                        "@context": [
+                            "https://www.w3.org/ns/epub-anno.jsonld",
+                            {
+                                "@language": "en",
+                                "@direction": "ltr"
+                            }
+                        ],
+                        "type": "AnnotationSet",
+                        "id": "urn:uuid:123-456-789",
+                        "items" : [
+                            {
+                                "type": "Annotation",
+                                "id": "urn:uuid:123-456-789-a1",
+                                "body": {
+                                    "type": "TextualBody",
+                                    "value": "This is a comment in English"
+                                }
+                            },
+                            …
+                        ]
+                    }
+                    </pre>
+                </aside>
+
+                <p>
+                    For setting the values locally, the same `@context` notation can be used within any
+                    object. This is referred to as the <a data-cite="json-ld11#scoped-contexts">"scoped" context</a>,
+                    i.e., a context that is only valid within the enclosing object and its descendent objects.
+                    Possible global values are overwritten.
+                </p>
+
+                <aside class="example" title="Setting language and direction locally">
+                    <pre>
+                        {
+                            "@context": [
+                                "https://www.w3.org/ns/epub-anno.jsonld",
+                                {
+                                    "@language": "en",
+                                    "@direction": "ltr"
+                                }
+                            ],
+                            "type": "AnnotationSet",
+                            "id": "urn:uuid:123-456-789",
+                            "items" : [
+                                …
+                                {
+                                    "id": "urn:uuid:123-456-789-a2",
+                                    "type": "Annotation",
+                                    "body": {
+                                        "@context": {
+                                            "@language": "he",
+                                            "@direction": "rtl"
+                                        },
+                                        "type": "TextualBody",
+                                        "value": "התגובה הזו בעברית"
+                                    }
+                                },
+                                …
+                            ]
+                        }
+                        </pre>
+                 </aside>
+                <!-- <section>
+                    <h3>Setting for a specific string</h3>
+                    <p>
+                        This is the finest granularity setting; instead of relying on the global or the scoped context, the
+                        language and direction are set on a specific string. This relies on an an additional, property called `stringValue`,
+                        and is used as follows:
+                    </p>
+
+                    <aside class="example" title="Setting language and direction locally">
+                        <pre>
+                            …
+                                "items": [
+                                    {
+                                        …
+                                    },
+                                    {
+                                        "id": "urn:uuid:123-456-789-a3",
+                                        "type": "Annotation",
+                                        "body": {
+                                            "type": "TextualBody",
+                                            "value": {
+                                                "@language"   : "he",
+                                                "@direction"  : "rtl",
+                                                "stringValue" : "התגובה הזו בעברית"
+                                            }
+                                        }
+                                    },
+                                    …
+                                ]
+                            …
+                        </pre>
+                    </aside>
+
+                    <p>
+                        `stringValue` is actually an alias set to the JSON-LD `@value` keyword by the core EPUB Annotation `@context`
+                        file. It has been introduced to avoid a possible clash with the `value` property, inherited from the [[annotation-model]] specification.
+                    </p>
+                    <div class="issue">
+                        <p>
+                            It is not clear whether the string level language setting is of any use for annotations. It
+                            may be simpler ignore this possibility and require the usage of scoped contexts everywhere.
+                        </p>
+                    </div>
+                </section> -->
+            </section>
         </section>
 
         <section>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1320,10 +1320,16 @@
                             {
                                 "id": "urn:uuid:123-456-789-a1",
                                 "type": "Annotation",
-                                "value": {
-                                    "language": "en",
-                                    "stringValue": "HTML is a markup language.",
-                                    "language": "en"
+                                "body" : {
+                                    "type": "TextualBody",
+                                    "value": {
+                                        "language": "en",
+                                        "stringValue": "HTML is a markup language.",
+                                        "language": "en"
+                                    }
+                                },
+                                "target" : {
+                                    …
                                 }
                             },
                             {
@@ -1336,6 +1342,9 @@
                                         "direction": "rtl",
                                         "stringValue": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
                                     }
+                                },
+                                "target": {
+                                    …
                                 }
                             },
                             …
@@ -1373,7 +1382,13 @@
                                 {
                                     "id": "urn:uuid:123-456-789-a1",
                                     "type": "Annotation",
-                                    "value": "HTML is a markup language."
+                                    "body": {
+                                        "type": "TextualBody",
+                                        "value": "HTML is a markup language."
+                                    },
+                                    "target": {
+                                        …
+                                    }
                                 },
                                 {
                                     "id": "urn:uuid:123-456-789-a3",
@@ -1385,6 +1400,9 @@
                                             "direction": "rtl",
                                             "stringValue": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
                                         }
+                                    },
+                                    "target": {
+                                        …
                                     }
                                 },
                                 …

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1295,7 +1295,7 @@
                     <a data-cite="json-ld11#dfn-base-direction">base direction</a>
                     of a natural language string can be set with the `@language` and `@direction` keywords, respectively.
                     The value for `@language` is a string representing a [[BCP47]] language tag.
-                    The value for `@direction` is a string whose value must be `"ltr"`, `"rtl"`.
+                    The value for `@direction` is a string whose value must be either `"ltr"` or `"rtl"`.
                     Using these keywords, the language and the direction of natural language strings can be set either globally,
                     e.g., for all annotations in an [=AnnotationSet=], or for a specific object like a [=Body object=].
                 </p>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1289,57 +1289,27 @@
                 <h2>Natural language strings</h2>
 
                 <p>
-                    The EPUB Annotation model inherits the <a data-cite="json-ld11#string-internationalization">string internationalization</a> features
-                    defined by [[[json-ld11]]]. The <a data-cite="json-ld11#dfn-default-language">default language</a> and
+                    The EPUB Annotation model inherits the <a data-cite="json-ld11#string-internationalization">string
+                    internationalization</a> features defined by [[[json-ld11]]].
+                    The <a data-cite="json-ld11#dfn-default-language">default language</a> and
                     <a data-cite="json-ld11#dfn-base-direction">base direction</a>
                     of a natural language string can be set with the `@language` and `@direction` keywords, respectively.
                     The value for `@language` is a string representing a [[BCP47]] language tag.
                     The value for `@direction` is a string whose value must be `"ltr"`, `"rtl"`.
                     Using these keywords, the language and the direction of natural language strings can be set either globally,
-                    e.g., for all annotations in an [=AnnotationSet=], or for a specific like, for example a [=Body object=].
+                    e.g., for all annotations in an [=AnnotationSet=], or for a specific object like a [=Body object=].
                 </p>
 
-                <p>
-                    For a global setting, the language and direction may be set by adding an extra, dedicated context object to
-                    `@context` (using the JSON array notation) setting the necessary values.
-                </p>
+                <section>
+                    <h3>Global setting</h3>
+                    <p>
+                        For global setting, the value of the top-level `@context` must be extended with an extra context object
+                        (using the JSON array notation) containing the necessary statements.
+                        The `@language` and `@direction` keys are used to set the respective values.
+                    </p>
 
-                <aside class="example" title="Setting language and direction globally">
-                    <pre>
-                    {
-                        "@context": [
-                            "https://www.w3.org/ns/epub-anno.jsonld",
-                            {
-                                "@language": "en",
-                                "@direction": "ltr"
-                            }
-                        ],
-                        "type": "AnnotationSet",
-                        "id": "urn:uuid:123-456-789",
-                        "items" : [
-                            {
-                                "type": "Annotation",
-                                "id": "urn:uuid:123-456-789-a1",
-                                "body": {
-                                    "type": "TextualBody",
-                                    "value": "This is a comment in English"
-                                }
-                            },
-                            …
-                        ]
-                    }
-                    </pre>
-                </aside>
-
-                <p>
-                    For setting the values locally, the same `@context` notation can be used within any
-                    object. This is referred to as the <a data-cite="json-ld11#scoped-contexts">"scoped" context</a>,
-                    i.e., a context that is only valid within the enclosing object and its descendent objects.
-                    Possible global values are overwritten.
-                </p>
-
-                <aside class="example" title="Setting language and direction locally">
-                    <pre>
+                    <aside class="example" title="Setting language and direction globally">
+                        <pre>
                         {
                             "@context": [
                                 "https://www.w3.org/ns/epub-anno.jsonld",
@@ -1351,25 +1321,69 @@
                             "type": "AnnotationSet",
                             "id": "urn:uuid:123-456-789",
                             "items" : [
-                                …
                                 {
-                                    "id": "urn:uuid:123-456-789-a2",
                                     "type": "Annotation",
+                                    "id": "urn:uuid:123-456-789-a1",
                                     "body": {
-                                        "@context": {
-                                            "@language": "he",
-                                            "@direction": "rtl"
-                                        },
                                         "type": "TextualBody",
-                                        "value": "התגובה הזו בעברית"
+                                        "value": "This is a comment in English"
                                     }
                                 },
                                 …
                             ]
                         }
                         </pre>
-                 </aside>
-                <!-- <section>
+                    </aside>
+
+                    <p>
+                        These language and direction values are valid for all natural language strings in the Annotation Set,
+                        unless overwritten by a local setting.
+                    </p>
+                </section>
+                <section>
+                    <h3>Local setting</h3>
+
+                    <p>
+                        For setting the values locally, the same `@context` notation can be used within any
+                        object. This is referred to as the <a data-cite="json-ld11#scoped-contexts">"scoped" context</a>,
+                        i.e., a context that is only valid within the enclosing object and its descendent objects.
+                        Possible global values are overwritten.
+                    </p>
+
+                    <aside class="example" title="Setting language and direction locally">
+                        <pre>
+                            {
+                                "@context": [
+                                    "https://www.w3.org/ns/epub-anno.jsonld",
+                                    {
+                                        "@language": "en",
+                                        "@direction": "ltr"
+                                    }
+                                ],
+                                "type": "AnnotationSet",
+                                "id": "urn:uuid:123-456-789",
+                                "items" : [
+                                    …
+                                    {
+                                        "id": "urn:uuid:123-456-789-a2",
+                                        "type": "Annotation",
+                                        "body": {
+                                            "@context": {
+                                                "@language": "he",
+                                                "@direction": "rtl"
+                                            },
+                                            "type": "TextualBody",
+                                            "value": "התגובה הזו בעברית"
+                                        }
+                                    },
+                                    …
+                                ]
+                            }
+                            </pre>
+                    </aside>
+                </section>
+
+                 <!-- <section>
                     <h3>Setting for a specific string</h3>
                     <p>
                         This is the finest granularity setting; instead of relying on the global or the scoped context, the

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -890,8 +890,6 @@
             "value": "j'adore !",
             "tags": ["teacher"],
             "color": "blue",
-            "language": "fr",
-            "textDirection": "ltr"
         }
     }
 			        </pre>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1022,7 +1022,7 @@
                                 <code> name </code>
                             </td>
                             <td> The name of the generator software. </td>
-                            <td> Localizable text </td>
+                            <td> string </td>
                             <td> Yes </td>
                         </tr>
                         <tr>
@@ -1313,7 +1313,7 @@
                         "type": "AnnotationSet",
                         "id": "urn:uuid:123-456-789",
                         "title" : {
-                            "stringValue": "This is an example for an annotation text",
+                            "text": "This is an example for an annotation text",
                             "language": "en"
                         },
                         "items" : [
@@ -1324,7 +1324,7 @@
                                     "type": "TextualBody",
                                     "value": {
                                         "language": "en",
-                                        "stringValue": "HTML is a markup language.",
+                                        "text": "HTML is a markup language.",
                                     }
                                 },
                                 "target" : {
@@ -1339,7 +1339,7 @@
                                     "value": {
                                         "language": "he",
                                         "direction": "rtl",
-                                        "stringValue": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
+                                        "text": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
                                     }
                                 },
                                 "target": {
@@ -1350,11 +1350,7 @@
                         ]
                     }
                     </pre>
-                 </aside>
-                 <div class="ednote">
-                    The "language", "direction", and "stringValue" terms are all aliases that we define. Ie, it is possible to use
-                    other terms, e.g., "lang" or "dir".
-                </div>
+                </aside>
 
                 <section>
                     <h3>Setting the default values</h3>
@@ -1397,7 +1393,7 @@
                                         "value": {
                                             "language": "he",
                                             "direction": "rtl",
-                                            "stringValue": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
+                                            "text": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
                                         }
                                     },
                                     "target": {

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1325,7 +1325,6 @@
                                     "value": {
                                         "language": "en",
                                         "stringValue": "HTML is a markup language.",
-                                        "language": "en"
                                     }
                                 },
                                 "target" : {

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -305,7 +305,7 @@
                                 <code> name </code>
                             </td>
                             <td> The name of the creator. </td>
-                            <td> natural language string </td>
+                            <td> Localizable text </td>
                             <td> No </td>
                         </tr>
                     </tbody>
@@ -840,7 +840,7 @@
                                 <code> value </code>
                             </td>
                             <td> The textual content of the annotation. </td>
-                            <td> natural language string </td>
+                            <td> Localizable text </td>
                             <td> Yes </td>
                         </tr>
                         <tr>
@@ -972,7 +972,7 @@
                             <code><dfn>title</dfn></code>
                         </td>
                         <td> A title to help identifying the set. </td>
-                        <td> natural language string </td>
+                        <td> Localizable text </td>
                         <td> No </td>
                     </tr>
                     <tr>
@@ -1024,7 +1024,7 @@
                                 <code> name </code>
                             </td>
                             <td> The name of the generator software. </td>
-                            <td> natural language string </td>
+                            <td> Localizable text </td>
                             <td> Yes </td>
                         </tr>
                         <tr>
@@ -1065,7 +1065,7 @@
                                 <code> dc:title </code>
                             </td>
                             <td> The title of the publication. </td>
-                            <td> natural language string </td>
+                            <td> Localizable text </td>
                             <td> No </td>
                         </tr>
                         <tr>
@@ -1081,7 +1081,7 @@
                                 <code> dc:publisher </code>
                             </td>
                             <td> The name of the publisher. </td>
-                            <td> natural language string </td>
+                            <td> Localizable text </td>
                             <td> No </td>
                         </tr>
                         <tr>
@@ -1089,7 +1089,7 @@
                                 <code> dc:creator </code>
                             </td>
                             <td> The author(s) of the publication. </td>
-                            <td> array of natural language strings </td>
+                            <td> array of Localizable texts </td>
                             <td> No </td>
                         </tr>
                         <tr>
@@ -1286,47 +1286,107 @@
             <h1>Internationalization Considerations</h1>
 
             <section class="informative">
-                <h2>Natural language strings</h2>
+                <h2>Localizable texts</h2>
 
                 <p>
                     The EPUB Annotation model inherits the <a data-cite="json-ld11#string-internationalization">string
                     internationalization</a> features defined by [[[json-ld11]]].
-                    The <a data-cite="json-ld11#dfn-default-language">default language</a> and
-                    <a data-cite="json-ld11#dfn-base-direction">base direction</a>
-                    of a natural language string can be set with the `@language` and `@direction` keywords, respectively.
-                    The value for `@language` is a string representing a [[BCP47]] language tag.
-                    The value for `@direction` is a string whose value must be either `"ltr"` or `"rtl"`.
-                    Using these keywords, the language and the direction of natural language strings can be set either globally,
-                    e.g., for all annotations in an [=AnnotationSet=], or for a specific object like a [=Body object=].
+                    These may be used for values that are defined as
+                    <a data-cite="i18n-glossary#dfn-localizable-text">localizable texts</a>.
+                    To set the right language metadata, the value is a separate
+                    object with the string value set explicitly through the `stringValue` property.
+                    The `language` and `direction` properties can be used to set the
+                    <a data-cite="i18n-glossary#dfn-language-tag">language tag</a>
+                    and the  <a data-cite="i18n-glossary#dfn-string-direction">string direction</a>, respectively.
+                    The value for `language` is a string representing a [[BCP47]] language tag.
+                    The value for `direction` is a string whose value must be either `"ltr"` or `"rtl"`.
                 </p>
 
+                <p>
+                    In the example below, two annotations within the same [=AnnotationSet=] use different languages.
+                    In the second annotation the string direction is also set to ensure the correct
+                    rendering of the text with mixed Latin and Hebrew characters.
+                </p>
+
+                <aside class="example" title="Setting the language explicitly for localizable texts">
+                    <pre>
+                    {
+                        "@context": "https://www.w3.org/ns/epub-anno.jsonld",
+                        "type": "AnnotationSet",
+                        "id": "urn:uuid:123-456-789",
+                        "title" : {
+                            "stringValue": "This is an example for an annotation text",
+                            "language": "en"
+                        },
+                        "items" : [
+                            {
+                                "id": "urn:uuid:123-456-789-a1",
+                                "type": "Annotation",
+                                "value": {
+                                    "language": "en",
+                                    "stringValue": "HTML is a markup language.",
+                                    "language": "en"
+                                }
+                            },
+                            {
+                                "id": "urn:uuid:123-456-789-a3",
+                                "type": "Annotation",
+                                "body": {
+                                    "type": "TextualBody",
+                                    "value": {
+                                        "language": "he",
+                                        "direction": "rtl",
+                                        "stringValue": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
+                                    }
+                                }
+                            },
+                            …
+                        ]
+                    }
+                    </pre>
+                 </aside>
+                 <div class="ednote">
+                    The "language", "direction", and "stringValue" terms are all aliases that we define. Ie, it is possible to use
+                    other terms, e.g., "lang" or "dir".
+                </div>
+
                 <section>
-                    <h3>Global setting</h3>
+                    <h3>Setting the default values</h3>
+
                     <p>
-                        For global setting, the value of the top-level `@context` must be extended with an extra context object
-                        (using the JSON array notation) containing the necessary statements.
-                        The `@language` and `@direction` keys are used to set the respective values.
+                        The default values for `language` and `direction` may be set as part of the context
+                        declaration of the Annotation Set. The value of the top-level `@context` must be
+                        extended with an extra context object (using the JSON array notation) containing the default setting using the the `@language` and `@direction` keywords. See the example below as an alternative for the previous example.
                     </p>
 
-                    <aside class="example" title="Setting language and direction globally">
+                    <aside class="example" title="Setting the default language to English">
                         <pre>
                         {
                             "@context": [
                                 "https://www.w3.org/ns/epub-anno.jsonld",
                                 {
-                                    "@language": "en",
-                                    "@direction": "ltr"
+                                    "@language": "en"
                                 }
                             ],
                             "type": "AnnotationSet",
                             "id": "urn:uuid:123-456-789",
+                            "title" : "This is an example for an annotation text",
                             "items" : [
                                 {
-                                    "type": "Annotation",
                                     "id": "urn:uuid:123-456-789-a1",
+                                    "type": "Annotation",
+                                    "value": "HTML is a markup language."
+                                },
+                                {
+                                    "id": "urn:uuid:123-456-789-a3",
+                                    "type": "Annotation",
                                     "body": {
                                         "type": "TextualBody",
-                                        "value": "This is a comment in English"
+                                        "value": {
+                                            "language": "he",
+                                            "direction": "rtl",
+                                            "stringValue": <bdo dir="rtl">"HTML היא שפת סימון."</bdo>
+                                        }
                                     }
                                 },
                                 …
@@ -1335,99 +1395,11 @@
                         </pre>
                     </aside>
 
-                    <p>
-                        These language and direction values are valid for all natural language strings in the Annotation Set,
-                        unless overwritten by a local setting.
+                    <p class="note">
+                        The extra object in the context can be used whenever a context is set. For example, it is possible to set the default value for a single annotation.
                     </p>
                 </section>
-                <section>
-                    <h3>Local setting</h3>
-
-                    <p>
-                        For setting the values locally, the same `@context` notation can be used within any
-                        object. This is referred to as the <a data-cite="json-ld11#scoped-contexts">"scoped" context</a>,
-                        i.e., a context that is only valid within the enclosing object and its descendent objects.
-                        Possible global values are overwritten.
-                    </p>
-
-                    <aside class="example" title="Setting language and direction locally">
-                        <pre>
-                            {
-                                "@context": [
-                                    "https://www.w3.org/ns/epub-anno.jsonld",
-                                    {
-                                        "@language": "en",
-                                        "@direction": "ltr"
-                                    }
-                                ],
-                                "type": "AnnotationSet",
-                                "id": "urn:uuid:123-456-789",
-                                "items" : [
-                                    …
-                                    {
-                                        "id": "urn:uuid:123-456-789-a2",
-                                        "type": "Annotation",
-                                        "body": {
-                                            "@context": {
-                                                "@language": "he",
-                                                "@direction": "rtl"
-                                            },
-                                            "type": "TextualBody",
-                                            "value": "התגובה הזו בעברית"
-                                        }
-                                    },
-                                    …
-                                ]
-                            }
-                            </pre>
-                    </aside>
-                </section>
-
-                 <!-- <section>
-                    <h3>Setting for a specific string</h3>
-                    <p>
-                        This is the finest granularity setting; instead of relying on the global or the scoped context, the
-                        language and direction are set on a specific string. This relies on an an additional, property called `stringValue`,
-                        and is used as follows:
-                    </p>
-
-                    <aside class="example" title="Setting language and direction locally">
-                        <pre>
-                            …
-                                "items": [
-                                    {
-                                        …
-                                    },
-                                    {
-                                        "id": "urn:uuid:123-456-789-a3",
-                                        "type": "Annotation",
-                                        "body": {
-                                            "type": "TextualBody",
-                                            "value": {
-                                                "@language"   : "he",
-                                                "@direction"  : "rtl",
-                                                "stringValue" : "התגובה הזו בעברית"
-                                            }
-                                        }
-                                    },
-                                    …
-                                ]
-                            …
-                        </pre>
-                    </aside>
-
-                    <p>
-                        `stringValue` is actually an alias set to the JSON-LD `@value` keyword by the core EPUB Annotation `@context`
-                        file. It has been introduced to avoid a possible clash with the `value` property, inherited from the [[annotation-model]] specification.
-                    </p>
-                    <div class="issue">
-                        <p>
-                            It is not clear whether the string level language setting is of any use for annotations. It
-                            may be simpler ignore this possibility and require the usage of scoped contexts everywhere.
-                        </p>
-                    </div>
-                </section> -->
-            </section>
+          </section>
         </section>
 
         <section>


### PR DESCRIPTION
Based on the discussion in #2950, this is an alternate version for the same issue. It emphasizes the setting of individual strings, just as it is done in the publication manifest. However a global setting is also possible for annotation sets.

As in #2950, the section is informative. We do ***not*** formally specify anything; we reuse a mechanism specified elsewhere, and use the keyword aliasing possibilities of JSON-LD.

See also https://github.com/w3c/epub-specs/pull/2950#issuecomment-4102225210

---

See:

* For EPUB Annotations 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/anno-alternate-use-json-ld-for-language-and-direction/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fanno-alternate-use-json-ld-for-language-and-direction%2Fepub34%2Fannotations%2Findex.html)
* For EPUB Annotations Vocabulary 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/anno-alternate-use-json-ld-for-language-and-direction/epub34/annotations-vocab/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations-vocab%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fanno-alternate-use-json-ld-for-language-and-direction%2Fepub34%2Fannotations-vocab%2Findex.html)
