### PR TITLE
Fix reference to charmod-norm

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -151,7 +151,7 @@
 				<p>This specification, EPUB Accessibility, addresses two key needs in the EPUB ecosystem:</p>
 
 				<ul>
-					<li>discoverability of the accessible qualities of <a data-cite="epub/#dfn-epub-publication">EPUB
+					<li>discoverability of the accessible qualities of <a data-cite="epub-3#dfn-epub-publication">EPUB
 							publications</a>; and</li>
 					<li>evaluation and certification of accessible EPUB publications.</li>
 				</ul>
@@ -188,7 +188,7 @@
 				<h3>Success techniques</h3>
 
 				<p>This specification takes an abstract approach to the accessibility requirements for <a
-						data-cite="epub/#dfn-epub-publication">EPUB publications</a>, similar to how WCAG [[wcag2]]
+						data-cite="epub-3#dfn-epub-publication">EPUB publications</a>, similar to how WCAG [[wcag2]]
 					separates its accessibility guidelines from the techniques to achieve them. This approach allows the
 					guidelines to remain stable even as the format evolves.</p>
 
@@ -222,7 +222,7 @@
 			<section id="sec-application" class="informative">
 				<h3>Application to older versions of EPUB</h3>
 
-				<p>This specification is applicable to any <a data-cite="epub/#dfn-epub-publication">EPUB
+				<p>This specification is applicable to any <a data-cite="epub-3#dfn-epub-publication">EPUB
 						publication</a>, regardless of what version of EPUB it conforms to.</p>
 
 				<p>For example, even though EPUB 2 [[opf-201]] was produced before this specification, and so makes no
@@ -231,7 +231,7 @@
 					version of EPUB 3 to get access to the most advanced accessibility features and techniques.</p>
 
 				<p>Note that EPUB 2 does not support all metadata expressions defined in this specification as it does
-					not have an equivalent to the <a data-cite="epub/#attrdef-refines"><code>refines</code>
+					not have an equivalent to the <a data-cite="epub-3#attrdef-refines"><code>refines</code>
 						attribute</a> [[epub-3]]. If metadata expressions that require a <code>refines</code> attribute
 					cannot be avoided, there will be a certain amount of ambiguity in the statements (i.e.,
 					relationships between expression might only be apparent by their placement in the package document
@@ -241,7 +241,7 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This specification uses <a data-cite="epub/#sec-terminology">terminology defined in EPUB 3</a>
+				<p>This specification uses <a data-cite="epub-3#sec-terminology">terminology defined in EPUB 3</a>
 					[[epub-3]].</p>
 
 				<p>It also defines the following term:</p>
@@ -254,7 +254,7 @@
 						<p>This specification uses the <a data-cite="wcag2#dfn-assistive-technologies">definition of
 								assistive technology</a> from [[wcag2]].</p>
 						<p>In the case of EPUB, an assistive technology is not always a separate application from a <a
-								data-cite="epub/#dfn-epub-reading-system">reading system</a>. Reading systems often
+								data-cite="epub-3#dfn-epub-reading-system">reading system</a>. Reading systems often
 							integrate features of standalone assistive technologies, such as text-to-speech
 							playback.</p>
 					</dd>
@@ -275,7 +275,7 @@
 			<section id="sec-disc-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>Unlike web pages, <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> are distributed
+				<p>Unlike web pages, <a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> are distributed
 					through many channels for personal consumption — a model that has made EPUB a successful format for
 					ebooks and other types of digital publications. A consequence of this model, however, is that
 					specific details about the accessibility of a publication have to travel with it.</p>
@@ -301,8 +301,8 @@
 			<section id="sec-disc-package">
 				<h3>Package metadata</h3>
 
-				<p>All <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MUST include [[schema-org]]
-					accessibility metadata in the <a data-cite="epub/#dfn-package-document">package document</a> that
+				<p>All <a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> MUST include [[schema-org]]
+					accessibility metadata in the <a data-cite="epub-3#dfn-package-document">package document</a> that
 					exposes their accessible properties, regardless of whether the publications also meet the <a
 						href="#sec-accessible-pubs">accessibility</a> or <a href="#app-optimized-pubs">optimization</a>
 					requirements.</p>
@@ -351,8 +351,8 @@
 					</li>
 				</ul>
 
-				<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MAY include additional [[schema-org]]
-					accessibility metadata not specified in this section.</p>
+				<p><a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> MAY include additional
+					[[schema-org]] accessibility metadata not specified in this section.</p>
 
 				<div class="note">
 					<p>This specification assumes that conformance and discoverability metadata will be processed and
@@ -381,7 +381,7 @@
 			<section id="sec-disc-linked-rec">
 				<h3>Linked metadata records</h3>
 
-				<p>Accessibility metadata can also be included in <a data-cite="epub/#sec-link-elem">linked records</a>
+				<p>Accessibility metadata can also be included in <a data-cite="epub-3#sec-link-elem">linked records</a>
 					[[epub-3]] (i.e., metadata records referenced from <code>link</code> elements), but the inclusion of
 					such metadata solely in a linked record does not satisfy the discoverability requirements of this
 					specification.</p>
@@ -395,13 +395,13 @@
 
 				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript, and SVG the core technologies used
 					for content authoring. Leveraging these technologies allows the authoring of <a
-						data-cite="epub/#dfn-epub-publication">EPUB publications</a> with a high degree of accessibility
-					through the application of established web accessibility techniques, such as using native elements
-					and controls whenever possible and enhancing custom interactive content with [[wai-aria]] roles,
-					states, and properties. Plus, whenever possible, the EPUB community adds publishing accessibility
-					needs to these standards &#8212; for example, through the creation of the [[dpub-aria-1.1]] role
-					module. It is not necessary for anyone familiar with web accessibility to learn a new accessibility
-					framework to make EPUB publications accessible.</p>
+						data-cite="epub-3#dfn-epub-publication">EPUB publications</a> with a high degree of
+					accessibility through the application of established web accessibility techniques, such as using
+					native elements and controls whenever possible and enhancing custom interactive content with
+					[[wai-aria]] roles, states, and properties. Plus, whenever possible, the EPUB community adds
+					publishing accessibility needs to these standards &#8212; for example, through the creation of the
+					[[dpub-aria-1.1]] role module. It is not necessary for anyone familiar with web accessibility to
+					learn a new accessibility framework to make EPUB publications accessible.</p>
 
 				<p>The primary source for producing accessible web content is the W3C's Web Content Accessibility
 					Guidelines (WCAG) [[wcag2]], which establish benchmarks for accessible content. WCAG defines four
@@ -429,7 +429,7 @@
 				<p>This specification does not repeat the requirements or techniques introduced in those documents, as
 					it risks breaking compatibility between the two standards (e.g., putting guidance out of sync, or in
 					conflict). At the same time, although this specification does not call out those requirements, it
-					does not diminish their importance in creating <a data-cite="epub/#dfn-epub-publication">EPUB
+					does not diminish their importance in creating <a data-cite="epub-3#dfn-epub-publication">EPUB
 						publications</a> that are accessible.</p>
 
 				<p>This specification instead defines how to apply WCAG to an EPUB publication — which is a <a
@@ -457,7 +457,7 @@
 				<section id="sec-wcag-conf">
 					<h4>WCAG conformance requirements</h4>
 
-					<p>To conform to this specification, an <a data-cite="epub/#dfn-epub-publication">EPUB
+					<p>To conform to this specification, an <a data-cite="epub-3#dfn-epub-publication">EPUB
 							publication</a>:</p>
 
 					<ul class="conformance-list">
@@ -529,7 +529,7 @@
 						<h5>Page and publication</h5>
 
 						<p>The WCAG <a data-cite="wcag2#wcag-2-layers-of-guidance">principles</a> [[wcag2]] focus on the
-							evaluation of individual web pages, but an <a data-cite="epub/#dfn-epub-publication">EPUB
+							evaluation of individual web pages, but an <a data-cite="epub-3#dfn-epub-publication">EPUB
 								publication</a> more closely resembles what WCAG refers to as a <a
 								data-cite="wcag2#dfn-set-of-web-pages">set of web pages</a>: "[a] collection of web
 							pages that share a common purpose" [[wcag2]].</p>
@@ -540,10 +540,10 @@
 							for content to be perceivable, operable, understandable, and robust.</p>
 
 						<p>For example, it is not sufficient to correctly order content within individual <a
-								data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> if the <a
-								data-cite="epub/#dfn-epub-spine">spine</a> ordering of documents is incorrect. Likewise,
-							including a title for every EPUB content document is complementary to providing a title for
-							the publication: the overall accessibility decreases if either is missing.</p>
+								data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a> if the <a
+								data-cite="epub-3#dfn-epub-spine">spine</a> ordering of documents is incorrect.
+							Likewise, including a title for every EPUB content document is complementary to providing a
+							title for the publication: the overall accessibility decreases if either is missing.</p>
 
 						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-12]] provide more information about
 							applying these guidelines to EPUB publications.</p>
@@ -552,7 +552,7 @@
 					<section id="sec-wcag-application">
 						<h5>Applying the conformance criteria</h5>
 
-						<p>When evaluating an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>, the WCAG
+						<p>When evaluating an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a>, the WCAG
 								<a data-cite="wcag2#conformance-reqs">conformance criteria</a> [[wcag2]] are applied as
 							follows:</p>
 
@@ -560,20 +560,20 @@
 							<li>When determining compliance with a conformance level, the whole EPUB publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
-							<li><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MUST NOT use EPUB's
+							<li><a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> MUST NOT use EPUB's
 								fallback mechanisms to provide a <a data-cite="wcag2#dfn-conforming-alternate-versions"
 									>conforming alternate version</a> [[wcag2]], as there is no reliable way for users
 								to access such fallbacks. If an EPUB publication uses fallbacks, both the primary
 								content and its fallback(s) MUST meet the requirements for the conformance level
 								claimed. EPUB-specific fallback mechanisms include <a
-									data-cite="epub/#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-3]], <a
-									data-cite="epub/#sec-opf-bindings">bindings</a> [[epub-3]] and content switching via
-								the <a data-cite="epub/#sec-xhtml-content-switch"><code>epub:switch</code> element</a>
-								[[epub-3]].</li>
+									data-cite="epub-3#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-3]], <a
+									data-cite="epub-3#sec-opf-bindings">bindings</a> [[epub-3]] and content switching
+								via the <a data-cite="epub-3#sec-xhtml-content-switch"><code>epub:switch</code>
+									element</a> [[epub-3]].</li>
 
 							<li>The "<a data-cite="wcag2#cc2">Full Pages</a>" requirement [[wcag2]] -- that parts of a
 								page cannot be excluded when making a conformance claim -- applies to every <a
-									data-cite="epub/#dfn-epub-content-document">EPUB content document</a> in the EPUB
+									data-cite="epub-3#dfn-epub-content-document">EPUB content document</a> in the EPUB
 								publication (i.e., they all have to conform in full to the conformance level
 								claimed).</li>
 						</ul>
@@ -604,10 +604,10 @@
 
 						<p>Providing page navigation also helps in reflowable publications that do not have a statically
 							paginated equivalent. The default pagination of these publications by <a
-								data-cite="epub/#dfn-epub-reading-system">reading systems</a> is not static since it
-							changes depending on the <a data-cite="epub/#dfn-viewport">viewport</a> size and user's font
-							settings. As a result, coordinating locations among users of the same <a
-								data-cite="epub/#dfn-epub-publication">EPUB publication</a> can be complicated without
+								data-cite="epub-3#dfn-epub-reading-system">reading systems</a> is not static since it
+							changes depending on the <a data-cite="epub-3#dfn-viewport">viewport</a> size and user's
+							font settings. As a result, coordinating locations among users of the same <a
+								data-cite="epub-3#dfn-epub-publication">EPUB publication</a> can be complicated without
 							static references.</p>
 
 						<p>The inclusion of page navigation represents one method of achieving the <a
@@ -629,7 +629,7 @@
 					<section id="sec-page-nav-applicability">
 						<h5>Applicability</h5>
 
-						<p>An <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> SHOULD include page
+						<p>An <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> SHOULD include page
 							navigation whenever any of the following cases is true:</p>
 
 						<ul>
@@ -666,7 +666,7 @@
 								<dt id="sec-page-src-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Users need to know the source of the pagination in an <a
-											data-cite="epub/#dfn-epub-publication">EPUB publication</a> to determine
+											data-cite="epub-3#dfn-epub-publication">EPUB publication</a> to determine
 										whether it will be useful for their needs. Print publications, for example,
 										produced in both hard and soft cover editions will have different pagination.
 										Different editions of the same book often also have different pagination.</p>
@@ -681,12 +681,12 @@
 									<p>When an EPUB publication includes <a href="#sec-page-breaks">page break
 											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
 										to a statically-paginated version of the publication, the publication MUST
-										identify that source in the <a data-cite="epub/#dfn-package-document">package
+										identify that source in the <a data-cite="epub-3#dfn-package-document">package
 											document</a> metadata.</p>
 									<p>If, however, these features are added to a digital-only <a
-											data-cite="epub/#dfn-epub-publication">EPUB publication</a>, the publication
-										MUST NOT specify a source (i.e., do not identify the current publication as the
-										source of its own pagination).</p>
+											data-cite="epub-3#dfn-epub-publication">EPUB publication</a>, the
+										publication MUST NOT specify a source (i.e., do not identify the current
+										publication as the source of its own pagination).</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageSource">Identifying the
 												pagination source</a> [[epub-a11y-tech-12]] for more information on
@@ -709,8 +709,8 @@
 								<dd>
 									<p>The page list is the primary means of navigating to page break locations as it
 										provides a list of links to each of the static page break locations in the <a
-											data-cite="epub/#dfn-epub-publication">EPUB publication</a>.</p>
-									<p><a data-cite="epub/#dfn-epub-reading-system">Reading systems</a> typically use
+											data-cite="epub-3#dfn-epub-publication">EPUB publication</a>.</p>
+									<p><a data-cite="epub-3#dfn-epub-reading-system">Reading systems</a> typically use
 										this list to generate a "go to page" interface in which users can plug in the
 										page number that they wish to move to, but sometimes offer users the ability to
 										access the full list and select the page number to go to.</p>
@@ -749,7 +749,7 @@
 
 								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Inserting page break markers into an <a data-cite="epub/#dfn-epub-publication"
+									<p>Inserting page break markers into an <a data-cite="epub-3#dfn-epub-publication"
 											>EPUB publication</a> provides users with context about where they are in
 										the text. <a>Assistive technologies</a> can use this information to announce the
 										current page number the user is on, for example, if the user wants to cite
@@ -770,10 +770,10 @@
 									<p>It is encouraged to include page break markers for all the pages in the source,
 										whether reproduced or not, but this is not a requirement.</p>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
-										of the content (e.g., EPUB 3 media overlays [[?epub]]), the page break markers
+										of the content (e.g., EPUB 3 media overlays [[?epub-3]]), the page break markers
 										MUST be identified in the playback instructions (e.g., using the <a
-											data-cite="epub/#sec-epub-type-attribute"><code>epub:type</code>
-											attribute</a> [[?epub]] in media overlays SMIL files).</p>
+											data-cite="?epub-3/#sec-epub-type-attribute"><code>epub:type</code>
+											attribute</a> [[?epub-3]] in media overlays SMIL files).</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-12#pageBreakMarkers">Provide page break
 												markers</a> [[epub-a11y-tech-12]] for more information on meeting this
@@ -793,7 +793,7 @@
 
 						<p>The provision of synchronized text-audio playback helps address various user needs. It not
 							only enables a seamless visual and auditory reading experience from beginning to end of an
-								<a data-cite="epub/#dfn-epub-publication">EPUB publication</a>, but is useful to users
+								<a data-cite="epub-3#dfn-epub-publication">EPUB publication</a>, but is useful to users
 							who only require audio playback (e.g., who cannot see the text or are prevented from reading
 							visually due to motion-sickness) or who only benefit from reading with text highlighting
 							(e.g., readers with dyslexia).</p>
@@ -804,7 +804,7 @@
 							ways to control which parts of the content are read aloud.</p>
 
 						<p>In order to offer users greater control over content presentation, EPUB publications need to
-							include structure and semantics so that the <a data-cite="epub/#dfn-epub-reading-system"
+							include structure and semantics so that the <a data-cite="epub-3#dfn-epub-reading-system"
 								>reading system</a> has the necessary context to enable this type of user experience.
 							With greater context, a reading system can provide the ability to skip past secondary
 							content that interferes with the primary narrative and escape users from deeply nested
@@ -819,7 +819,7 @@
 					<section id="sec-sync-applicability">
 						<h5>Applicability</h5>
 
-						<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> with synchronized text-audio
+						<p><a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> with synchronized text-audio
 							playback MUST conform to all requirements in [[epub-3]]. It is not necessary to meet any
 							additional requirements beyond those defined in [[epub-3]] to be conformant with this
 							specification.</p>
@@ -862,7 +862,7 @@
 
 								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> MUST include
+									<p><a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> MUST include
 										synchronized audio playback for all visible textual content as well as all
 										textual alternatives for visual media.</p>
 									<div class="note">
@@ -885,14 +885,14 @@
 
 								<dt id="sec-mo-order-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Every <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> has a
+									<p>Every <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> has a
 										default reading order that allows users to progress through the content. The
 										default reading order consists of two parts: the order of references in the
 										spine provides a high-level progression through the <a
-											data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> that
+											data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a> that
 										make up the publication, while the markup within each EPUB content document
 										provides the default progression through the content elements (i.e., as
-										represented in the document object model [[dom]]).</p>
+										represented in the document object model [[?dom]]).</p>
 									<p>For many languages, the default reading order also matches the logical reading
 										order &#8212; the way that users will naturally follow the narrative. It ensures
 										that readers can follow the primary narrative and that they encounter secondary
@@ -919,7 +919,7 @@
 										both:</p>
 									<ul>
 										<li>the order of the referenced EPUB content documents in the <a
-												data-cite="epub/#dfn-epub-spine">spine</a>; and</li>
+												data-cite="epub-3#dfn-epub-spine">spine</a>; and</li>
 										<li>the order of each element within its respective EPUB content document.</li>
 									</ul>
 									<p>If an EPUB publication uses a different ordering, that ordering MUST still result
@@ -945,17 +945,17 @@
 								<dt id="sec-sync-skippability-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Being able to read the primary narrative of a work without interruption is
-										central to reading comprehension. <a data-cite="epub/#dfn-epub-publication">EPUB
-											publications</a> are typically structured to visually represent secondary
-										information such as page break markers and footnotes outside the main narrative
-										flow (e.g., by using different background colors or placement so readers can
-										filter this information visually out while reading).</p>
+										central to reading comprehension. <a data-cite="epub-3#dfn-epub-publication"
+											>EPUB publications</a> are typically structured to visually represent
+										secondary information such as page break markers and footnotes outside the main
+										narrative flow (e.g., by using different background colors or placement so
+										readers can filter this information visually out while reading).</p>
 									<p>Readers who prefer auditory playback, however, cannot skip this information with
 										the same ease in a linear audio-based reading experience. And, without
 										structural semantics, synchronized text-audio playback cannot offer skipping
 										content either.</p>
 									<p>When the synchronized text-audio playback instructions include structural
-										semantics, however, <a data-cite="epub/#dfn-epub-reading-system">reading
+										semantics, however, <a data-cite="epub-3#dfn-epub-reading-system">reading
 											systems</a> can create reading experiences that allow users to decide which
 										secondary content to skip by default.</p>
 								</dd>
@@ -991,12 +991,12 @@
 										they are visually offset from the primary narrative so easily jumped into and
 										out of.</p>
 									<p>The same ease of escaping from content is only possible if <a
-											data-cite="epub/#dfn-epub-publication">EPUB publications</a> include
+											data-cite="epub-3#dfn-epub-publication">EPUB publications</a> include
 										structural semantics in the synchronized text/audio format. Users might not be
 										able to escape from lists, sidebars, figures, and other highly structured
 										content, without the structural semantics of those elements being available.</p>
 									<p>When the synchronized text-audio playback instructions include this information,
-											<a data-cite="epub/#dfn-epub-reading-system">reading systems</a> can
+											<a data-cite="epub-3#dfn-epub-reading-system">reading systems</a> can
 										simplify playback for auditory readers to enable a comparable reading
 										experience.</p>
 								</dd>
@@ -1021,8 +1021,8 @@
 								<dt id="sec-sync-navdoc-obj">Objective</dt>
 								<dd>
 									<p>Ensure auditory playback is possible for the navigation aids in the <a
-											data-cite="epub/#dfn-epub-navigation-document">EPUB navigation document</a>
-										when presented by <a data-cite="epub/#dfn-epub-reading-system">reading
+											data-cite="epub-3#dfn-epub-navigation-document">EPUB navigation document</a>
+										when presented by <a data-cite="epub-3#dfn-epub-reading-system">reading
 											systems</a>.</p>
 								</dd>
 
@@ -1040,7 +1040,7 @@
 
 								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> SHOULD include
+									<p><a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> SHOULD include
 										synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
 											document</a> [[epub-3]].</p>
@@ -1062,9 +1062,9 @@
 				<section id="sec-conf-reporting-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>Evaluators report the accessibility conformance of an <a data-cite="epub/#dfn-epub-publication"
+					<p>Evaluators report the accessibility conformance of an <a data-cite="epub-3#dfn-epub-publication"
 							>EPUB publication</a> through the expression of metadata properties in the <a
-							data-cite="epub/#dfn-package-document">package document</a>.</p>
+							data-cite="epub-3#dfn-package-document">package document</a>.</p>
 
 					<p>This metadata establishes both:</p>
 
@@ -1104,8 +1104,8 @@
 					<h4>Publication conformance</h4>
 
 					<p>To indicate conformance to the accessibility requirements of this specification, an <a
-							data-cite="epub/#dfn-epub-publication">EPUB publication</a> [[epub-3]] MUST specify in its
-							<a data-cite="epub/#sec-pkg-metadata">metadata section</a> a <a
+							data-cite="epub-3#dfn-epub-publication">EPUB publication</a> [[epub-3]] MUST specify in its
+							<a data-cite="epub-3#sec-pkg-metadata">metadata section</a> a <a
 							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
 								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[dcterms]] whose value,
 						after <a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]], exactly matches
@@ -1234,10 +1234,10 @@
 					<section id="sec-evaluator-name">
 						<h5>Evaluator name</h5>
 
-						<p>The <a data-cite="epub/#dfn-package-document">package document</a> metadata MUST include an
+						<p>The <a data-cite="epub-3#dfn-package-document">package document</a> metadata MUST include an
 								<a href="#certifiedBy"><code id="a11y-certifiedBy">a11y:certifiedBy</code></a> property
 							that specifies the name of the party that evaluated the <a
-								data-cite="epub/#dfn-epub-publication">EPUB publication</a>.</p>
+								data-cite="epub-3#dfn-epub-publication">EPUB publication</a>.</p>
 
 						<div class="note">
 							<p>If an organization evaluates an EPUB publication, users will typically want to know the
@@ -1272,7 +1272,7 @@
 						<p>If the date the evaluation was performed on is known, include that information in a <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
 									><code>dcterms:date</code> property</a> [[dcterms]] <a
-								data-cite="epub/#subexpression">associated with</a> [[epub-3]] the <a
+								data-cite="epub-3#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<p>It is REQUIRED that the date string conform to [[iso8601-1]], particularly the subset
@@ -1304,7 +1304,7 @@
 						<p>If the evaluator has credentials or badges that establish their authority to evaluate
 							content, include that information in an <a href="#certifierCredential"><code
 									id="a11y-certifierCredential">a11y:certifierCredential</code> properties</a>
-							<a data-cite="epub/#subexpression">associated with</a> [[epub-3]] the <a
+							<a data-cite="epub-3#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<div class="note">
@@ -1349,7 +1349,7 @@
 						<p>If the evaluator provides a publicly-readable report of its assessment, provide a link to the
 							assessment in an <a href="#certifierReport"><code id="a11y-certifierReport"
 									>a11y:certifierReport</code> property</a>
-							<a data-cite="epub/#subexpression">associated with</a> [[epub-3]] the <a
+							<a data-cite="epub-3#subexpression">associated with</a> [[epub-3]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<aside class="example" title="An external accessibility report">
@@ -1377,7 +1377,7 @@
 
 						<aside class="example" title="A local accessibility report">
 							<p>The following example shows a link to an accessibility report included in the <a
-									data-cite="epub/#dfn-epub-container">EPUB container</a>.</p>
+									data-cite="epub-3#dfn-epub-container">EPUB container</a>.</p>
 							<pre>&lt;metadata …>
    &lt;meta
        property="dcterms:conformsTo"
@@ -1409,7 +1409,7 @@
 							It is not a conformance requirement of this specification.</p>
 					</div>
 
-					<p>How long a conformance evaluation of an <a data-cite="epub/#dfn-epub-publication">EPUB
+					<p>How long a conformance evaluation of an <a data-cite="epub-3#dfn-epub-publication">EPUB
 							publication</a> is good for is a complex question. Unlike web sites, which are continuously
 						evolving, EPUB publications often do not get updated again after their initial publication. As a
 						result, an unmodified EPUB publication will always conform to its last evaluation.</p>
@@ -1425,7 +1425,7 @@
 
 					<ul>
 						<li>modifications to the nature or order of markup in <a
-								data-cite="epub/#dfn-epub-content-document">EPUB content documents</a>;</li>
+								data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a>;</li>
 						<li>additions or modifications to images that convey information;</li>
 						<li>modifications to formatting that affects the readability (e.g., contrast); and</li>
 						<li>additions or modifications to interactive controls, forms, etc.</li>
@@ -1448,7 +1448,7 @@
 						<li>additions or modifications to decorative images;</li>
 						<li>modifications to the formatting that do not affect the understanding of the content or
 							change the text display; and</li>
-						<li>modifications to <a data-cite="epub/#dfn-package-document">package document</a>
+						<li>modifications to <a data-cite="epub-3#dfn-package-document">package document</a>
 							metadata.</li>
 					</ul>
 
@@ -1475,9 +1475,9 @@
 					a specific need or reading modality is often not conformant to WCAG exactly because it targets a
 					specific audience.</p>
 
-				<p>For example, an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> with synchronized text
-					and audio can contain a full audio recording of the content but limit the text content to only the
-					major headings. In this case, the EPUB publication is consumable by users who needs to hear the
+				<p>For example, an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> with synchronized
+					text and audio can contain a full audio recording of the content but limit the text content to only
+					the major headings. In this case, the EPUB publication is consumable by users who needs to hear the
 					content (i.e., they can listen to the full publication and can navigate between headings) but is not
 					usable by anyone who cannot hear the audio.</p>
 
@@ -1518,7 +1518,7 @@
 				<h3>Additional resources</h3>
 
 				<p>The following documents provide additional information on how to author accessible <a
-						data-cite="epub/#dfn-epub-publication">EPUB publications</a>:</p>
+						data-cite="epub-3#dfn-epub-publication">EPUB publications</a>:</p>
 
 				<dl>
 					<dt>
@@ -1593,7 +1593,7 @@
 			<h2>Distribution</h2>
 
 			<div class="note">
-				<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> do not have to meet the
+				<p>Although <a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> do not have to meet the
 					recommendations in this section to conform to this specification, some jurisdictions require EPUB
 					publications to follow similar practices. <a
 						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
@@ -1601,7 +1601,7 @@
 					the European Union.</p>
 			</div>
 
-			<p>The creation of accessible <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> does not
+			<p>The creation of accessible <a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> does not
 				guarantee that the publication will be obtainable or consumable by users in an accessible fashion.
 				Depending on how they are distributed, other factors will influence their overall accessibility. For
 				example, an accessible interface for locating and obtaining content is an essential part of the
@@ -1638,10 +1638,10 @@
 				new features are introduced by this specification.</p>
 
 			<p>The inclusion of accessibility metadata similarly does not introduce security or privacy issues, as
-				describing an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> only provides a general
+				describing an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> only provides a general
 				idea of its suitability for different user groups.</p>
 
-			<p>The use of accessibility metadata in <a data-cite="epub/#dfn-epub-reading-system">reading systems</a>,
+			<p>The use of accessibility metadata in <a data-cite="epub-3#dfn-epub-reading-system">reading systems</a>,
 				bookstores and any other interface that can build a profile of the user, on the other hand, has the
 				potential to violate the user's privacy. While it might seem helpful to store and anticipate the type of
 				content a user is most likely to consume, for example, or how best to initiate its playback, developers
@@ -1659,7 +1659,7 @@
 		<section id="app-optimized-pubs" class="appendix informative">
 			<h2>Guidelines for optimized publication standards</h2>
 
-			<p>An optimized <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> is one that has been created
+			<p>An optimized <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> is one that has been created
 				to address a specific accessibility need, as discussed in <a href="#sec-targeted-accessibility"
 				></a>.</p>
 
@@ -1750,8 +1750,8 @@
 					<h4>About this vocabulary</h4>
 
 					<p>This vocabulary defines properties for describing the accessibility of <a
-							data-cite="epub/#dfn-epub-publication">EPUB publications</a> in the <a
-							data-cite="epub/#dfn-package-document">package document</a> metadata.</p>
+							data-cite="epub-3#dfn-epub-publication">EPUB publications</a> in the <a
+							data-cite="epub-3#dfn-package-document">package document</a> metadata.</p>
 				</section>
 
 				<section id="app-vocab-ref">
@@ -1762,7 +1762,7 @@
 
 					<p>This specification reserves the prefix "<code>a11y:</code>" for use with properties in this
 						vocabulary. It is not required to declare the prefix in the <a
-							data-cite="epub/#dfn-package-document">package document</a>.</p>
+							data-cite="epub-3#dfn-package-document">package document</a>.</p>
 				</section>
 			</section>
 
@@ -1783,7 +1783,7 @@
 						<tr>
 							<th>Description:</th>
 							<td>Identifies a party responsible for the testing and certification of the accessibility of
-								an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>.</td>
+								an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a>.</td>
 						</tr>
 						<tr>
 							<th>Allowed value(s):</th>
@@ -1944,7 +1944,8 @@
 						<tr>
 							<th>Extends:</th>
 							<td>Only applies to the EPUB publication. MUST NOT be used when the <a
-									data-cite="epub#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+									data-cite="epub-3#attrdef-refines"><code>refines</code> attribute</a> is
+								present.</td>
 						</tr>
 						<tr>
 							<th>Example:</th>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -265,7 +265,9 @@
 				</div>
 			</section>
 
-			<section id="conformance"></section>
+			<section id="conformance">
+				<p>All statements in parentheses are <em>non-normative</em>.</p>
+			</section>
 		</section>
 		<section id="sec-discovery">
 			<h2>Discoverability</h2>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -266,7 +266,7 @@
 			</section>
 
 			<section id="conformance">
-				<p>All statements in parentheses are <em>non-normative</em>.</p>
+				<p>All explanatory statements in parentheses are <em>non-normative</em>.</p>
 			</section>
 		</section>
 		<section id="sec-discovery">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -646,7 +646,8 @@
 			</section>
 
 			<section id="conformance">
-				<p>All statements in parentheses and all algorithm explanations are <em>non-normative</em>.</p>
+				<p>All explanatory statements in parentheses and all algorithm explanations are
+					<em>non-normative</em>.</p>
 			</section>
 
 			<section id="sec-intro-shorthands" class="informative">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -646,8 +646,8 @@
 			</section>
 
 			<section id="conformance">
-				<p>All explanatory statements in parentheses and all algorithm explanations are
-					<em>non-normative</em>.</p>
+				<p>All caution boxes, explanatory statements in parentheses, and algorithm explanations are also
+						<em>non-normative</em>.</p>
 			</section>
 
 			<section id="sec-intro-shorthands" class="informative">
@@ -3075,7 +3075,7 @@
 			<section id="sec-vocab-assoc">
 				<h3>Vocabulary association mechanisms</h3>
 
-				<section id="vocab-assoc-intro">
+				<section id="vocab-assoc-intro" class="informative">
 					<h3>Introduction</h3>
 
 					<p>The package document allows metadata expressions, and metadata extensibility, through the use of
@@ -7839,7 +7839,7 @@ No Entry</pre>
 		<section id="sec-aural-rendering">
 			<h2>Aural rendering</h2>
 
-			<section id="sec-aural-intro">
+			<section id="sec-aural-intro" class="informative">
 				<h3>Introduction</h3>
 
 				<p>Although EPUB 3 is primarily considered a visual reading format, [=EPUB publications=] are designed
@@ -9652,8 +9652,8 @@ html.my-document-playing * {
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
 					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as <a
-							href="https://www.w3.org/TR/geolocation/">Geolocation</a> [[geolocation]] and <a
-							href="https://www.w3.org/TR/push-api/">Push Notifications</a> [[push-api]].</li>
+							href="https://www.w3.org/TR/geolocation/">Geolocation</a> [[?geolocation]] and <a
+							href="https://www.w3.org/TR/push-api/">Push Notifications</a> [[?push-api]].</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
 					<li>Avoiding deprecated features of EPUB due to the potential for undiscovered bugs in
 						implementations.</li>
@@ -10662,7 +10662,7 @@ EPUB/images/cover.png</pre>
 							<li id="sec-font-obfuscation">
 								<p><a data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]]</p>
 								<div class="caution">
-									<p>NIST is advising that use of the SHA-1 algorithm [[fips-180-4]] be phased out by
+									<p>NIST is advising that use of the SHA-1 algorithm [[?fips-180-4]] be phased out by
 										the end of 2030. The Publishing Maintenance Working Group does not intend to
 										support font obfuscation in EPUB publications past that date due to its reliance
 										on SHA-1, although reading systems will have to continue to support

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -646,7 +646,7 @@
 			</section>
 
 			<section id="conformance">
-				<p>All algorithm explanations are <em>non-normative</em>.</p>
+				<p>All statements in parentheses and all algorithm explanations are <em>non-normative</em>.</p>
 			</section>
 
 			<section id="sec-intro-shorthands" class="informative">
@@ -1855,7 +1855,7 @@
 						<li>
 							<p id="ocf-fn-cn">All file names within the same directory MUST be unique following Unicode
 								canonical normalization [[uax15]] and then full case folding [[unicode]]. (Refer to <a
-									data-cite="charmod-norm#CanonicalFoldNormalizationStep">Unicode Canonical Case Fold
+									data-cite="?charmod-norm#CanonicalFoldNormalizationStep">Unicode Canonical Case Fold
 									Normalization Step</a>&#160;[[?charmod-norm]] for more information.)</p>
 						</li>
 					</ul>
@@ -2502,7 +2502,7 @@
 									container, not parts of files.</p>
 
 								<p id="encryption-restrictions">The following files MUST NOT be encrypted:</p>
-								
+
 								<ul class="nomark">
 									<li>
 										<code>mimetype</code>
@@ -2527,7 +2527,7 @@
 									</li>
 									<li>[=package document=]</li>
 								</ul>
-								
+
 								<p>Encrypted data replaces unencrypted data in an OCF abstract container. For example,
 									if an image named <code>photo.jpeg</code> is encrypted, the contents of the
 										<code>photo.jpeg</code> resource is replaced with its encrypted contents.

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -200,8 +200,8 @@
 			</section>
 
 			<section id="conformance">
-				<p>All explanatory statements in parentheses and all algorithm explanations are
-					<em>non-normative</em>.</p>
+				<p>All caution boxes, explanatory statements in parentheses, and algorithm explanations are also
+						<em>non-normative</em>.</p>
 			</section>
 
 			<section id="sec-intro-relations" class="informative">
@@ -780,10 +780,10 @@
 				<h3>Font obfuscation</h3>
 
 				<div class="caution">
-					<p>NIST is advising that use of the SHA-1 algorithm [[fips-180-4]] be phased out by the end of 2030.
-						The Publishing Maintenance Working Group does not intend to support font obfuscation in EPUB
-						publications past that date due to its reliance on SHA-1 &#8212; the feature is now marked as
-						outdated to not invalidate existing EPUB publications. Reading system developers will have to
+					<p>NIST is advising that use of the SHA-1 algorithm [[?fips-180-4]] be phased out by the end of
+						2030. The Publishing Maintenance Working Group does not intend to support font obfuscation in
+						EPUB publications past that date due to its reliance on SHA-1 &#8212; the feature is now marked
+						as outdated to not invalidate existing EPUB publications. Reading system developers will have to
 						consider continuing to support deobfuscation to fully support all EPUB publications that have
 						used the feature. As CSS provides font fallbacks, however, ending support will only affect the
 						appearance of some text content.</p>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -200,7 +200,8 @@
 			</section>
 
 			<section id="conformance">
-				<p>All statements in parentheses and all algorithm explanations are <em>non-normative</em>.</p>
+				<p>All explanatory statements in parentheses and all algorithm explanations are
+					<em>non-normative</em>.</p>
 			</section>
 
 			<section id="sec-intro-relations" class="informative">

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2467,7 +2467,7 @@
 			<section id="sec-obs-deprecated">
 				<h3>Deprecated features</h3>
 
-				<p id="confreq-rs-deprecated">[=reading systems=] MAY support <a data-cite="epub-34#deprecated"
+				<p id="confreq-rs-deprecated">[=Reading systems=] MAY support <a data-cite="epub-34#deprecated"
 						>deprecated authoring features</a> [[epub-34]].</p>
 
 				<p id="sec-embedded-media">In addition, the following reading system features are now deprecated:</p>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -200,7 +200,7 @@
 			</section>
 
 			<section id="conformance">
-				<p>All algorithm explanations are <em>non-normative</em>.</p>
+				<p>All statements in parentheses and all algorithm explanations are <em>non-normative</em>.</p>
 			</section>
 
 			<section id="sec-intro-relations" class="informative">


### PR DESCRIPTION
Changes the link to informative so that charmod-norm isn't listed as a normative reference.

Also clarifies that all statements in parentheses are informative.

Fixes #2965


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2970.html" title="Last updated on Mar 27, 2026, 7:17 PM UTC (d3a4311)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2970/e6d9db2...d3a4311.html" title="Last updated on Mar 27, 2026, 7:17 PM UTC (d3a4311)">Diff</a>