### PR TITLE
Removing a reference to the json-ld import mechanism

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1170,8 +1170,7 @@
                 Following the requirements of JSON-LD, each annotation file (whether a single annotation or an
                 annotation set) MUST start with a context declaration referring to the following, EPUB Annotation
                 specific context: <code>https://www.w3.org/ns/epub-anno.jsonld</code>.
-                This context file imports (using the <a data-cite="json-ld11#imported-contexts">imported contexts</a>
-                feature of JSON-LD) the "core" context file of the [[[annotation-model]]] [[annotation-model]], i.e.,
+                This context file imports the "core" context file of the [[[annotation-model]]] [[annotation-model]], i.e.,
                 <code>https://www.w3.org/ns/anno.jsonld</code>.
                 The EPUB Annotation specific context file contains terms extending, an sometimes overriding the terms
                 in the core annotation context file, as defined in this specification.


### PR DESCRIPTION
For technical reasons this approach is no longer in use in yml2vocab, which generates the context file for the annotation vocabulary. I forgot to remove the reference to it in the spec.