### PR TITLE
Add opus in mp4 as a core media type

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1050,7 +1050,7 @@
 						</tr>
 						<tr>
 							<td id="cmt-mp4-aac" data-tests="#pub-cmt-mp4">
-								<ol>
+								<ol class="cmt">
 									<li>
 										<code>audio/mp4; codecs=aac</code>
 									</li>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1067,7 +1067,7 @@
 							<td id="cmt-mp4-opus">
 								<code>audio/mp4; codecs=opus</code>
 							</td>
-							<td> [[mpeg4-audio]], [[mp4]], [[opus-iso]] </td>
+							<td> [[mpeg4-audio]], [[mp4]], [[rfc6716]] </td>
 							<td>OPUS audio using MP4 container</td>
 							<td>3.4</td>
 						</tr>

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1050,11 +1050,26 @@
 						</tr>
 						<tr>
 							<td id="cmt-mp4-aac" data-tests="#pub-cmt-mp4">
-								<code>audio/mp4</code>
+								<ol>
+									<li>
+										<code>audio/mp4; codecs=aac</code>
+									</li>
+									<li>
+										<code>audio/mp4</code>
+									</li>
+								</ol>
 							</td>
 							<td> [[mpeg4-audio]], [[mp4]] </td>
 							<td>AAC LC audio using MP4 container</td>
 							<td>3.0</td>
+						</tr>
+						<tr>
+							<td id="cmt-mp4-opus">
+								<code>audio/mp4; codecs=opus</code>
+							</td>
+							<td> [[mpeg4-audio]], [[mp4]], [[opus-iso]] </td>
+							<td>OPUS audio using MP4 container</td>
+							<td>3.4</td>
 						</tr>
 						<tr>
 							<td id="cmt-ogg-opus" data-tests="#pub-cmt-opus">
@@ -1062,7 +1077,7 @@
 							</td>
 							<td> [[rfc7845]] </td>
 							<td>OPUS audio using OGG container</td>
-							<td>3.0</td>
+							<td>3.3</td>
 						</tr>
 						<tr>
 							<th colspan="4" id="cmt-grp-text" class="tbl-group">Style</th>
@@ -11292,8 +11307,11 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>14-Apr-2026: Added Opus in MP4 container as a core media type and added additional media type
+						with codec for AAC LC. See <a href="https://github.com/w3c/epub-specs/issues/2979">issue
+							2979</a>.</li>
 					<li>29-Jan-2026: Moved manifest fallbacks for content to the outdated features. See <a
-							href="https://github.com/w3c/epub-specs/issues/2900">issue 2900</a></li>
+							href="https://github.com/w3c/epub-specs/issues/2900">issue 2900</a>.</li>
 					<li>23-January-2026: Added JPEG XL as a core media type for images. See <a
 							href="https://github.com/w3c/epub-specs/issues/2896">issue 2896</a>.</li>
 					<li>18-Dec-2025: Renamed "obsolete but conforming features" to "outdated features". As discussed in

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -1067,7 +1067,7 @@
 							<td id="cmt-mp4-opus">
 								<code>audio/mp4; codecs=opus</code>
 							</td>
-							<td> [[mpeg4-audio]], [[mp4]], [[rfc6716]] </td>
+							<td> [[mpeg4-audio]], [[mp4]], [[rfc8251]] </td>
 							<td>OPUS audio using MP4 container</td>
 							<td>3.4</td>
 						</tr>


### PR DESCRIPTION
In addition, this pull request allows the codecs parameter for aac lc media type in addition to using "audio/mp4".

Fixes #2979


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2984.html" title="Last updated on Apr 14, 2026, 4:31 PM UTC (28161f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2984/b102fd4...28161f1.html" title="Last updated on Apr 14, 2026, 4:31 PM UTC (28161f1)">Diff</a>