### PR TITLE
Add some context to the use of the term Segment in the Target section.

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -113,9 +113,6 @@
 
                 <li> Web Annotations have 1 or more Targets, while only a single <a href="#target">Target</a> is
                     allowed for an EPUB Annotation.
-                    The Target of an EPUB Annotation is the content being annotated, which is
-                    a specific segment in a document within the EPUB package defined by its relative
-                    <a href="#source">Source</a> URL and a <a href="#selector">Selector</a>.
                 </li>
 
                 <li> Web Annotations may have multiple motivations, while only a single motivation is allowed for EPUB
@@ -320,7 +317,7 @@
 
             <section>
                 <h2>Target</h2>
-                <p>The <dfn>Target object</dfn> of an annotation associates the annotation with a specific segment of a
+                <p>The <dfn>Target object</dfn> of an annotation associates the annotation with a specific Segment (of Interest) of a
                     resource in the current publication.</p>
                 <p> This document defines three target sub-properties: </p>
                 <table class="zebra">


### PR DESCRIPTION
Associated with issue #2884.

---

See:

* For EPUB Annotations 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/anno-segment/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fanno-segment%2Fepub34%2Fannotations%2Findex.html)
