### PR TITLE
Add note about linked its documents

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -2502,7 +2502,7 @@
 									container, not parts of files.</p>
 
 								<p id="encryption-restrictions">The following files MUST NOT be encrypted:</p>
-								
+
 								<ul class="nomark">
 									<li>
 										<code>mimetype</code>
@@ -2527,7 +2527,7 @@
 									</li>
 									<li>[=package document=]</li>
 								</ul>
-								
+
 								<p>Encrypted data replaces unencrypted data in an OCF abstract container. For example,
 									if an image named <code>photo.jpeg</code> is encrypted, the contents of the
 										<code>photo.jpeg</code> resource is replaced with its encrypted contents.
@@ -6419,6 +6419,13 @@ No Entry</pre>
 							attributes).</p>
 
 						<p>The use of these attributes MUST conform to the requirements defined in [[its20]].</p>
+
+						<div class="note">
+							<p>It is also possible to link to an ITS document from an [[html]] [^link^] element as
+								defined in the section <a data-cite="its20#html5-global-approach">Global approach in
+									HTML5</a> [[its20]]. As such linked files are [=exempt resources=], an extension to
+								[[html]] is not required to accommodate this use case.</p>
+						</div>
 					</section>
 
 					<section id="sec-xhtml-custom-attributes" data-epubcheck="true"


### PR DESCRIPTION
Adds the text from https://github.com/w3c/epub-specs/issues/2964#issuecomment-4110329744

Fixes #2964


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2969.html" title="Last updated on Mar 24, 2026, 1:50 PM UTC (de49b6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2969/e6d9db2...de49b6f.html" title="Last updated on Mar 24, 2026, 1:50 PM UTC (de49b6f)">Diff</a>