### PR TITLE
Update section number reference to zip appnote

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -2974,9 +2974,12 @@
 								Deflate-compressed ZIP entries within the ZIP archive.</p>
 						</li>
 						<li>
-							<p id="confreq-zip-64">OCF ZIP containers MAY use the ZIP64 extensions defined as "Version
-								1" in section 4.3.14 ("Zip64 end of central directory record") of the application note
-								[[zip]] and SHOULD use only those extensions when the content requires them.</p>
+							<p id="confreq-zip-64">OCF ZIP containers MAY use the ZIP64 extensions defined as <a
+									href="https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT#:~:text=4.3.14.2"
+									>"Version 1"</a> in <a
+									href="https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT#:~:text=4.3.14%20%20Zip64%20end%20of%20central%20directory%20record"
+									>section 4.3.14 ("Zip64 end of central directory record")</a> [[zip]] and SHOULD use
+								only those extensions when the content requires them.</p>
 						</li>
 						<li>
 							<p id="confreq-zip-enc">OCF ZIP containers MUST NOT use the encryption features defined by

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -2975,8 +2975,8 @@
 						</li>
 						<li>
 							<p id="confreq-zip-64">OCF ZIP containers MAY use the ZIP64 extensions defined as "Version
-								1" in section V, subsection G of the application note [[zip]] and SHOULD use only those
-								extensions when the content requires them.</p>
+								1" in section 4.3.14 ("Zip64 end of central directory record") of the application note
+								[[zip]] and SHOULD use only those extensions when the content requires them.</p>
 						</li>
 						<li>
 							<p id="confreq-zip-enc">OCF ZIP containers MUST NOT use the encryption features defined by
@@ -11311,6 +11311,8 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>04-May-2026: Fixed outdated section number reference to ZIP64 extensions in the ZIP application
+						note. See <a href="https://github.com/w3c/epub-specs/issues/2993">issue 2993</a>.</li>
 					<li>15-Apr-2026: Added recommendation against using variable bitrate MP3 files with media overlays.
 						See <a href="https://github.com/w3c/epub-specs/issues/2978">issue 2978</a>.</li>
 					<li>14-Apr-2026: Added Opus in MP4 container as a core media type and added additional media type


### PR DESCRIPTION
I've linked the references to make them a bit easier to follow, but the appnote is a hideous giant pre block of text so I had to rely on text fragment selectors.

Fixes #2993


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2994.html" title="Last updated on May 4, 2026, 12:21 PM UTC (5e18f4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2994/da5f28d...5e18f4a.html" title="Last updated on May 4, 2026, 12:21 PM UTC (5e18f4a)">Diff</a>