### PR TITLE
The title property for AnnotationSets have been removed from the examples

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -107,7 +107,7 @@
             </p>
             <ul>
                 <li> Web Annotations may have 0 or more Bodies, whereas this document requires to have a single <a href="#body">Body</a>
-                    per annotation. Although most use cases relate to textual notes embedded in the annotation, this version 
+                    per annotation. Although most use cases relate to textual notes embedded in the annotation, this version
                     of the specification paves the way to the inclusion of audiovisual notes by also allowing external Web resources.
                 </li>
 
@@ -241,9 +241,9 @@
 
                 <p class="note">The type of annotation should be considered when determining the value of the
                     [=motivation=] property.
-                    An annotation with a Body structure corresponds to a "comment". 
-                    An annotation without Body structure corresponds to a "highlight" if its Selector defines a range of characters, 
-                    a region in an image, or a time period, 
+                    An annotation with a Body structure corresponds to a "comment".
+                    An annotation without Body structure corresponds to a "highlight" if its Selector defines a range of characters,
+                    a region in an image, or a time period,
                     and a "bookmark" if it does not.
                 </p>
 
@@ -848,8 +848,8 @@
                             <td>
                                 <code> format </code>
                             </td>
-                            <td> The media-type of the note. Only plain text is allowed for textual notes. 
-                                Audiovisual notes can be of any media type supported by EPUB, 
+                            <td> The media-type of the note. Only plain text is allowed for textual notes.
+                                Audiovisual notes can be of any media type supported by EPUB,
                                 see EPUB Media Types <!--<a data-cite="epub34#sec-core-media-types">EPUB Media Types</a>-->.
                             </td>
                             </td>
@@ -1148,13 +1148,13 @@
                     </tbody>
                 </table>
 
-                <p class="note"> 
-                    
+                <p class="note">
+
                     All properties are from the Dublin Core Vocabulary [[dcterms]], also referenced
                     in the [[[annotation-model]]] as well as in the EPUB <a data-cite="epub-34#sec-pkg-metadata">package
                         document metadata</a>.
 
-                    Implementers are free to add other properties from the Dublin Core Vocabulary, or to use properties from other vocabularies, as long as they are properly declared in the context file.                
+                    Implementers are free to add other properties from the Dublin Core Vocabulary, or to use properties from other vocabularies, as long as they are properly declared in the context file.
                 </p>
 
                 <aside class="example" title="An AnnotationSet containing one annotation">
@@ -1165,7 +1165,6 @@
         "type": "AnnotationSet",
         "generator": "https://github.com/edrlab/thorium-reader/releases/tag/v3.1.0",
         "generated": "2023-09-01T10:00:00Z",
-        "title": "Annotations Mme Prof, La Peste, cours 1ere B",
         "about": {
             "dc:identifier": [
                 "urn:isbn:1234567890"
@@ -1225,42 +1224,42 @@
                 Such implementations may safely ignore the context
                 declarations and are not required to dereference the respective URLs.
             </p>
-            
+
             <section>
 
-                <p> An AnnotationSet can be shared as a detached file, or embedded in an EPUB package. 
-                    The advantage of detached annotations is that they can be shared independently of the publication, 
-                    and that they can be associated with a publication without modifying it. 
-                    The advantage of embedded annotations is that they are always available to users of the publication, 
+                <p> An AnnotationSet can be shared as a detached file, or embedded in an EPUB package.
+                    The advantage of detached annotations is that they can be shared independently of the publication,
+                    and that they can be associated with a publication without modifying it.
+                    The advantage of embedded annotations is that they are always available to users of the publication,
                     without any need to import them.
 
                 <p class="note">
                     Reading Systems are not required to store annotations with such a format: this format is for export and import purposes.
                 </p>
-            
+
                 </p>
 
                 <h2>Detached annotations</h2>
-                
-                <p> For packaging the set of constituent resources that comprise an AnnotationSet, 
-                    this specification uses the ZIP format 
+
+                <p> For packaging the set of constituent resources that comprise an AnnotationSet,
+                    this specification uses the ZIP format
                     as specified in ISO/IEC 21320-1:2015 ([[ISO21320]] and [[zip]]). </p>
-                
-                <p> This specification introduces a dedicated file extension for detached annotations: 
+
+                <p> This specification introduces a dedicated file extension for detached annotations:
                     <code>.annotations</code>.
                 </p>
 
                 <p> The media type of this file is
                     <code>application/zip;profile="https://www.w3.org/TR/epub-anno-10/"</code>. </p>
-            
-                <p> The serialized AnnotationSet is stored in the ZIP file as <code>annotations.json</code>, in the root of the ZIP file. 
-                    Audiovisual notes, if present, MAY be in any location descendant from the root of the ZIP file. 
+
+                <p> The serialized AnnotationSet is stored in the ZIP file as <code>annotations.json</code>, in the root of the ZIP file.
+                    Audiovisual notes, if present, MAY be in any location descendant from the root of the ZIP file.
                     Annotation bodies within the AnnotationSet MUST reference these resources via relative-URL strings [[url]].</p>
 
                 <div class="note">
-                    <p> The [[zip]] specification has few constraints on the characters allowed 
-                        for file and directory names. 
-                        When crafting such names, authors must be careful to use characters which 
+                    <p> The [[zip]] specification has few constraints on the characters allowed
+                        for file and directory names.
+                        When crafting such names, authors must be careful to use characters which
                         allow a broad interoperability among operating systems.</p>
                 </div>
 
@@ -1270,9 +1269,9 @@
 
                 <h2>Annotations embedded in EPUB</h2>
 
-                <p> The AnnotationSet is stored in the META-INF directory as <code>annotations.json</code>. 
-                    Audiovisual notes, if present, MAY be in any location descendant from the META-INF directory, 
-                    or in the META-INF directory itself. 
+                <p> The AnnotationSet is stored in the META-INF directory as <code>annotations.json</code>.
+                    Audiovisual notes, if present, MAY be in any location descendant from the META-INF directory,
+                    or in the META-INF directory itself.
                     Annotation bodies within the AnnotationSet MUST reference these resources via relative-URL strings [[url]].</p>
 
                 <div class="note">
@@ -1288,7 +1287,7 @@
 
             <section>
                 <h2> Displaying filtered annotations </h2>
-                <p> It is recommended that Reading systems  enable filtering by motivation, creator, style and tags. 
+                <p> It is recommended that Reading systems  enable filtering by motivation, creator, style and tags.
                     For instance, a user can display &quot;blue&quot; colored annotations only, or
                     &quot;typo&quot; tagged annotations only. Filtering on multiple criteria is a plus. </p>
 
@@ -1331,16 +1330,16 @@
             <section>
                 <h2>Importing annotations</h2>
                 <p> To simplify associating annotations with a publication, a Reading System has to
-                    offer a way to select a publication before selecting an annotation set. 
+                    offer a way to select a publication before selecting an annotation set.
                     An automatic association of an annotation set with a publication (e.g. via drag and
-                    drop) can also be proposed, but identifying the proper publication from 
+                    drop) can also be proposed, but identifying the proper publication from
                     the metadata in the annotation set is error prone. </p>
-                <p> When importing an annotation set, the good practice for Reading Systems is to 
+                <p> When importing an annotation set, the good practice for Reading Systems is to
                     display publication metadata (e.g. title, author), the number of annotations found in the set,
                     and offer the user the choice to abort the import if the information does not match their expectations. </p>
-                <p> Each annotation is uniquely identified, independently of the annotation set it is part of. 
+                <p> Each annotation is uniquely identified, independently of the annotation set it is part of.
                     During the import of an annotation set,
-                    if one or more annotations are found to be already stored in the application, 
+                    if one or more annotations are found to be already stored in the application,
                     the Reading System will offer the user a choice: either overriding the existing annotations,
                     or abort the import of the annotation set. </p>
 
@@ -1349,8 +1348,8 @@
             <section>
                 <h2>Dealing with audiovisual notes</h2>
                 <p> This specification provides mechanisms for handling audiovisual notes.</p>
-                <p> If an application does not support audiovisual notes, it has to ignore them 
-                    when importing an annotation set. It is good practice to notify the user 
+                <p> If an application does not support audiovisual notes, it has to ignore them
+                    when importing an annotation set. It is good practice to notify the user
                     that some annotations were not imported due to lack of support. </p>
 
                 </section>
@@ -1360,7 +1359,7 @@
                 <p> This document specifies a closed set of six colors chosen because of their
                     extensive support in well-known reading systems. However, most existing reading apps
                     offer a smaller set to their users. </p>
-                <p> If an application imports annotations with a color it does not support, 
+                <p> If an application imports annotations with a color it does not support,
                     it is good practice to ignore the color information and to
                     display them with a neutral color. The recommended neutral color is grey. </p>
                 <p> Some applications may support colors not in the set defined by this specification
@@ -1410,10 +1409,6 @@
                         "@context": "https://www.w3.org/ns/epub-anno.jsonld",
                         "type": "AnnotationSet",
                         "id": "urn:uuid:123-456-789",
-                        "title" : {
-                            "text": "This is an example for an annotation text",
-                            "language": "en"
-                        },
                         "items" : [
                             {
                                 "id": "urn:uuid:123-456-789-a1",
@@ -1470,7 +1465,6 @@
                             ],
                             "type": "AnnotationSet",
                             "id": "urn:uuid:123-456-789",
-                            "title" : "This is an example for an annotation text",
                             "items" : [
                                 {
                                     "id": "urn:uuid:123-456-789-a1",


### PR DESCRIPTION
See above

---

See:

* For EPUB Annotations 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/annotations/removal-of-titles/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fannotations%2Fremoval-of-titles%2Fepub34%2Fannotations%2Findex.html)

