### PR TITLE
Added a subtitle

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -11,7 +11,7 @@
         <script src="../../common/js/add-caution-hd.js" class="remove"></script>
         <script class="remove">
             var respecConfig = {
-                subtitle: "An interchange format for annotations, highlights, and bookmarks",
+                subtitle: "An interchange format for user notes, highlights, and bookmarks",
                 group: "pm",
                 wgPublicList: "public-pm-wg",
                 specStatus: "ED",

--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -11,6 +11,7 @@
         <script src="../../common/js/add-caution-hd.js" class="remove"></script>
         <script class="remove">
             var respecConfig = {
+                subtitle: "An interchange format for annotations, highlights, and bookmarks",
                 group: "pm",
                 wgPublicList: "public-pm-wg",
                 specStatus: "ED",


### PR DESCRIPTION
To move forward a discussion (see [slack discussion](https://w3ccommunity.slack.com/archives/C0AP01YQ34N/p1775847228401349)) on adding more "clues" to the essence of the annotation spec.

---

See:

* For EPUB Annotations 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/annotations/added-subtitle/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fannotations%2Fadded-subtitle%2Fepub34%2Fannotations%2Findex.html)
