### PR TITLE
Removing markdown as a possible annotation format

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -848,7 +848,7 @@
                                 <code> format </code>
                             </td>
                             <td> The media-type of the annotation value. It
-                                MUST be "text/plain".
+                                SHOULD be "text/plain".
                             </td>
                             <td> string</td>
                             <td> No </td>

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -847,9 +847,10 @@
                             <td>
                                 <code> format </code>
                             </td>
-                            <td> The media-type of the annotation value; "text/plain" by
-                                default; "text/markdown" is recommended. </td>
-                            <td> [[RFC6838]], [[RFC7763]] </td>
+                            <td> The media-type of the annotation value. It
+                                MUST be "text/plain".
+                            </td>
+                            <td> string</td>
                             <td> No </td>
                         </tr>
                         <tr>
@@ -894,6 +895,18 @@
                         </tr>
                     </tbody>
                 </table>
+
+                <p class="note">
+
+                    The format for a "TextualBody" is restricted to plain text.
+                    Markdown was also considered, but current practice among Reading Systems
+                    is to use text without any formatting in annotations.
+                    Consequently, defining Markdown as an alternative in the exchange format
+                    would have very little chance of being implemented.
+                    A further issue is the great variety of Markdown-based formats, without any one
+                    being stable enough to be referenced normatively.
+                    Future versions of this specification may reconsider this.
+                </p>
 
                 <p class="note">Read “Best practices for Reading Systems” about using tags in an annotation. </p>
                 <p class="issue" data-number="2854"></p>


### PR DESCRIPTION
This PR implements the [WG REsolution of 2026.03.26](https://w3c.github.io/pm-wg/minutes/2026-03-26.html#0088).

Fixes #2942

---

See:

* For EPUB Annotations 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/removing-markdown-from-annotation/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fremoving-markdown-from-annotation%2Fepub34%2Fannotations%2Findex.html)
