### PR TITLE
Clarify that hasFeature matching requires identical values

### DIFF
--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2571,14 +2571,28 @@ partial interface Navigator {
 					<section id="app-ers-hasFeature-desc">
 						<h5>Description</h5>
 
-						<p data-dfn-for="EpubReadingSystem">The <code><dfn>hasFeature</dfn></code> method returns a
-							boolean value indicating whether the reading system supports any version of the specified
-							feature, or <code>undefined</code> if the reading system does not recognize the specified
-							feature.</p>
+						<p data-dfn-for="EpubReadingSystem">The <code><dfn>hasFeature</dfn></code> method indicates
+							whether a reading system supports the specified feature. If no version is supplied with the
+							named feature, the result indicates whether any version of the feature is supported.</p>
+
+						<p>When a reading system supports a feature queried from the <code>hasFeature</code> method, it
+							MUST return a boolean value indicating its support. If the feature is not recognized, the
+							reading system MUST return <code>undefined</code>.</p>
+
+						<p>The <code>feature</code> parameter specified in the <code>hasFeature</code> call MUST be
+							[=identical to=] [[infra]] a supported feature for a reading system to return a
+								<code>true</code> value.</p>
+
+						<div class="note">
+							<p>Refer to <a href="#app-ers-hasFeature-features"></a> for a list of features that have to
+								be supported.</p>
+						</div>
 
 						<p>The <code>version</code> parameter allows querying of custom features that could change in
 							incompatible ways over time. The return value indicates support only for the specified
-							version of the feature.</p>
+							version of the feature. When the <code>version</code> parameter is set, its value MUST be
+							[=identical to=] [[infra]] the version number supported by the reading system in order to
+							return a <code>true</code> value.</p>
 
 						<p><a href="#app-ers-hasFeature-features">Features defined in this specification</a> are
 							versionless. If a reading system supports a feature defined in this specification, it MUST
@@ -2599,9 +2613,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 						<p id="scripting-req-readingsystem-features" data-tests="#scr-readingsystem-features">The
 							following table lists the set of features that reading systems that support the
-								<code>epubReadingSystem</code> object MUST recognize. When the features are queried from
-							the <code>hasFeature</code> method, reading systems MUST return a boolean value indicating
-							their support.</p>
+								<code>epubReadingSystem</code> object MUST recognize.</p>
 
 						<table>
 							<thead>
@@ -2685,6 +2697,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
+					<li>14-Apr-2026: Clarified that the <code>feature</code> and <code>version</code> parameters of 
+						<code>hasFeature</code> are case sensitive for matching. See <a
+							href="https://github.com/w3c/epub-specs/issues/2966">issue 2966</a>.</li>
 					<li>29-Jan-2026: Removed processing requirements for manifest fallbacks when used for content as
 						this is now marked as an outdated feature. See <a
 							href="https://github.com/w3c/epub-specs/issues/2900">issue 2900</a>.</li>

--- a/epub34/rs/index.html
+++ b/epub34/rs/index.html
@@ -2580,7 +2580,7 @@ partial interface Navigator {
 							reading system MUST return <code>undefined</code>.</p>
 
 						<p>The <code>feature</code> parameter specified in the <code>hasFeature</code> call MUST be
-							[=identical to=] [[infra]] a supported feature for a reading system to return a
+							[=string/is|identical to=] [[infra]] a supported feature for a reading system to return a
 								<code>true</code> value.</p>
 
 						<div class="note">
@@ -2591,7 +2591,7 @@ partial interface Navigator {
 						<p>The <code>version</code> parameter allows querying of custom features that could change in
 							incompatible ways over time. The return value indicates support only for the specified
 							version of the feature. When the <code>version</code> parameter is set, its value MUST be
-							[=identical to=] [[infra]] the version number supported by the reading system in order to
+							[=string/is|identical to=] [[infra]] the version number supported by the reading system in order to
 							return a <code>true</code> value.</p>
 
 						<p><a href="#app-ers-hasFeature-features">Features defined in this specification</a> are
@@ -2697,8 +2697,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-rs-33/">EPUB Reading Systems
 						3.3</a></summary>
 				<ul>
-					<li>14-Apr-2026: Clarified that the <code>feature</code> and <code>version</code> parameters of 
-						<code>hasFeature</code> are case sensitive for matching. See <a
+					<li>14-Apr-2026: Clarified that the <code>feature</code> and <code>version</code> parameters of
+							<code>hasFeature</code> are case sensitive for matching. See <a
 							href="https://github.com/w3c/epub-specs/issues/2966">issue 2966</a>.</li>
 					<li>29-Jan-2026: Removed processing requirements for manifest fallbacks when used for content as
 						this is now marked as an outdated feature. See <a


### PR DESCRIPTION
I've updated the description section to clarify that both the feature and version parameters must be identical to the queried support feature to match.

The issue suggested numeric parsing of the version but we've never said what the value has to be. Since 1.1.1 or 1.a or anything else are valid versions, I've re-used the "identical to" definition from infra and left it at that. (And as all the spec-defined features are versionless, there's little likelihood that any choice on matching here matters.)

Fixes #2966 

---

 [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2966/epub34/rs/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Frs%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-2966%2Fepub34%2Frs%2Findex.html)
