### PR TITLE
Annotations colors are not css values

### DIFF
--- a/epub34/annotations-vocab/index.context.jsonld
+++ b/epub34/annotations-vocab/index.context.jsonld
@@ -6,6 +6,7 @@
         "language": "@language",
         "direction": "@direction",
         "text": "@value",
+        "@vocab": "http://www.w3.org/ns/ea#",
         "About": "http://www.w3.org/ns/ea#About",
         "Annotation": {
             "@id": "http://www.w3.org/ns/ea#Annotation",

--- a/epub34/annotations-vocab/index.jsonld
+++ b/epub34/annotations-vocab/index.jsonld
@@ -79,7 +79,7 @@
         "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/epub-anno-vocab-10/",
-    "dc:date": "2026-04-07",
+    "dc:date": "2026-04-10",
     "rdfs_properties": [{
         "@id": "ea:about",
         "@type": ["rdf:Property", "owl:ObjectProperty"],

--- a/epub34/annotations-vocab/index.ttl
+++ b/epub34/annotations-vocab/index.ttl
@@ -15,7 +15,7 @@ ea: a owl:Ontology ;
     dc:title """EPUB Annotations Vocabulary 1.0"""@en ;
     dc:description """RDFS [[rdf-schema]] vocabulary formalizing the terms defined in the [[[epub-anno-10]]] specification. The vocabulary is a "profile" of the W3C [[[annotation-vocab]]]"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/epub-anno-vocab-10/> ;
-    dc:date "2026-04-07"^^xsd:date ;
+    dc:date "2026-04-10"^^xsd:date ;
 .
 
 # Property definitions

--- a/epub34/annotations-vocab/index.yml
+++ b/epub34/annotations-vocab/index.yml
@@ -6,6 +6,8 @@ json_ld:
         "direction" : "@direction"
         "text"      : "@value"
     import: "https://www.w3.org/ns/anno.jsonld"        # Note the 'https' some JSON-LD environments require that...
+    set_vocab       : true
+
 
 vocab:
     - id: ea

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -247,7 +247,6 @@
                     for all the tables in the document.
                 </p>
 
-                <p class="issue" data-number="2926"></p>
                 <p class="issue" data-number="2884"></p>
 
                 <aside class="example" title="Core structure of an EPUB annotation">
@@ -881,7 +880,6 @@
                 </table>
 
                 <p class="note">
-
                     The format for a "TextualBody" is restricted to plain text.
                     Markdown was also considered, but current practice among Reading Systems
                     is to use text without any formatting in annotations.
@@ -890,6 +888,15 @@
                     A further issue is the great variety of Markdown-based formats, without any one
                     being stable enough to be referenced normatively.
                     Future versions of this specification may reconsider this.
+                </p>
+
+                <p class="note">
+                    The terms used for [=color=] or [=highlight=] (e.g., "pink", "orange",
+                    "solid", etc.) are only indicative.
+                    They are not meant to denote precise values (e.g., `#ffc0cb` for "pink").
+                    Instead, they represent the terms usually used by Reading Systems.
+                    The terms are mapped onto real values depending on factors like color themes
+                    or the type of displays (eInk, LCD, LED, etc.) to ensure optimal readability.
                 </p>
 
                 <p class="note">Read “Best practices for Reading Systems” about using tags in an annotation. </p>
@@ -1186,6 +1193,10 @@
                     }
                 </pre>
             </aside>
+
+            <p>
+                The data model is inherently extensible: implementation may add reading system or application dependent terms, e.g., a reference to user color profiles.
+            </p>
 
             <p class="note">
                 Implementations that do not rely on the linked data aspects of annotations may rely on bespoke

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -880,6 +880,15 @@
                 </table>
 
                 <p class="note">
+                    The terms used for [=color=] or [=highlight=] (e.g., "pink", "orange",
+                    "solid", etc.) are only indicative.
+                    They are not meant to denote precise values (e.g., `#ffc0cb` for "pink").
+                    Instead, they represent the terms usually used by Reading Systems.
+                    The terms are mapped onto real values depending on factors like color themes
+                    or the type of displays (eInk, LCD, LED, etc.) to ensure optimal readability.
+                </p>
+
+                <p class="note">
                     The format for a "TextualBody" is restricted to plain text.
                     Markdown was also considered, but current practice among Reading Systems
                     is to use text without any formatting in annotations.
@@ -890,14 +899,6 @@
                     Future versions of this specification may reconsider this.
                 </p>
 
-                <p class="note">
-                    The terms used for [=color=] or [=highlight=] (e.g., "pink", "orange",
-                    "solid", etc.) are only indicative.
-                    They are not meant to denote precise values (e.g., `#ffc0cb` for "pink").
-                    Instead, they represent the terms usually used by Reading Systems.
-                    The terms are mapped onto real values depending on factors like color themes
-                    or the type of displays (eInk, LCD, LED, etc.) to ensure optimal readability.
-                </p>
 
                 <p class="note">Read “Best practices for Reading Systems” about using tags in an annotation. </p>
                 <aside class="example" title="An annotation Body">

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1196,7 +1196,8 @@
             </aside>
 
             <p>
-                The data model is inherently extensible: implementation may add reading system or application dependent terms, e.g., a reference to user color profiles.
+                The data model is inherently extensible: implementations may add reading system
+                dependent terms, e.g., a reference to user color profiles.
             </p>
 
             <p class="note">

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -880,8 +880,8 @@
                 </table>
 
                 <p class="note">
-                    The terms used for [=color=] or [=highlight=] (e.g., "pink", "orange",
-                    "solid", etc.) are only indicative.
+                    The terms used for [=color=] and [=highlight=] (e.g., "pink", "orange",
+                    "solid", etc.) are only labels.
                     They are not meant to denote precise values (e.g., `#ffc0cb` for "pink").
                     Instead, they represent the terms usually used by Reading Systems.
                     The terms are mapped onto real values depending on factors like color themes

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -884,8 +884,8 @@
                     "solid", etc.) are only labels.
                     They are not meant to denote precise values (e.g., `#ffc0cb` for "pink").
                     Instead, they represent the terms usually used by Reading Systems.
-                    The terms are mapped onto real values depending on factors like color themes
-                    or the type of displays (eInk, LCD, LED, etc.) to ensure optimal readability.
+                    The terms are mapped onto real values depending on factors like user
+                    preference (e.g. color themes) or device characteristics (e.g. display type).
                 </p>
 
                 <p class="note">

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1285,7 +1285,7 @@
 
                 </section>
                 <section>
-                    <h3>Dealing with colors</h3>
+                    <h3>Handling colors</h3>
                     <p> This document specifies a closed set of six colors chosen because of their
                         extensive support in well-known reading systems. However, most existing reading apps
                         offer a smaller set to their users. </p>


### PR DESCRIPTION
This is to fix #2971. The PR follows the discussion on [9th of April](https://w3c.github.io/pm-wg/minutes/2026-04-09.html#45b5).

---

See:

* For EPUB Annotations 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/annotations/colors-not-css/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fannotations%2Fcolors-not-css%2Fepub34%2Fannotations%2Findex.html)
