### PR TITLE
Rearrange a11y spec and techniques for understanding doc

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -333,9 +333,9 @@
 
 					<p>Given these differences in application, however, it is important to include EPUB landmarks and
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
-						navigation in its own way. Providing EPUB landmarks further fulfills the requirement for <a
-							data-cite="epub-a11y-understand#multiple-ways">multiple ways</a> [[epub-a11y-understand]] to
-						access the content.</p>
+						navigation in its own way. Providing EPUB landmarks further fulfills the requirement for <!--<a
+							data-cite="epub-a11y-understand#multiple-ways">-->multiple
+						ways<!--</a> [[epub-a11y-understand]] --> to access the content.</p>
 
 					<p>The EPUB specification does not require that EPUB publications include a specific set of
 						landmarks; it only recommends to include a link to the start of the body matter as well as to

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -261,115 +261,6 @@
 			<section id="sec-wcag-content-access">
 				<h3>Content access</h3>
 
-				<section id="spread-order">
-					<span id="access-001"></span>
-					<h4>Ensure meaningful order of content across spreads</h4>
-
-					<p><a data-cite="wcag2#meaningful-sequence">Success Criterion 1.3.2</a> [[wcag2]] specifies that
-						each web page have a meaningful order (i.e., that the visual presentation of the content match
-						the underlying markup).</p>
-
-					<p>As EPUB allows two <a data-cite="epub/#dfn-epub-content-document">EPUB content documents</a> to
-						be rendered together in a <a data-cite="epub/#spread">synthetic spread</a> [[epub-3]], the order
-						of content within a single document cannot always be evaluated in isolation. Content might span
-						visually from one document to the next. For example, a sidebar might span the bottom of two
-						pages.</p>
-
-					<p>Ordering each document separately by the visual display will lead to users of <a
-							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> encountering
-						gaps between the start and end of the spanned text. If the markup cannot be arranged to provide
-						a more logical reading experience (e.g., the beginning of the spanned content at the end of the
-						first page followed by the conclusion at the start of the next), another means of satisfying
-						this criteria will be necessary to avoid failure (e.g., a hyperlink could be provided to allow a
-						user to jump from the break point on the first page to the continuation on the next).</p>
-				</section>
-
-				<section id="multiple-ways">
-					<span id="access-002"></span>
-					<h4>Provide multiple ways to access the content</h4>
-
-					<p><a data-cite="wcag2#multiple-ways">Success Criterion 2.4.5</a> [[wcag2]] requires there be more
-						than one way to locate a web page within a set of web pages. By default, <a
-							data-cite="epub/#dfn-epub-publication">EPUB publications</a> meet this WCAG requirement so
-						long as <a data-cite="epub/#sec-spine-elem">all EPUB content documents are included in the
-							spine</a> and <a data-cite="epub/#sec-itemref-elem">access to all non-linear documents is
-							provided</a> [[epub-3]].</p>
-
-					<p>The reason an EPUB publication passes by meeting these requirements has to do with differences in
-						how a user interacts with the set of documents in an EPUB publication. In particular, although
-						an EPUB publication typically consists of many <a data-cite="epub/#dfn-epub-content-document"
-							>EPUB content documents</a>, <a data-cite="epub/#dfn-epub-reading-system">reading
-							systems</a> automatically provide the ability for the user to move seamlessly from one
-						document to the next, so long as they are listed in the <a data-cite="epub/#sec-spine-elem"
-							>spine</a> [[epub-3]]. To the user, an EPUB publication is a single document they have
-						complete access to, not a set of disconnected pages that they need links to move through.</p>
-
-					<p>The required table of contents provides a second method to access the major headings of the
-						publication. The user can jump to any heading and continue to navigate from there, regardless of
-						how the publication is chunked.</p>
-
-					<p>Following these two requirements therefore satisfies the need for multiple ways to access the
-						content. Reading systems also typically provide search capabilities so users also have a third
-						option available in most cases.</p>
-
-					<p>Although following EPUB's basic requirements will meet this criterion, providing additional
-						methods to improve access beyond the minimum is encouraged. Some suggestions include:</p>
-
-					<ul>
-						<li>
-							<p>adding at least one link to every EPUB content document in the spine to the table of
-								contents, when feasible;</p>
-						</li>
-						<li>
-							<p>adding an index to locate major topics; and</p>
-						</li>
-						<li>
-							<p>adding additional navigation aids to the <a
-									data-cite="epub/#dfn-epub-navigation-document">EPUB navigation document</a> (e.g.,
-								lists of figures and tables).</p>
-						</li>
-					</ul>
-
-					<section id="sec-access-002-toc">
-						<h5>Note about the table of contents</h5>
-
-						<p>A common question about the EPUB table of contents is what completeness it needs to have with
-							respect to the headings of the publication. Although the obvious answer is to create a
-							simple aggregation of all the headings for all the sections, practically there are several
-							usability challenges to this approach.</p>
-
-						<p>Factors such as device screen sizes can make the table of contents for publications with a
-							deep hierarchy of headings unreadable, so headings below a certain depth get trimmed to
-							improve the readability. Further, <a data-cite="epub/#dfn-epub-reading-system">reading
-								systems</a> do not always provide structured access to the headings in the table of
-							contents, or provide shortcuts to navigate the links. The result is that users have to
-							listen to each link one at a time to find where they want to go, a tedious and
-							time-consuming process.</p>
-
-						<p>Although it is expected that reading systems will improve access to the table of contents as
-							accessibility support for EPUB evolves — making complete tables of contents usable by
-							everyone — there are legitimate usability reasons why they are not provided now.</p>
-
-						<p>When opting not to provide links to all the headings, it is best to optimize the links that
-							are provided to improve the overall reading experience. Some considerations on how to
-							achieve this include:</p>
-
-						<ul>
-							<li>
-								<p>ensuring that there is at least one link to every <a
-										data-cite="epub/#dfn-epub-content-document">EPUB content document</a> — allowing
-									the user to reach each document simplifies navigation to the minor headings within
-									them; and</p>
-							</li>
-							<li>
-								<p>only omitting minor headings from the table of contents — although a subjective
-									decision, there is often a level of diminishing value for navigation (e.g., fourth
-									level and lower headings often only delimit short subsections on a topic).</p>
-							</li>
-						</ul>
-					</section>
-				</section>
-
 				<section id="toc-linear-order">
 					<span id="access-003"></span>
 					<h4>Ensure the order of table of contents entries matches linear order</h4>
@@ -415,194 +306,22 @@
 					</div>
 				</section>
 
-				<section id="access-bypass-blocks">
-					<h4>Bypass blocks not necessary</h4>
-
-					<p>Web sites are constructed very differently from EPUB publications. A typical web site wraps the
-						content of each page within a repeating template, for example. This template gives each page a
-						consistent look and feel, but users are rarely interested in the wrapper content after visiting
-						the first page. Visual readers can typically skip past the site header, navigation bars, search
-						boxes, and other helpful but seldom-used features to get right to the content.</p>
-
-					<p>To provide the same ease of access to readers who would have to navigate sequentially through the
-						repetitive content, <a href="https://www.w3.org/TR/WCAG/#bypass-blocks">success criterion
-							2.4.1</a> [[wcag2]] requires a means of bypassing the repeated content in a set of pages.
-						This success criterion does not apply to typical EPUB publications, however, as EPUB content
-						documents do not repeat content in the same way that web sites do.</p>
-
-					<p>Each new content document might begin with similar content, such as learning objectives or key
-						terms, but this content is part of the body of the publication and not identical to what came
-						before. Consequently, it is not required to add a link to skip it. (Secondary content still
-						needs to be identified in accordance with <a
-							href="https://www.w3.org/TR/WCAG/#info-and-relationships">success criterion 1.3.1</a>,
-						however.)</p>
-
-					<div class="note">
-						<p>If an EPUB publication were to reproduce a set of web pages with their full site trappings,
-							then success criterion 2.4.1 would apply, but this practice is not common.</p>
-					</div>
-				</section>
-			</section>
-
-			<section id="sec-wcag-roles">
-				<h3>Roles</h3>
-
-				<section id="roles-epub-type">
-					<span id="sem-001"></span>
-					<h4>ARIA roles and <code>epub:type</code></h4>
-
-					<div class="note">
-						<p>The following guidance is only for <a data-cite="epub/#dfn-epub-content-document">EPUB
-								content documents</a>. The <code>type</code> attribute is the only means of adding
-							structural information to <a data-cite="epub/#dfn-media-overlay-document">media overlay
-								documents</a> so that features like lists and tables can be navigated more efficiently.
-							It is also required in the <a data-cite="epub/#dfn-epub-navigation-document">EPUB navigation
-								document</a> to identify key structures.</p>
-					</div>
-
-					<p>Although the <code>role</code> attribute might seem similar in nature to the <a
-							data-cite="epub/#sec-epub-type-attribute"><code>type</code> attribute</a> [[epub-3]], their
-						target uses in EPUB content documents do not overlap.</p>
-
-					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
-						accessibility in content while the <code>type</code> attribute provides hooks to enable <a
-							data-cite="epub/#dfn-epub-reading-system">reading system</a> behaviors. Omitting roles
-						lessens the accessibility for users of <a data-cite="epub-a11y-11#dfn-assistive-technology"
-							>assistive technologies</a>, in other words, while omitting types diminishes certain
-						functionality in <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> (e.g., pop-up
-						footnotes or special presentations of the content).</p>
-
-					<p>Since each attribute offers different advantages, it is only necessary to pair them together when
-						both attributes provide benefits. For example, it is common to pair footnote roles and types to
-						ensure reading systems can provide pop-up functionality and assistive technologies can announce
-						the type of link the user has encountered.</p>
-
-					<p>For anyone looking to move from the <code>type</code> attribute to using ARIA roles, the <a
-							href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
-							Authoring Guide</a> details notable authoring differences between the two attributes. It
-						also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
-						equivalent ARIA roles in [[dpub-aria-1.1]] and [[wai-aria]]. [[html-aria]] is another useful
-						reference that provides the full list of restrictions on where ARIA roles can be used in
-						HTML.</p>
-
-					<p>Finally, be aware that the use of the <code>type</code> attribute is not a means of satisfying
-						requirements for ARIA roles in WCAG.</p>
-				</section>
-
-				<section id="role-repetition">
-					<span id="sem-002"></span>
-					<h4>Do not repeat roles across chunked content</h4>
-
-					<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> appear as single
-						contiguous documents to users when read, they are typically composed of many individual <a
-							data-cite="epub/#dfn-epub-content-document">EPUB content documents</a>. This practice keeps
-						the amount of markup that has to be rendered small to reduce the load time in <a
-							data-cite="epub/#dfn-epub-reading-system">reading systems</a> (i.e., to minimize the time
-						the user has to wait for a document to appear). It is rare, at least for books, for an EPUB
-						publication to contain only one EPUB content document with all the content in it.</p>
-
-					<p>When content is chunked in this way, it often requires restructuring the information to fit
-						within the new file structure. A part, for example, will typically not include all the chapters
-						that belong to it. Instead, the part heading might be separated from each chapter, leaving each
-						chapter in a separate document.</p>
-
-					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
-						functionality of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive
-						technologies</a>. In the case of [[wai-aria]] roles, the result is that only the subset present
-						in the currently-loaded EPUB content document are exposed to users. An assistive technology
-						cannot provide a list of landmarks for the whole publication, as it cannot see outside the
-						current document.</p>
-
-					<p>To counteract this destructuring effect, a common bad practice is to re-add or re-identify
-						structures in the belief that having this information in every document will be helpful to users
-						(e.g., adding an extra [[html]] <a data-lt="section"><code>section</code> element</a> around a
-						chapter to indicate it belongs to a part). All this practice does, however, is add repetition
-						that is not only disruptive when reading but can make the structure of the publication harder to
-						follow. It is therefore advised not to attempt to rebuild structures in these ways.</p>
-
-					<p>For example, consider a book that has five parts and each part contains five chapters.
-						Structurally, each chapter belongs to its part (i.e., is grouped with it), as in the following
-						markup:</p>
-
-					<pre>&lt;html … >
-   …
-   &lt;body>
-      &lt;section
-          role="doc-part"
-          aria-labelledby="p1">
-         
-         &lt;h1 id="p1">Part 1&lt;/h1>
-         
-         &lt;section
-             role="doc-chapter"
-             aria-labelledby="c1">
-            
-            &lt;h2 id="c1">Chapter 1&lt;/h2>
-            …
-         &lt;/section>
-         …
-      &lt;/section>
-      …
-   &lt;/body>
-&lt;/html></pre>
-
-					<div class="note">
-						<p>When more than one instance of a role is included in a document, each has to be uniquely
-							identified. The <code>aria-labelledby</code> attribute provides the name of each landmark in
-							the preceding example. The attribute is not required if only one instance is present, so it
-							is omitted from the following examples.</p>
-					</div>
-
-					<p>Since this would lead to a large content file, the part heading is typically split out into its
-						own EPUB content document so that it will appear on its own page:</p>
-
-					<pre>&lt;html … >
-   …
-   &lt;body>
-      &lt;section 
-          role="doc-part">
-         &lt;h1 id="p1">Part 1&lt;/h1>
-      &lt;/section>
-   &lt;/body>
-&lt;/html></pre>
-
-					<p>Each chapter is then separated into a separate EPUB content document:</p>
-
-					<pre>&lt;html … >
-   …
-   &lt;body>
-      &lt;section
-          role="doc-chapter">
-         
-         &lt;h2>Chapter 1&lt;/h2>
-         …
-      &lt;/section>
-   &lt;/body>
-&lt;/html></pre>
-
-					<p>If another <code>section</code> tag were added around the chapter in the preceding example to
-						indicate it is in part one (e.g., using the <code>aria-label</code> attribute so the heading is
-						not visible) users would hear "Part 1 Part 1 Chapter 1" because "Part 1" is also the heading in
-						the document that precedes the first chapter.</p>
-				</section>
-
 				<section id="landmarks">
 					<span id="sem-003"></span>
 					<h4>Include EPUB landmarks</h4>
 
 					<p>[[wai-aria]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
-							data-cite="epub/#sec-nav-landmarks">EPUB landmarks</a> [[epub-3]]: both are designed to
+							data-cite="epub-3/#sec-nav-landmarks">EPUB landmarks</a> [[epub-3]]: both are designed to
 						provide users with quick access to the major structures of a document, such as chapters,
 						glossaries and indexes.</p>
 
-					<p>ARIA landmarks are compiled automatically by <a data-cite="epub-a11y-11#dfn-assistive-technology"
-							>assistive technologies</a> from the <a href="#roles-epub-type">roles</a> that have been
-						applied to in an <a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content
-							document</a>, but this also means that ARIA landmarks are limited to how the EPUB
-						publication has been chunked up. An assistive technology can only present the landmarks found in
-						the currently-loaded document; it cannot provide a complete picture of all the landmarks in a
-						multi-document publication (see the <a href="#role-repetition">previous section</a> for more
-						discussion about content chunking).</p>
+					<p data-cite="html">ARIA landmarks are compiled automatically by <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> from the <a
+							data-cite="wai-aria#roles">roles</a> [[wai-aria]] that have been applied to in an <a
+							href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB content document</a>, but
+						this also means that ARIA landmarks are limited to how the EPUB publication has been chunked up.
+						An assistive technology can only present the landmarks found in the currently-loaded document;
+						it cannot provide a complete picture of all the landmarks in a multi-document publication.</p>
 
 					<p>EPUB landmarks, on the other hand, are compiled prior to distribution, and are not directly
 						linked to the use of the <a data-cite="epub/#sec-epub-type-attribute"
@@ -614,7 +333,9 @@
 
 					<p>Given these differences in application, however, it is important to include EPUB landmarks and
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
-						navigation in its own way.</p>
+						navigation in its own way. Providing EPUB landmarks further fulfills the requirement for <a
+							data-cite="epub-a11y-understand#multiple-ways">multiple ways</a> [[epub-a11y-understand]] to
+						access the content.</p>
 
 					<p>The EPUB specification does not require that EPUB publications include a specific set of
 						landmarks; it only recommends to include a link to the start of the body matter as well as to
@@ -700,14 +421,19 @@
 
 						<ul>
 							<li>
-								<p>EPUB 2 <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">guide
-										element</a></p>
+								<p>
+									<a href="https://www.w3.org/TR/epub-aria-authoring">EPUB Type to ARIA Role Authoring
+										Guide</a> [[epub-aria-authoring]] </p>
 							</li>
 							<li>
-								<p>EPUB 3 <a data-cite="epub/#sec-nav-landmarks">landmarks nav</a></p>
+								<p><a data-cite="epub/#sec-nav-landmarks">The landmarks nav</a> [[epub-3]]</p>
 							</li>
 							<li>
-								<p>ARIA <a data-cite="wai-aria#landmark_roles">landmarks</a></p>
+								<p><a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">The guide
+										element</a> [[opf-201]]</p>
+							</li>
+							<li>
+								<p><a data-cite="wai-aria#landmark_roles">ARIA landmarks</a> [[wai-aria]]</p>
 							</li>
 						</ul>
 					</section>

--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -69,6 +69,11 @@
 						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
+					"epub-a11y-understand": {
+						"title": "Understanding EPUB Accessibility 1.2",
+						"href": "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
+						"publisher": "W3C"
+					},
 					"iso24751-3": {
 						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
 						"href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",
@@ -122,10 +127,9 @@
 			<section id="sec-overview">
 				<h3>Overview</h3>
 
-				<p>This document, EPUB Accessibility Techniques, provides informative guidance on how to understand and
-					apply the accessibility requirements defined in the EPUB Accessibility 1.2 specification
-					[[epub-a11y-12]] that are unique to <a data-cite="epub/#dfn-epub-publication">EPUB
-					publications</a>.</p>
+				<p>This document, EPUB Accessibility Techniques, provides informative guidance on how to apply the
+					accessibility requirements defined in the EPUB Accessibility 1.2 specification [[epub-a11y-12]] that
+					are unique to <a data-cite="epub/#dfn-epub-publication">EPUB publications</a>.</p>
 
 				<p>This document does not cover general web accessibility techniques already addressed in [[wcag2]] and
 					[[wai-aria]], for example, for which no substantive differences in application exist. Following
@@ -137,6 +141,12 @@
 					accessible content. An EPUB publication has to meet all the requirements of EPUB Accessibility 1.2
 					to make a claim of accessibility; verifying only the techniques in this document is not
 					sufficient.</p>
+
+				<div class="note">
+					<p>For general help understanding how WCAG success criteria and EPUB objectives defined in
+						[[epub-a11y-12]] apply to EPUB publications, refer to [[[epub-a11y-understand]]]
+						[[epub-a11y-understand]].</p>
+				</div>
 			</section>
 
 			<section id="sec-terminology">
@@ -262,7 +272,6 @@
 				<h3>Content access</h3>
 
 				<section id="toc-linear-order">
-					<span id="access-003"></span>
 					<h4>Ensure the order of table of contents entries matches linear order</h4>
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
@@ -307,7 +316,6 @@
 				</section>
 
 				<section id="landmarks">
-					<span id="sem-003"></span>
 					<h4>Include EPUB landmarks</h4>
 
 					<p>[[wai-aria]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
@@ -444,7 +452,6 @@
 				<h3>Titles and headings</h3>
 
 				<section id="pub-title">
-					<span id="titles-001"></span>
 					<h4>Include publication and document titles</h4>
 
 					<p><a data-cite="wcag2#page-titled">Success Criterion 2.4.2</a> [[wcag2]] requires that each web
@@ -498,7 +505,6 @@
 				</section>
 
 				<section id="heading-hierarchy">
-					<span id="titles-002"></span>
 					<h4>Ensure numbered headings reflect publication hierarchy</h4>
 
 					<p>To a user, an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> appears as a single
@@ -574,7 +580,6 @@
 				</section>
 
 				<section id="heading-purpose">
-					<span id="titles-003"></span>
 					<h4>Heading topic or purpose</h4>
 
 					<p><a data-cite="wcag2#non-text-content">Success Criterion 2.4.6</a> [[wcag2]] currently states that
@@ -603,7 +608,6 @@
 				<h3>Descriptions</h3>
 
 				<section id="alt-text">
-					<span id="desc-001"></span>
 					<h4>Include alternative text descriptions</h4>
 
 					<p>The first version of these techniques only required alternative text for images regardless of
@@ -633,7 +637,6 @@
 				<h3>Language</h3>
 
 				<section id="package-lang">
-					<span id="lang-001"></span>
 					<h4>Language of package document</h4>
 
 					<p>Success Criterions <a data-cite="wcag2#language-of-page">3.1.1</a> and <a
@@ -680,7 +683,6 @@
 				</section>
 
 				<section id="publication-lang">
-					<span id="lang-002"></span>
 					<h4>Language of the EPUB publication</h4>
 
 					<p>In addition to being able to express the language of text content, the <a
@@ -720,7 +722,6 @@
 				<h3>Text</h3>
 
 				<section id="unicode-text">
-					<span id="text-001"></span>
 					<h4>Use Unicode for text content</h4>
 
 					<p><a data-cite="wcag2#non-text-content">Success Criterion 1.1.1</a> [[wcag2]] requires that text
@@ -789,8 +790,7 @@
 			<section id="sec-epub-page-navigation">
 				<h3>Page navigation</h3>
 
-				<section id="pageBreakMarkers">
-					<span id="page-001"></span>
+				<section id="page-breaks">
 					<h4>Provide page break markers</h4>
 
 					<p>Both the EPUB Structural Semantics Vocabulary [[epub-ssv]] and Digital Publishing WAI-ARIA 1.0
@@ -832,7 +832,7 @@
 					</aside>
 
 					<p>EPUB 2 does not include markup to identify static page break marks in the content. Page break
-						destinations can be included to enable hyperlinking, but the <a href="#pageList">page
+						destinations can be included to enable hyperlinking, but the <a href="#page-list">page
 						list</a> is the only way a user can jump to the locations.</p>
 
 					<aside class="example" title="Adding a hyperlink destination in EPUB 2">
@@ -864,8 +864,7 @@
 					</div>
 				</section>
 
-				<section id="pageBreakMarkers-audio">
-					<span id="page-002"></span>
+				<section id="page-breaks-audio">
 					<h4>Identify pages in audio playback</h4>
 
 					<p>Readers rarely stop reading to review each new page number, so when page numbers are read aloud
@@ -928,8 +927,7 @@
 						apply.</p>
 				</section>
 
-				<section id="pageList">
-					<span id="page-003"></span>
+				<section id="page-list">
 					<h4>Provide a page list</h4>
 
 					<p>A page list — a list of hyperlinks to the static page break locations — is the most effective way
@@ -1016,8 +1014,7 @@
 					</aside>
 				</section>
 
-				<section id="pageSource">
-					<span id="page-004"></span>
+				<section id="page-source">
 					<h4>Identify the pagination source</h4>
 
 					<p>Users typically want to know the source of the page break markers included in an <a
@@ -1092,8 +1089,7 @@
 			<section id="sec-epub-sync-text-audio">
 				<h3>Synchronized text-audio playback</h3>
 
-				<section id="sync-coverage">
-					<span id="sync-001"></span>
+				<section id="sync-completeness">
 					<h4>Ensuring complete text coverage</h4>
 
 					<p>Ensuring the complete text of an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a>
@@ -1145,7 +1141,6 @@
 				</section>
 
 				<section id="sync-reading-order">
-					<span id="sync-002"></span>
 					<h4>Specifying the reading order</h4>
 
 					<p>The default reading order typically represents the order in which <a
@@ -1175,7 +1170,6 @@
 				</section>
 
 				<section id="sync-skippability">
-					<span id="sync-003"></span>
 					<h4>Identifying skippable structures</h4>
 
 					<p>Some content elements are not critical to read when following the primary narrative of a work,
@@ -1277,7 +1271,6 @@
 				</section>
 
 				<section id="sync-escapability">
-					<span id="sync-004"></span>
 					<h4>Identifying escapable structures</h4>
 
 					<p>Some content elements are containers for expressing complex information. A table, for example,
@@ -1380,8 +1373,7 @@
 					</aside>
 				</section>
 
-				<section id="sync-nav">
-					<span id="sync-005"></span>
+				<section id="sync-nav-doc">
 					<h4>Synchronizing the navigation document</h4>
 
 					<p>A <a data-cite="epub/#dfn-media-overlay-document">media overlay document</a> can be provided for
@@ -1401,7 +1393,6 @@
 			<h2>Distribution techniques</h2>
 
 			<section id="dist-drm">
-				<span id="dist-001"></span>
 				<h3>Do not restrict access through digital rights management</h3>
 
 				<p><a data-cite="epub/#dfn-epub-publication">EPUB publications</a> typically require preservation of the
@@ -1425,7 +1416,6 @@
 			</section>
 
 			<section id="dist-a11y-metadata">
-				<span id="dist-002"></span>
 				<h3>Include accessibility metadata in distribution records</h3>
 
 				<p>When an <a data-cite="epub/#dfn-epub-publication">EPUB publication</a> is ingested into a

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -661,22 +661,14 @@
 								<dt id="sec-page-src-obj">Objective</dt>
 								<dd>
 									<p>Identify the source of static page break locations.</p>
-								</dd>
 
-								<dt id="sec-page-src-understand">Understanding this Objective</dt>
-								<dd>
-									<p>Users need to know the source of the pagination in an <a
-											data-cite="epub-3#dfn-epub-publication">EPUB publication</a> to determine
-										whether it will be useful for their needs. Print publications, for example,
-										produced in both hard and soft cover editions will have different pagination.
-										Different editions of the same book often also have different pagination.</p>
-									<p>Including a recognizable identifier for the statically paginated source, such as
-										its ISBN or ISSN, ensures that users can determine which version the pagination
-										corresponds to.</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#page-source">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-page-src-conf">Meeting this Objective</dt>
-
 								<dd>
 									<p>When an EPUB publication includes <a href="#sec-page-breaks">page break
 											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
@@ -703,20 +695,11 @@
 								<dt id="sec-page-list-obj">Objective</dt>
 								<dd>
 									<p>Provide navigation to static page break locations.</p>
-								</dd>
 
-								<dt id="sec-page-list-understand">Understanding this Objective</dt>
-								<dd>
-									<p>The page list is the primary means of navigating to page break locations as it
-										provides a list of links to each of the static page break locations in the <a
-											data-cite="epub-3#dfn-epub-publication">EPUB publication</a>.</p>
-									<p><a data-cite="epub-3#dfn-epub-reading-system">Reading systems</a> typically use
-										this list to generate a "go to page" interface in which users can plug in the
-										page number that they wish to move to, but sometimes offer users the ability to
-										access the full list and select the page number to go to.</p>
-									<p>Without a page list, page navigation becomes extremely difficult as it would rely
-										on navigating the individual <a href="#sec-page-breaks">page break markers</a>
-										(if they are even present).</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#page-list">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-page-list-conf">Meeting this Objective</dt>
@@ -745,20 +728,11 @@
 								<dt id="sec-page-breaks-obj">Objective</dt>
 								<dd>
 									<p>Provide static page break locations.</p>
-								</dd>
 
-								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
-								<dd>
-									<p>Inserting page break markers into an <a data-cite="epub-3#dfn-epub-publication"
-											>EPUB publication</a> provides users with context about where they are in
-										the text. <a>Assistive technologies</a> can use this information to announce the
-										current page number the user is on, for example, if the user wants to cite
-										something on the page.</p>
-									<p>The inclusion of page break markers can also allow users to move quickly forwards
-										and backwards by page without having to access the page list each time.</p>
-									<p>The inclusion of these markers also simplifies the creation of a <a
-											href="#sec-page-list">page list</a>, as they provide easily referenced
-										destinations for the links.</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#page-breaks">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-page-break-conf">Meeting this Objective</dt>
@@ -845,19 +819,11 @@
 								<dt id="sec-mo-comlete-obj">Objective</dt>
 								<dd>
 									<p>Ensure that all text content is available in audio.</p>
-								</dd>
 
-								<dt id="sec-mo-complete-understand">Understanding this Objective</dt>
-								<dd>
-									<p>Although it is possible for users who require a publication in audio form to use
-										text-to-speech playback, the experience is considerably poorer than when
-										pre-recorded narration is provided. Text-to-speech engines have limited built-in
-										vocabularies, causing them to mangle and mispronounce most uncommon words they
-										encounter. As a result users have to have words repeated and spelled out to make
-										sense of the content, slowing down their reading and reducing comprehension.</p>
-									<p>For this reason, it is important to provide narration for the full text of a
-										publication in addition to the full text. Users can then decide which reading
-										modality they prefer &#8212; text, audio, or a mix of the two.</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#completeness">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
@@ -881,36 +847,11 @@
 								<dt id="sec-mo-order-obj">Objective</dt>
 								<dd>
 									<p>Ensure synchronized text-audio playback matches logical reading order.</p>
-								</dd>
 
-								<dt id="sec-mo-order-understand">Understanding this Objective</dt>
-								<dd>
-									<p>Every <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> has a
-										default reading order that allows users to progress through the content. The
-										default reading order consists of two parts: the order of references in the
-										spine provides a high-level progression through the <a
-											data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a> that
-										make up the publication, while the markup within each EPUB content document
-										provides the default progression through the content elements (i.e., as
-										represented in the document object model [[?dom]]).</p>
-									<p>For many languages, the default reading order also matches the logical reading
-										order &#8212; the way that users will naturally follow the narrative. It ensures
-										that readers can follow the primary narrative and that they encounter secondary
-										content where the author intended it to be read. The default reading order also
-										establishes some less obvious relations, like the progress within a table from
-										cell to cell and row to row.</p>
-									<p>If the sequence of the synchronized text-audio playback does not match this
-										progression, it can cause confusion for readers, whether they are only listening
-										to the audio or trying to also follow visually.</p>
-									<p>Ordering the playback to match the default reading order is the safest way to
-										ensure that users can follow the text. In some cases, however, strict adherence
-										to this practice can result in a suboptimal reading experience (e.g., playback
-										of a table by column instead of row might make more natural sense in some
-										cases). These publications have a logical reading order that cannot match the
-										default order of the elements of the host format.</p>
-									<p>The goal of this objective is not to forbid alternate presentations, but to
-										ensure that deviations are only made to better represent the logical reading
-										order of the content.</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#sync-reading-order">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-sync-order-conf">Meeting this Objective</dt>
@@ -940,24 +881,11 @@
 								<dt id="sec-sync-skippability-obj">Objective</dt>
 								<dd>
 									<p>Enable users to automatically skip over content.</p>
-								</dd>
 
-								<dt id="sec-sync-skippability-understand">Understanding this Objective</dt>
-								<dd>
-									<p>Being able to read the primary narrative of a work without interruption is
-										central to reading comprehension. <a data-cite="epub-3#dfn-epub-publication"
-											>EPUB publications</a> are typically structured to visually represent
-										secondary information such as page break markers and footnotes outside the main
-										narrative flow (e.g., by using different background colors or placement so
-										readers can filter this information visually out while reading).</p>
-									<p>Readers who prefer auditory playback, however, cannot skip this information with
-										the same ease in a linear audio-based reading experience. And, without
-										structural semantics, synchronized text-audio playback cannot offer skipping
-										content either.</p>
-									<p>When the synchronized text-audio playback instructions include structural
-										semantics, however, <a data-cite="epub-3#dfn-epub-reading-system">reading
-											systems</a> can create reading experiences that allow users to decide which
-										secondary content to skip by default.</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#skippability">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-sync-skippability-conf">Meeting this Objective</dt>
@@ -980,25 +908,11 @@
 								<dt id="sec-sync-escapability-obj">Objective</dt>
 								<dd>
 									<p>Enable users to automatically escape from structured content.</p>
-								</dd>
 
-								<dt id="sec-sync-escapability-understand">Understanding this Objective</dt>
-								<dd>
-									<p>When reading visually, users can quickly move through, and escape from, highly
-										structured content such as sidebars, lists, and figures. Visual readers can skim
-										lists and quickly return to the primary narrative once they locate the desired
-										information, for example. The same is true for reading figures and sidebars, as
-										they are visually offset from the primary narrative so easily jumped into and
-										out of.</p>
-									<p>The same ease of escaping from content is only possible if <a
-											data-cite="epub-3#dfn-epub-publication">EPUB publications</a> include
-										structural semantics in the synchronized text/audio format. Users might not be
-										able to escape from lists, sidebars, figures, and other highly structured
-										content, without the structural semantics of those elements being available.</p>
-									<p>When the synchronized text-audio playback instructions include this information,
-											<a data-cite="epub-3#dfn-epub-reading-system">reading systems</a> can
-										simplify playback for auditory readers to enable a comparable reading
-										experience.</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#escapability">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-sync-escapability-conf">Meeting this Objective</dt>
@@ -1024,18 +938,11 @@
 											data-cite="epub-3#dfn-epub-navigation-document">EPUB navigation document</a>
 										when presented by <a data-cite="epub-3#dfn-epub-reading-system">reading
 											systems</a>.</p>
-								</dd>
 
-								<dt id="sec-sync-navdoc-understand">Understanding this Objective</dt>
-								<dd>
-									<p>Reading systems typically provide their own interfaces to the navigation aids in
-										the EPUB navigation document. For example, they open the table of contents as a
-										specialized interface on top of the content the user is reading.</p>
-									<p>To access these interfaces, users typically rely on text-to-speech playback, when
-										available, to hear the entries.</p>
-									<p>Providing synchronized text-audio playback for the EPUB navigation document
-										provides reading systems the ability to use auditory labels for the links,
-										improving the experience for auditory readers.</p>
+									<!-- <p class="understand">
+										<a data-cite="epub-a11y-understand#nav-doc">Understanding this
+											objective</a> [[epub-a11y-understand]]
+									</p> -->
 								</dd>
 
 								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -80,6 +80,11 @@
 						"date": "05 January 2017",
 						"publisher": "IDPF"
 					},
+					"epub-a11y-understand": {
+						"title": "Understanding EPUB Accessibility 1.2",
+						"href": "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
+						"publisher": "W3C"
+					},
 					"epub-3": {
 						"title": "EPUB 3",
 						"href": "https://www.w3.org/TR/epub/",
@@ -132,6 +137,25 @@
 			}
 			#change-log > details > p {
 				margin-left: 1rem;
+			}
+			#sec-epub-req dt {
+				margin-bottom: 1rem;
+			}
+			#sec-epub-req dd {
+				margin-bottom: 2rem;
+			}
+			div.info {
+				float: right;
+				text-align: end;
+				font-size: 90%;
+				background-color: rgb(245, 245, 245);
+				border-left: 0.4rem solid rgb(60, 120, 240);
+				padding: 0.5rem 1rem;
+				margin-top: -3.5rem;
+			}
+			div.info a {
+				display: block;
+				margin-bottom: 0.5rem;
 			}</style>
 	</head>
 	<body>
@@ -184,39 +208,61 @@
 				</div>
 			</section>
 
-			<section id="sec-success-techniques" class="informative">
-				<h3>Success techniques</h3>
+			<section id="sec-supporting-docs" class="informative">
+				<h3>Supporting documents</h3>
 
-				<p>This specification takes an abstract approach to the accessibility requirements for <a
-						data-cite="epub-3#dfn-epub-publication">EPUB publications</a>, similar to how WCAG [[wcag2]]
-					separates its accessibility guidelines from the techniques to achieve them. This approach allows the
-					guidelines to remain stable even as the format evolves.</p>
+				<p>The following supporting documents provide informative guidance that helps with understanding and
+					implementing this standard:</p>
 
-				<p>To facilitate this approach, the companion <a data-cite="epub-a11y-tech-12#">EPUB Accessibility
-						Techniques</a> [[epub-a11y-tech-12]] document outlines conformance techniques. These techniques
-					explain how to meet the requirements of this specification for different versions of EPUB.</p>
+				<dl>
+					<dt>Understanding EPUB Accessibility</dt>
+					<dd>
+						<p>This document assumes a high level of familiarity with both EPUB 3 [[epub-3]] and WCAG 2
+							[[wcag2]]. It expects that implementers of the standard understand how to apply WCAG 2,
+							which focuses on web content, to an <a data-cite="epub-3#dfn-epub-publication">EPUB
+								publication</a>, which is more like a packaged web site that reads as a single
+							document.</p>
 
-				<section id="sec-sc-i18n">
-					<h4>Internationalization</h4>
+						<p>The [[[epub-a11y-understand]]] [[epub-a11y-understand]] document goes into more detail about
+							how to understand success criteria in the context of an EPUB publication &#8212; when they
+							apply, or not, what to look for in publications, etc. It also explains the additional <a
+								href="#sec-epub-req">EPUB objectives</a> introduced in this document.</p>
+					</dd>
 
-					<p>This specification is also designed to address the accessibility needs of users independent of
-						what languages they read. The same is true for the principles and success criteria defined in
-						[[wcag2]]. The goal is to ensure that users can fully consume the information of a publication
-						regardless of their preferred reading modality.</p>
+					<dt>EPUB Accessibility Techniques</dt>
+					<dd>
+						<p>This specification takes an abstract approach to the accessibility requirements for EPUB
+							publications, similar to how WCAG [[wcag2]] separates its accessibility guidelines from the
+							techniques to achieve them. This approach allows the guidelines to remain stable even as the
+							format evolves.</p>
 
-					<p>At the same time, the language and writing conventions of the authored text will influence the
-						techniques necessary to meet the accessibility requirements. EPUB <a
-							href="https://www.w3.org/TR/epub/#confreq-xml-enc">requires support for Unicode text</a>
-						[[epub-3]], for example, which ensures the correct character data can be used (i.e., avoiding
-						the need to use images of text). Although this is an important feature, it is often not enough
-						on its own to ensure that the text is fully accessible in any given language (e.g., additional
-						information about directionality, emphasis, pronunciation, etc. might also be needed).</p>
+						<p>To facilitate this approach, the companion [[[epub-a11y-tech-12]]] [[epub-a11y-tech-12]]
+							document outlines conformance techniques. These techniques explain how to meet the
+							requirements of this specification for different versions of EPUB.</p>
+					</dd>
+				</dl>
+			</section>
 
-					<p>Consequently, there can also be language- or culture-specific practices for meeting accessibility
-						requirements. Whether these practices are defined within this specification and its techniques
-						or elsewhere (e.g., in WCAG techniques or language-specific best practice recommendations) will
-						depend on whether the issues are specific to EPUB or broadly affect all web content.</p>
-				</section>
+			<section id="sec-sc-i18n" class="informative">
+				<h3>Internationalization</h3>
+
+				<p>This specification is designed to address the accessibility needs of users independent of what
+					languages they read. The same is true for the principles and success criteria defined in [[wcag2]].
+					The goal is to ensure that users can fully consume the information of a publication regardless of
+					their preferred reading modality.</p>
+
+				<p>At the same time, the language and writing conventions of the authored text will influence the
+					techniques necessary to meet the accessibility requirements. EPUB <a
+						href="https://www.w3.org/TR/epub/#confreq-xml-enc">requires support for Unicode text</a>
+					[[epub-3]], for example, which ensures the correct character data can be used (i.e., avoiding the
+					need to use images of text). Although this is an important feature, it is often not enough on its
+					own to ensure that the text is fully accessible in any given language (e.g., additional information
+					about directionality, emphasis, pronunciation, etc. might also be needed).</p>
+
+				<p>Consequently, there can also be language- or culture-specific practices for meeting accessibility
+					requirements. Whether these practices are defined within this specification and its techniques or
+					elsewhere (e.g., in WCAG techniques or language-specific best practice recommendations) will depend
+					on whether the issues are specific to EPUB or broadly affect all web content.</p>
 			</section>
 
 			<section id="sec-application" class="informative">
@@ -654,88 +700,79 @@
 					<section id="sec-page-nav-obj">
 						<h5>Objectives</h5>
 
-						<section id="sec-page-src">
+						<section id="page-source">
 							<h6>Pagination source</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#page-source">Understanding pagination source</a>
+								<a data-cite="epub-a11y-tech-12#page-source">Techniques for pagination source</a>
+							</div>
+
 							<dl>
-								<dt id="sec-page-src-obj">Objective</dt>
+								<dt id="page-source-obj">Objective</dt>
 								<dd>
 									<p>Identify the source of static page break locations.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#page-source">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-page-src-conf">Meeting this Objective</dt>
+								<dt id="page-source-conf">Meeting this Objective</dt>
 								<dd>
-									<p>When an EPUB publication includes <a href="#sec-page-breaks">page break
-											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
-										to a statically-paginated version of the publication, the publication MUST
-										identify that source in the <a data-cite="epub-3#dfn-package-document">package
+									<p>When an EPUB publication includes <a href="#page-breaks">page break markers</a>
+										and/or a <a href="#page-list">page list</a> that correspond to a
+										statically-paginated version of the publication, the publication MUST identify
+										that source in the <a data-cite="epub-3#dfn-package-document">package
 											document</a> metadata.</p>
 									<p>If, however, these features are added to a digital-only <a
 											data-cite="epub-3#dfn-epub-publication">EPUB publication</a>, the
 										publication MUST NOT specify a source (i.e., do not identify the current
 										publication as the source of its own pagination).</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#pageSource">Identifying the
-												pagination source</a> [[epub-a11y-tech-12]] for more information on
-											meeting this objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-page-list">
+						<section id="page-list">
 							<h6>Page list</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#page-list">Understanding page list</a>
+								<a data-cite="epub-a11y-tech-12#page-list">Techniques for page list</a>
+							</div>
+
 							<dl>
-								<dt id="sec-page-list-obj">Objective</dt>
+								<dt id="page-list-obj">Objective</dt>
 								<dd>
 									<p>Provide navigation to static page break locations.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#page-list">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-page-list-conf">Meeting this Objective</dt>
+								<dt id="page-list-conf">Meeting this Objective</dt>
 								<dd>
 									<p>An EPUB publication MUST include a page list.</p>
 									<p>The page list SHOULD include links to all pages of content reproduced from the
 										source (i.e., it does not have to include links for blank pages or content not
 										reproduced in the digital edition).</p>
-									<p>The page list MUST include links to all the <a href="#sec-page-breaks-obj">page
-											break markers</a> in the content.</p>
+									<p>The page list MUST include links to all the <a href="#page-breaks-obj">page break
+											markers</a> in the content.</p>
 									<p>It is encouraged to include links to all pages in the source in the page list,
 										whether they are reproduced or not, but this is not a conformance
 										requirement.</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#pageList">Provide a page list</a>
-											[[epub-a11y-tech-12]] for more information on meeting this objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-page-breaks">
+						<section id="page-breaks">
 							<h6>Page breaks</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#page-breaks">Understanding page breaks</a>
+								<a data-cite="epub-a11y-tech-12#page-breaks">Techniques for page breaks</a>
+							</div>
+
 							<dl>
-								<dt id="sec-page-breaks-obj">Objective</dt>
+								<dt id="page-breaks-obj">Objective</dt>
 								<dd>
 									<p>Provide static page break locations.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#page-breaks">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-page-break-conf">Meeting this Objective</dt>
+								<dt id="page-break-conf">Meeting this Objective</dt>
 								<dd>
 									<p>Inclusion of page break markers in an EPUB publication is OPTIONAL.</p>
 									<p>If an EPUB publication includes page break markers, the page break markers SHOULD
@@ -748,11 +785,6 @@
 										MUST be identified in the playback instructions (e.g., using the <a
 											data-cite="?epub-3/#sec-epub-type-attribute"><code>epub:type</code>
 											attribute</a> [[?epub-3]] in media overlays SMIL files).</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#pageBreakMarkers">Provide page break
-												markers</a> [[epub-a11y-tech-12]] for more information on meeting this
-											objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>
@@ -812,49 +844,44 @@
 					<section id="sec-sync-obj">
 						<h5>Objectives</h5>
 
-						<section id="sec-sync-complete">
+						<section id="sync-completeness">
 							<h6>Completeness</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#sync-completeness">Understanding completeness</a>
+								<a data-cite="epub-a11y-tech-12#sync-completeness">Techniques for completeness</a>
+							</div>
+
 							<dl>
-								<dt id="sec-mo-comlete-obj">Objective</dt>
+								<dt id="sync-completeness-obj">Objective</dt>
 								<dd>
 									<p>Ensure that all text content is available in audio.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#completeness">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
+								<dt id="sync-completeness-conf">Meeting this Objective</dt>
 								<dd>
 									<p><a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> MUST include
 										synchronized audio playback for all visible textual content as well as all
 										textual alternatives for visual media.</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-coverage">Ensuring complete
-												text coverage</a> [[epub-a11y-tech-12]] for more information on meeting
-											this objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-sync-order">
+						<section id="sync-reading-order">
 							<h6>Reading order</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#sync-reading-order">Understanding reading order</a>
+								<a data-cite="epub-a11y-tech-12#sync-reading-order">Techniques for reading order</a>
+							</div>
+
 							<dl>
-								<dt id="sec-mo-order-obj">Objective</dt>
+								<dt id="sync-reading-order-obj">Objective</dt>
 								<dd>
 									<p>Ensure synchronized text-audio playback matches logical reading order.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#sync-reading-order">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-sync-order-conf">Meeting this Objective</dt>
+								<dt id="sync-reading-order-conf">Meeting this Objective</dt>
 								<dd>
 									<p>The order of the synchronized text-audio playback instructions SHOULD reflect
 										both:</p>
@@ -865,97 +892,77 @@
 									</ul>
 									<p>If an EPUB publication uses a different ordering, that ordering MUST still result
 										in a logical playback of the content.</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-reading-order">Specifying the
-												reading order</a> [[epub-a11y-tech-12]] for more information on meeting
-											this objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-sync-skippability">
+						<section id="sync-skippability">
 							<h6>Skippability</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#sync-skippability">Understanding skippability</a>
+								<a data-cite="epub-a11y-tech-12#sync-skippability">Techniques for skippability</a>
+							</div>
+
 							<dl>
-								<dt id="sec-sync-skippability-obj">Objective</dt>
+								<dt id="sync-skippability-obj">Objective</dt>
 								<dd>
 									<p>Enable users to automatically skip over content.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#skippability">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-sync-skippability-conf">Meeting this Objective</dt>
+								<dt id="sync-skippability-conf">Meeting this Objective</dt>
 								<dd>
 									<p>Synchronized text-audio playback instructions SHOULD identify all skippable
 										structures.</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-skippability">Identifying
-												skippable structures</a> [[epub-a11y-tech-12]] for more information on
-											meeting this objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-sync-escapability">
+						<section id="sync-escapability">
 							<h6>Escapability</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#sync-escapability">Understanding escapability</a>
+								<a data-cite="epub-a11y-tech-12#sync-escapability">Techniques for escapability</a>
+							</div>
+
 							<dl>
-								<dt id="sec-sync-escapability-obj">Objective</dt>
+								<dt id="sync-escapability-obj">Objective</dt>
 								<dd>
 									<p>Enable users to automatically escape from structured content.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#escapability">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-sync-escapability-conf">Meeting this Objective</dt>
+								<dt id="sync-escapability-conf">Meeting this Objective</dt>
 								<dd>
 									<p>Synchronized text-audio playback instructions SHOULD identify all escapable
 										structures.</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-escapability">Identifying
-												escapable structures</a> [[epub-a11y-tech-12]] for more information on
-											meeting this objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-sync-navdoc">
+						<section id="sync-nav-doc">
 							<h6>Navigation document</h6>
 
+							<div class="info">
+								<a data-cite="epub-a11y-understand#sync-nav-doc">Understanding navigation document</a>
+								<a data-cite="epub-a11y-tech-12#sync-nav-doc">Techniques for navigation document</a>
+							</div>
+
 							<dl>
-								<dt id="sec-sync-navdoc-obj">Objective</dt>
+								<dt id="sync-nav-doc-obj">Objective</dt>
 								<dd>
 									<p>Ensure auditory playback is possible for the navigation aids in the <a
 											data-cite="epub-3#dfn-epub-navigation-document">EPUB navigation document</a>
 										when presented by <a data-cite="epub-3#dfn-epub-reading-system">reading
 											systems</a>.</p>
-
-									<!-- <p class="understand">
-										<a data-cite="epub-a11y-understand#nav-doc">Understanding this
-											objective</a> [[epub-a11y-understand]]
-									</p> -->
 								</dd>
 
-								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>
+								<dt id="sync-nav-doc-conf">Meeting this Objective</dt>
 								<dd>
 									<p><a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> SHOULD include
 										synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
 											document</a> [[epub-3]].</p>
-									<div class="note">
-										<p>Refer to <a data-cite="epub-a11y-tech-12#sync-nav">Synchronizing the
-												navigation document</a> [[epub-a11y-tech-12]] for more information on
-											meeting this objective.</p>
-									</div>
 								</dd>
 							</dl>
 						</section>

--- a/wg-notes/epub-aria-authoring/index.html
+++ b/wg-notes/epub-aria-authoring/index.html
@@ -72,27 +72,38 @@
 					attribute</a> [[wai-aria]] to ensure that they are properly applied for their intended purposes and
 				audiences.</p>
 
-			<p>The biggest of these differences is in their primary applications. The <code>epub:type</code> attribute
-				has evolved to aid publisher workflows. It has limited use enabling reading system behaviors outside of
-				some core functionality of EPUB (identifying navigation elements and enhancing media overlay documents).
-				Although it was hoped the attribute would also expose information to assistive technologies, in practice
-				it does not.</p>
+			<p>The key difference is that the <code>role</code> attribute bridges accessibility in content while the
+					<code>type</code> attribute provides hooks to enable <a data-cite="epub/#dfn-epub-reading-system"
+					>reading system</a> behaviors. Omitting roles lessens the accessibility for users of <a
+					data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>, in other words, while
+				omitting types diminishes certain functionality in <a data-cite="epub/#dfn-epub-reading-system">reading
+					systems</a> (e.g., pop-up footnotes or special presentations of the content).</p>
 
-			<p>The primary purpose of the <code>role</code> attribute, on the other hand, is to expose information to
-				assistive technologies. It is not to facilitate user agent behaviors.</p>
+			<p>The result is that the application of <code>epub:type</code> semantics is largely harmless, but
+				misapplication of ARIA roles can have negative impacts on the reading experience, from over-announcement
+				of information to broken rendering for assistive technology users.</p>
 
-			<p>The result of these differences is that the application of <code>epub:type</code> semantics is largely
-				harmless, but misapplication of ARIA roles can have negative impacts on the reading experience, from
-				over-announcement of information to broken rendering for assistive technology users.</p>
+			<p>It is sometimes helpful to pair the attributes together, but this is only useful when both attributes
+				provide benefits for their respective use cases. For example, it is common to pair footnote roles and
+				types to ensure reading systems can provide pop-up functionality and assistive technologies can announce
+				the type of link the user has encountered.</p>
 
 			<p>This guide addresses key authoring differences to be aware of when migrating to ARIA roles from the
 					<code>epub:type</code> attribute, or when using both attributes together. The goal is to help
 				publishers avoid the pitfalls of applying ARIA roles like they would <code>epub:type</code> semantics
 				and breaking the reading experience for users of assistive technologies.</p>
 
-			<p class="note">This guide is not intended as a comprehensive overview of ARIA roles. For more information
-				about ARIA and how to apply it to HTML document, refer to [[wai-aria]] and [[html-aria]],
-				respectively.</p>
+			<div class="note">
+				<p>This guide is not intended as a comprehensive overview of ARIA roles. For more information about ARIA
+					and how to apply it to HTML document, refer to [[wai-aria]] and [[html-aria]], respectively.</p>
+
+				<p>It also only applies to <a data-cite="epub-3/#dfn-epub-content-document">EPUB content documents</a>.
+					The <code>epub:type</code> attribute is the only means of adding structural information to <a
+						data-cite="epub-3/#dfn-media-overlay-document">media overlay documents</a> so that features like
+					lists and tables can be navigated more efficiently. It is also required in the <a
+						data-cite="epub-3/#dfn-epub-navigation-document">EPUB navigation document</a> to identify key
+					structures.</p>
+			</div>
 		</section>
 		<section id="sec-mappings">
 			<h2>Mapping types to roles</h2>
@@ -125,77 +136,127 @@
 				</thead>
 				<tbody>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#abstract">abstract</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#abstract">abstract</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-abstract">doc-abstract</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-abstract">doc-abstract</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#acknowledgments">acknowledgments</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#acknowledgments">acknowledgments</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-acknowledgments">doc-acknowledgments</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-acknowledgments">doc-acknowledgments</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#afterword">afterword</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#afterword">afterword</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-afterword">doc-afterword</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-afterword">doc-afterword</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#answer">answer</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#answer">answer</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#answers">answers</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#appendix">appendix</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-appendix">doc-appendix</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#assessment">assessment</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#assessments">assessments</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#backmatter">backmatter</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#answers">answers</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#balloon">balloon</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#biblioentry">biblioentry</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#appendix">appendix</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-appendix">doc-appendix</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#assessment">assessment</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#assessments">assessments</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#backmatter">backmatter</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#balloon">balloon</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#biblioentry">biblioentry</a>
+						</td>
 						<td></td>
 						<td>doc-biblioentry <br />
 							<strong>Deprecated</strong>
@@ -204,133 +265,227 @@
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#bibliography">bibliography</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#bibliography">bibliography</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-bibliography">doc-bibliography</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-bibliography">doc-bibliography</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#biblioref">biblioref</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#biblioref">biblioref</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-biblioref">doc-biblioref</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-biblioref">doc-biblioref</a>
+						</td>
 						<td></td>
-						<td><code>a</code></td>
+						<td>
+							<code>a</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#bodymatter">bodymatter</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#bodymatter">bodymatter</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#bridgehead">bridgehead</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#case-study">case-study</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#chapter">chapter</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-chapter">doc-chapter</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#colophon">colophon</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-colophon">doc-colophon</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#concluding-sentence">concluding-sentence</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#conclusion">conclusion</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#bridgehead">bridgehead</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-conclusion">doc-conclusion</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#contributors">contributors</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#copyright-page">copyright-page</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#case-study">case-study</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#cover">cover</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><em hidden="hidden">cover</em></td>
-						<td><a href="https://www.w3.org/TR/epub/#cover-image">cover-image</a></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-cover">doc-cover</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#chapter">chapter</a>
+						</td>
 						<td></td>
-						<td><code>img</code></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-chapter">doc-chapter</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#covertitle">covertitle</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#colophon">colophon</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-colophon">doc-colophon</a>
+						</td>
 						<td></td>
-						<td></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#credit">credit</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#concluding-sentence">concluding-sentence</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-credit">doc-credit</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#credits">credits</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-credits">doc-credits</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#dedication">dedication</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-dedication">doc-dedication</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#division">division</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#endnote">endnote</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#conclusion">conclusion</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-conclusion">doc-conclusion</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#contributors">contributors</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#copyright-page">copyright-page</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#cover">cover</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<em hidden="hidden">cover</em>
+						</td>
+						<td>
+							<a href="https://www.w3.org/TR/epub/#cover-image">cover-image</a>
+						</td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-cover">doc-cover</a>
+						</td>
+						<td></td>
+						<td>
+							<code>img</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#covertitle">covertitle</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#credit">credit</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-credit">doc-credit</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#credits">credits</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-credits">doc-credits</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#dedication">dedication</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-dedication">doc-dedication</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#division">division</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#endnote">endnote</a>
+						</td>
 						<td></td>
 						<td>doc-endnote <br />
 							<strong>Deprecated</strong>
@@ -339,656 +494,1059 @@
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#endnotes">endnotes</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#endnotes">endnotes</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-endnotes">doc-endnotes</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-endnotes">doc-endnotes</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#epigraph">epigraph</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#epigraph">epigraph</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-epigraph">doc-epigraph</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-epigraph">doc-epigraph</a>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#epilogue">epilogue</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#epilogue">epilogue</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-epilogue">doc-epilogue</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-epilogue">doc-epilogue</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#errata">errata</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#errata">errata</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-errata">doc-errata</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-errata">doc-errata</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><em>No Equivalent</em></td>
+						<td>
+							<em>No Equivalent</em>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-example">doc-example</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-example">doc-example</a>
+						</td>
 						<td></td>
 						<td><code>aside</code>, <code>section</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#feedback">feedback</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#feedback">feedback</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#figure">figure</a></td>
-						<td></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#figure">figure</a></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#fill-in-the-blank-problem"
-								>fill-in-the-blank-problem</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#footnote">footnote</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#figure">figure</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-footnote">doc-footnote</a></td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#figure">figure</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#fill-in-the-blank-problem"
+								>fill-in-the-blank-problem</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#footnote">footnote</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-footnote">doc-footnote</a>
+						</td>
 						<td></td>
 						<td><code>aside</code>, <code>footer</code>, <code>header</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#footnotes">footnotes</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#footnotes">footnotes</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#foreword">foreword</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-foreword">doc-foreword</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#frontmatter">frontmatter</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#fulltitle">fulltitle</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#foreword">foreword</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-foreword">doc-foreword</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#frontmatter">frontmatter</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#general-problem">general-problem</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#fulltitle">fulltitle</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#glossary">glossary</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-glossary">doc-glossary</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#glossterm">glossterm</a></td>
-						<td></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#term">term</a></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#glossdef">glossdef</a></td>
-						<td></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#definition">definition</a></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#glossref">glossref</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-glossref">doc-glossref</a></td>
-						<td></td>
-						<td><code>a</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#halftitle">halftitle</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#halftitlepage">halftitlepage</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#general-problem">general-problem</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#imprint">imprint</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#imprimatur">imprimatur</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#glossary">glossary</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-glossary">doc-glossary</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#glossterm">glossterm</a>
+						</td>
+						<td></td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#term">term</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#glossdef">glossdef</a>
+						</td>
+						<td></td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#definition">definition</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#glossref">glossref</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-glossref">doc-glossref</a>
+						</td>
+						<td></td>
+						<td>
+							<code>a</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#halftitle">halftitle</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index">index</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#halftitlepage">halftitlepage</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-index">doc-index</a></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#imprint">imprint</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#imprimatur">imprimatur</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index">index</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-index">doc-index</a>
+						</td>
 						<td></td>
 						<td><code>nav</code>, <code>section</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-headnotes">index-headnotes</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-headnotes">index-headnotes</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-legend">index-legend</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-group">index-group</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-legend">index-legend</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-entry-list">index-entry-list</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-entry">index-entry</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-group">index-group</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-term">index-term</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-editor-note">index-editor-note</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-entry-list">index-entry-list</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-locator">index-locator</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-locator-list">index-locator-list</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-entry">index-entry</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-locator-range">index-locator-range</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-xref-preferred">index-xref-preferred</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-term">index-term</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-xref-related">index-xref-related</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-term-category">index-term-category</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-editor-note">index-editor-note</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#index-term-categories"
-							>index-term-categories</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#introduction">introduction</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-locator">index-locator</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-introduction">doc-introduction</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#keyword">keyword</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#keywords">keywords</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-locator-list">index-locator-list</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#label">label</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#landmarks">landmarks</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-locator-range">index-locator-range</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#directory">directory</a></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-xref-preferred">index-xref-preferred</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-xref-related">index-xref-related</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-term-category">index-term-category</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#index-term-categories">index-term-categories</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#introduction">introduction</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-introduction">doc-introduction</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#keyword">keyword</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#keywords">keywords</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#label">label</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#landmarks">landmarks</a>
+						</td>
+						<td></td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#directory">directory</a>
+						</td>
 						<td><code>ol</code>, <code>ul</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-objective">learning-objective</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-objective">learning-objective</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-objectives">learning-objectives</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-outcome">learning-outcome</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-objectives">learning-objectives</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-outcomes">learning-outcomes</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-resource">learning-resource</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-outcome">learning-outcome</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-resources">learning-resources</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-standard">learning-standard</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-outcomes">learning-outcomes</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#learning-standards">learning-standards</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#list">list</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-resource">learning-resource</a>
+						</td>
 						<td></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#list">list</a></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#list-item">list-item</a></td>
-						<td></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#listitem">listitem</a></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#loa">loa</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#loi">loi</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-resources">learning-resources</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#lot">lot</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#lov">lov</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-standard">learning-standard</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#match-problem">match-problem</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#multiple-choice-problem"
-								>multiple-choice-problem</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#learning-standards">learning-standards</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#noteref">noteref</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-noteref">doc-noteref</a></td>
-						<td></td>
-						<td><code>a</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#notice">notice</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-notice">doc-notice</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#ordinal">ordinal</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#other-credits">other-credits</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#list">list</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#list">list</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#list-item">list-item</a>
+						</td>
+						<td></td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#listitem">listitem</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#loa">loa</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#panel">panel</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#loi">loi</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#panel-group">panel-group</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#pagebreak">pagebreak</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#lot">lot</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-pagebreak">doc-pagebreak</a></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
-						<td><code>hr</code></td>
+						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#page-list">page-list</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#lov">lov</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-pagelist">doc-pagelist</a></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#match-problem">match-problem</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#multiple-choice-problem"
+								>multiple-choice-problem</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#noteref">noteref</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-noteref">doc-noteref</a>
+						</td>
+						<td></td>
+						<td>
+							<code>a</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#notice">notice</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-notice">doc-notice</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#ordinal">ordinal</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#other-credits">other-credits</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#panel">panel</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#panel-group">panel-group</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#pagebreak">pagebreak</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-pagebreak">doc-pagebreak</a>
+						</td>
+						<td></td>
+						<td>
+							<code>hr</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#page-list">page-list</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-pagelist">doc-pagelist</a>
+						</td>
 						<td></td>
 						<td><code>nav</code>, <code>section</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#part">part</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#part">part</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-part">doc-part</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-part">doc-part</a>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td>
+							<code>section</code>
+						</td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#practice">practice</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#practice">practice</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#practices">practices</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#preamble">preamble</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#preface">preface</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#practices">practices</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-preface">doc-preface</a></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#prologue">prologue</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#preamble">preamble</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-prologue">doc-prologue</a></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
-						<td><code>section</code></td>
+						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#pullquote">pullquote</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#preface">preface</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-pullquote">doc-pullquote</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-preface">doc-preface</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#prologue">prologue</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-prologue">doc-prologue</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#pullquote">pullquote</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-pullquote">doc-pullquote</a>
+						</td>
 						<td></td>
 						<td><code>aside</code>, <code>section</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#question">question</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#question">question</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#qna">qna</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-qna">doc-qna</a></td>
-						<td></td>
-						<td><code>section</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#backlink">backlink</a></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-backlink">doc-backlink</a></td>
-						<td></td>
-						<td><code>a</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#revision-history">revision-history</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#seriespage">seriespage</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#qna">qna</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-qna">doc-qna</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#backlink">backlink</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-backlink">doc-backlink</a>
+						</td>
+						<td></td>
+						<td>
+							<code>a</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#revision-history">revision-history</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#sound-area">sound-area</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#seriespage">seriespage</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#subchapter">subchapter</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#subtitle">subtitle</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#sound-area">sound-area</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-subtitle">doc-subtitle</a></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#subchapter">subchapter</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#subtitle">subtitle</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-subtitle">doc-subtitle</a>
+						</td>
 						<td></td>
 						<td><code>h1</code>-<code>h6</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#table">table</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#table">table</a>
+						</td>
 						<td></td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#table">table</a></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#table-row">table-row</a></td>
-						<td></td>
-						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#row">row</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#table">table</a>
+						</td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#table-cell">table-cell</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#table-row">table-row</a>
+						</td>
 						<td></td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/wai-aria/#cell">cell</a></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#text-area">text-area</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#row">row</a>
+						</td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#tip">tip</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#table-cell">table-cell</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-tip">doc-tip</a></td>
 						<td></td>
-						<td><code>aside</code></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#title">title</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/wai-aria/#cell">cell</a>
+						</td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#titlepage">titlepage</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#text-area">text-area</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#toc">toc</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#tip">tip</a>
+						</td>
 						<td></td>
-						<td><a href="https://www.w3.org/TR/dpub-aria/#doc-toc">doc-toc</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-tip">doc-tip</a>
+						</td>
+						<td></td>
+						<td>
+							<code>aside</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#title">title</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#titlepage">titlepage</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#toc">toc</a>
+						</td>
+						<td></td>
+						<td>
+							<a href="https://www.w3.org/TR/dpub-aria/#doc-toc">doc-toc</a>
+						</td>
 						<td></td>
 						<td><code>nav</code>, <code>section</code></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#toc-brief">toc-brief</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#toc-brief">toc-brief</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#topic-sentence">topic-sentence</a></td>
-						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#true-false-problem">true-false-problem</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#topic-sentence">topic-sentence</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
 					<tr>
-						<td><a href="https://www.w3.org/TR/epub-ssv/#volume">volume</a></td>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#true-false-problem">true-false-problem</a>
+						</td>
 						<td></td>
-						<td><em>No Role</em></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a href="https://www.w3.org/TR/epub-ssv/#volume">volume</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
 						<td></td>
 						<td></td>
 					</tr>
@@ -1000,50 +1558,132 @@
 					any role value.</p>
 				<ul class="col">
 					<li><code>a</code> (without an <code>href</code> attribute)</li>
-					<li><code>abbr</code></li>
-					<li><code>address</code></li>
-					<li><code>b</code></li>
-					<li><code>bdi</code></li>
-					<li><code>bdo</code></li>
-					<li><code>blockquote</code></li>
-					<li><code>canvas</code></li>
-					<li><code>cite</code></li>
-					<li><code>code</code></li>
-					<li><code>data</code></li>
-					<li><code>del</code></li>
-					<li><code>dfn</code></li>
-					<li><code>div</code></li>
-					<li><code>em</code></li>
+					<li>
+						<code>abbr</code>
+					</li>
+					<li>
+						<code>address</code>
+					</li>
+					<li>
+						<code>b</code>
+					</li>
+					<li>
+						<code>bdi</code>
+					</li>
+					<li>
+						<code>bdo</code>
+					</li>
+					<li>
+						<code>blockquote</code>
+					</li>
+					<li>
+						<code>canvas</code>
+					</li>
+					<li>
+						<code>cite</code>
+					</li>
+					<li>
+						<code>code</code>
+					</li>
+					<li>
+						<code>data</code>
+					</li>
+					<li>
+						<code>del</code>
+					</li>
+					<li>
+						<code>dfn</code>
+					</li>
+					<li>
+						<code>div</code>
+					</li>
+					<li>
+						<code>em</code>
+					</li>
 					<li><code>figure</code> (without a <code>figcaption</code>)</li>
-					<li><code>hgroup</code></li>
-					<li><code>i</code></li>
-					<li><code>ins</code></li>
-					<li><code>kbd</code></li>
-					<li><code>mark</code></li>
-					<li><code>output</code></li>
-					<li><code>p</code></li>
-					<li><code>pre</code></li>
-					<li><code>q</code></li>
-					<li><code>rp</code></li>
-					<li><code>rt</code></li>
-					<li><code>ruby</code></li>
-					<li><code>s</code></li>
-					<li><code>samp</code></li>
-					<li><code>small</code></li>
-					<li><code>span</code></li>
-					<li><code>strong</code></li>
-					<li><code>sub</code></li>
-					<li><code>sup</code></li>
-					<li><code>svg</code></li>
-					<li><code>table</code></li>
-					<li><code>tbody</code></li>
-					<li><code>tfoot</code></li>
-					<li><code>thead</code></li>
+					<li>
+						<code>hgroup</code>
+					</li>
+					<li>
+						<code>i</code>
+					</li>
+					<li>
+						<code>ins</code>
+					</li>
+					<li>
+						<code>kbd</code>
+					</li>
+					<li>
+						<code>mark</code>
+					</li>
+					<li>
+						<code>output</code>
+					</li>
+					<li>
+						<code>p</code>
+					</li>
+					<li>
+						<code>pre</code>
+					</li>
+					<li>
+						<code>q</code>
+					</li>
+					<li>
+						<code>rp</code>
+					</li>
+					<li>
+						<code>rt</code>
+					</li>
+					<li>
+						<code>ruby</code>
+					</li>
+					<li>
+						<code>s</code>
+					</li>
+					<li>
+						<code>samp</code>
+					</li>
+					<li>
+						<code>small</code>
+					</li>
+					<li>
+						<code>span</code>
+					</li>
+					<li>
+						<code>strong</code>
+					</li>
+					<li>
+						<code>sub</code>
+					</li>
+					<li>
+						<code>sup</code>
+					</li>
+					<li>
+						<code>svg</code>
+					</li>
+					<li>
+						<code>table</code>
+					</li>
+					<li>
+						<code>tbody</code>
+					</li>
+					<li>
+						<code>tfoot</code>
+					</li>
+					<li>
+						<code>thead</code>
+					</li>
 					<li><code>th</code>, <code>td</code>, <code>tr</code> (if table is not exposed as
 						<code>table</code>, <code>grid</code>, or <code>treegrid</code>)</li>
-					<li><code>time</code></li>
-					<li><code>u</code></li>
-					<li><code>var</code></li>
+					<li>
+						<code>time</code>
+					</li>
+					<li>
+						<code>u</code>
+					</li>
+					<li>
+						<code>var</code>
+					</li>
 				</ul>
 			</aside>
 
@@ -1088,10 +1728,95 @@
 
 				<p>Do not reapply a semantic just because your content has been chunked into separate files.</p>
 
-				<p>For example, ensure that the <a href="https://www.w3.org/TR/dpub-aria/#doc-part"
-							><code>doc-part</code> role</a> [[dpub-aria]] is only applied to the section that contains
-					the heading for the part. Do not reapply the part role for each chapter that belongs to the part, as
-					it will be announced to users of assistive technologies each time it occurs, causing confusion.</p>
+				<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> appear as single contiguous
+					documents to users when read, they are typically composed of many individual <a
+						data-cite="epub/#dfn-epub-content-document">EPUB content documents</a>. This practice keeps the
+					amount of markup that has to be rendered small to reduce the load time in <a
+						data-cite="epub/#dfn-epub-reading-system">reading systems</a> (i.e., to minimize the time the
+					user has to wait for a document to appear). It is rare, at least for books, for an EPUB publication
+					to contain only one EPUB content document with all the content in it.</p>
+
+				<p>When content is chunked in this way, it often requires restructuring the information to fit within
+					the new file structure. A part, for example, will typically not include all the chapters that belong
+					to it. Instead, the part heading might be separated from each chapter, leaving each chapter in a
+					separate document.</p>
+
+				<p>Although visually these restructuring decisions can be hidden from readers, they impact the
+					functionality of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>. In
+					the case of [[wai-aria]] roles, the result is that only the subset present in the currently-loaded
+					EPUB content document are exposed to users. An assistive technology cannot provide a list of
+					landmarks for the whole publication, as it cannot see outside the current document.</p>
+
+				<p>To counteract this destructuring effect, a common bad practice is to re-add or re-identify structures
+					in the belief that having this information in every document will be helpful to users (e.g., adding
+					an extra [[html]] <a data-lt="section"><code>section</code> element</a> around a chapter to indicate
+					it belongs to a part). All this practice does, however, is add repetition that is not only
+					disruptive when reading but can make the structure of the publication harder to follow. It is
+					therefore advised not to attempt to rebuild structures in these ways.</p>
+
+				<p>For example, consider a book that has five parts and each part contains five chapters. Structurally,
+					each chapter belongs to its part (i.e., is grouped with it), as in the following markup:</p>
+
+				<pre>&lt;html … >
+   …
+   &lt;body>
+      &lt;section
+          role="doc-part"
+          aria-labelledby="p1">
+         
+         &lt;h1 id="p1">Part 1&lt;/h1>
+         
+         &lt;section
+             role="doc-chapter"
+             aria-labelledby="c1">
+            
+            &lt;h2 id="c1">Chapter 1&lt;/h2>
+            …
+         &lt;/section>
+         …
+      &lt;/section>
+      …
+   &lt;/body>
+&lt;/html></pre>
+
+				<div class="note">
+					<p>When more than one instance of a role is included in a document, each has to be uniquely
+						identified. The <code>aria-labelledby</code> attribute provides the name of each landmark in the
+						preceding example. The attribute is not required if only one instance is present, so it is
+						omitted from the following examples.</p>
+				</div>
+
+				<p>Since this would lead to a large content file, the part heading is typically split out into its own
+					EPUB content document so that it will appear on its own page:</p>
+
+				<pre>&lt;html … >
+   …
+   &lt;body>
+      &lt;section 
+          role="doc-part">
+         &lt;h1 id="p1">Part 1&lt;/h1>
+      &lt;/section>
+   &lt;/body>
+&lt;/html></pre>
+
+				<p>Each chapter is then separated into a separate EPUB content document:</p>
+
+				<pre>&lt;html … >
+   …
+   &lt;body>
+      &lt;section
+          role="doc-chapter">
+         
+         &lt;h2>Chapter 1&lt;/h2>
+         …
+      &lt;/section>
+   &lt;/body>
+&lt;/html></pre>
+
+				<p>If another <code>section</code> tag were added around the chapter in the preceding example to
+					indicate it is in part one (e.g., using the <code>aria-label</code> attribute so the heading is not
+					visible) users would hear "Part 1 Part 1 Chapter 1" because "Part 1" is also the heading in the
+					document that precedes the first chapter.</p>
 			</section>
 
 			<section id="sec-hd">

--- a/wg-notes/epub-aria-authoring/index.html
+++ b/wg-notes/epub-aria-authoring/index.html
@@ -66,11 +66,10 @@
 		<section id="sec-intro">
 			<h2>Introduction</h2>
 
-			<p>It is important to understand the differences between the <a
-					href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
-				[[epub-3]] and the <a href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code>
-					attribute</a> [[wai-aria]] to ensure that they are properly applied for their intended purposes and
-				audiences.</p>
+			<p>It is important to understand the differences between the <a data-cite="epub-3#sec-epub-type-attribute"
+						><code>epub:type</code> attribute</a> [[epub-3]] and the <a
+					data-cite="wai-aria#host_general_role"><code>role</code> attribute</a> [[wai-aria]] to ensure that
+				they are properly applied for their intended purposes and audiences.</p>
 
 			<p>The key difference is that the <code>role</code> attribute bridges accessibility in content while the
 					<code>type</code> attribute provides hooks to enable <a data-cite="epub/#dfn-epub-reading-system"
@@ -112,17 +111,16 @@
 				are elements that accept any role, you need to take care to ensure that roles are only used where they
 				will make sense to users of assistive technologies.</p>
 
-			<p>The following table maps the semantics from the <a href="https://www.w3.org/TR/epub-ssv-11/">EPUB
-					Structural Semantics Vocabulary</a> [[epub-ssv-11]] to the corresponding roles in [[wai-aria]] and
-				the [[dpub-aria]] module.</p>
+			<p>The following table maps the semantics from the <a href="https://www.w3.org/TR/epub-ssv/">EPUB Structural
+					Semantics Vocabulary</a> [[epub-ssv-11]] to the corresponding roles in [[wai-aria]] and the
+				[[dpub-aria]] module.</p>
 
-			<p>As the use of the <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
-					attribute</a> [[epub-3]] is much more liberal than the <a
-					href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code> attribute</a>
-				[[wai-aria]], you cannot interchange types and roles on every HTML element, even when a role mapping
-				exists. The elements you are allowed to use roles on are identified in the last column of the table. In
-				addition, refer to the note at the end of the table for the <a href="#role-general">list of elements
-					that accept any role value</a>.</p>
+			<p>As the use of the <a data-cite="epub-3#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
+				[[epub-3]] is much more liberal than the <a data-cite="wai-aria#host_general_role"><code>role</code>
+					attribute</a> [[wai-aria]], you cannot interchange types and roles on every HTML element, even when
+				a role mapping exists. The elements you are allowed to use roles on are identified in the last column of
+				the table. In addition, refer to the note at the end of the table for the <a href="#role-general">list
+					of elements that accept any role value</a>.</p>
 
 			<table id="mappings" class="zebra">
 				<thead>
@@ -137,24 +135,11 @@
 				<tbody>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#abstract">abstract</a>
+							<a data-cite="epub-ssv#abstract">abstract</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-abstract">doc-abstract</a>
-						</td>
-						<td></td>
-						<td>
-							<code>section</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#acknowledgments">acknowledgments</a>
-						</td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-acknowledgments">doc-acknowledgments</a>
+							<a data-cite="dpub-aria#doc-abstract">doc-abstract</a>
 						</td>
 						<td></td>
 						<td>
@@ -163,46 +148,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#afterword">afterword</a>
+							<a data-cite="epub-ssv#acknowledgments">acknowledgments</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-afterword">doc-afterword</a>
-						</td>
-						<td></td>
-						<td>
-							<code>section</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#answer">answer</a>
-						</td>
-						<td></td>
-						<td>
-							<em>No Role</em>
-						</td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#answers">answers</a>
-						</td>
-						<td></td>
-						<td>
-							<em>No Role</em>
-						</td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#appendix">appendix</a>
-						</td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-appendix">doc-appendix</a>
+							<a data-cite="dpub-aria#doc-acknowledgments">doc-acknowledgments</a>
 						</td>
 						<td></td>
 						<td>
@@ -211,7 +161,20 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#assessment">assessment</a>
+							<a data-cite="epub-ssv#afterword">afterword</a>
+						</td>
+						<td></td>
+						<td>
+							<a data-cite="dpub-aria#doc-afterword">doc-afterword</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#answer">answer</a>
 						</td>
 						<td></td>
 						<td>
@@ -222,7 +185,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#assessments">assessments</a>
+							<a data-cite="epub-ssv#answers">answers</a>
 						</td>
 						<td></td>
 						<td>
@@ -233,7 +196,20 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#backmatter">backmatter</a>
+							<a data-cite="epub-ssv#appendix">appendix</a>
+						</td>
+						<td></td>
+						<td>
+							<a data-cite="dpub-aria#doc-appendix">doc-appendix</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#assessment">assessment</a>
 						</td>
 						<td></td>
 						<td>
@@ -244,7 +220,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#balloon">balloon</a>
+							<a data-cite="epub-ssv#assessments">assessments</a>
 						</td>
 						<td></td>
 						<td>
@@ -255,7 +231,29 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#biblioentry">biblioentry</a>
+							<a data-cite="epub-ssv#backmatter">backmatter</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#balloon">balloon</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#biblioentry">biblioentry</a>
 						</td>
 						<td></td>
 						<td>doc-biblioentry <br />
@@ -266,11 +264,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#bibliography">bibliography</a>
+							<a data-cite="epub-ssv#bibliography">bibliography</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-bibliography">doc-bibliography</a>
+							<a data-cite="dpub-aria#doc-bibliography">doc-bibliography</a>
 						</td>
 						<td></td>
 						<td>
@@ -279,11 +277,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#biblioref">biblioref</a>
+							<a data-cite="epub-ssv#biblioref">biblioref</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-biblioref">doc-biblioref</a>
+							<a data-cite="dpub-aria#doc-biblioref">doc-biblioref</a>
 						</td>
 						<td></td>
 						<td>
@@ -292,7 +290,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#bodymatter">bodymatter</a>
+							<a data-cite="epub-ssv#bodymatter">bodymatter</a>
 						</td>
 						<td></td>
 						<td>
@@ -303,7 +301,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#bridgehead">bridgehead</a>
+							<a data-cite="epub-ssv#bridgehead">bridgehead</a>
 						</td>
 						<td></td>
 						<td>
@@ -314,7 +312,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#case-study">case-study</a>
+							<a data-cite="epub-ssv#case-study">case-study</a>
 						</td>
 						<td></td>
 						<td>
@@ -325,11 +323,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#chapter">chapter</a>
+							<a data-cite="epub-ssv#chapter">chapter</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-chapter">doc-chapter</a>
+							<a data-cite="dpub-aria#doc-chapter">doc-chapter</a>
 						</td>
 						<td></td>
 						<td>
@@ -338,35 +336,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#colophon">colophon</a>
+							<a data-cite="epub-ssv#colophon">colophon</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-colophon">doc-colophon</a>
-						</td>
-						<td></td>
-						<td>
-							<code>section</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#concluding-sentence">concluding-sentence</a>
-						</td>
-						<td></td>
-						<td>
-							<em>No Role</em>
-						</td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#conclusion">conclusion</a>
-						</td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-conclusion">doc-conclusion</a>
+							<a data-cite="dpub-aria#doc-colophon">doc-colophon</a>
 						</td>
 						<td></td>
 						<td>
@@ -375,7 +349,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#contributors">contributors</a>
+							<a data-cite="epub-ssv#concluding-sentence">concluding-sentence</a>
 						</td>
 						<td></td>
 						<td>
@@ -386,7 +360,20 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#copyright-page">copyright-page</a>
+							<a data-cite="epub-ssv#conclusion">conclusion</a>
+						</td>
+						<td></td>
+						<td>
+							<a data-cite="dpub-aria#doc-conclusion">doc-conclusion</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#contributors">contributors</a>
 						</td>
 						<td></td>
 						<td>
@@ -397,7 +384,18 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#cover">cover</a>
+							<a data-cite="epub-ssv#copyright-page">copyright-page</a>
+						</td>
+						<td></td>
+						<td>
+							<em>No Role</em>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#cover">cover</a>
 						</td>
 						<td></td>
 						<td>
@@ -411,10 +409,10 @@
 							<em hidden="hidden">cover</em>
 						</td>
 						<td>
-							<a href="https://www.w3.org/TR/epub/#cover-image">cover-image</a>
+							<a data-cite="epub-3#cover-image">cover-image</a>
 						</td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-cover">doc-cover</a>
+							<a data-cite="dpub-aria#doc-cover">doc-cover</a>
 						</td>
 						<td></td>
 						<td>
@@ -423,7 +421,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#covertitle">covertitle</a>
+							<a data-cite="epub-ssv#covertitle">covertitle</a>
 						</td>
 						<td></td>
 						<td>
@@ -434,24 +432,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#credit">credit</a>
+							<a data-cite="epub-ssv#credit">credit</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-credit">doc-credit</a>
-						</td>
-						<td></td>
-						<td>
-							<code>section</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#credits">credits</a>
-						</td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-credits">doc-credits</a>
+							<a data-cite="dpub-aria#doc-credit">doc-credit</a>
 						</td>
 						<td></td>
 						<td>
@@ -460,11 +445,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#dedication">dedication</a>
+							<a data-cite="epub-ssv#credits">credits</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-dedication">doc-dedication</a>
+							<a data-cite="dpub-aria#doc-credits">doc-credits</a>
 						</td>
 						<td></td>
 						<td>
@@ -473,7 +458,20 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#division">division</a>
+							<a data-cite="epub-ssv#dedication">dedication</a>
+						</td>
+						<td></td>
+						<td>
+							<a data-cite="dpub-aria#doc-dedication">doc-dedication</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#division">division</a>
 						</td>
 						<td></td>
 						<td>
@@ -484,7 +482,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#endnote">endnote</a>
+							<a data-cite="epub-ssv#endnote">endnote</a>
 						</td>
 						<td></td>
 						<td>doc-endnote <br />
@@ -495,35 +493,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#endnotes">endnotes</a>
+							<a data-cite="epub-ssv#endnotes">endnotes</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-endnotes">doc-endnotes</a>
-						</td>
-						<td></td>
-						<td>
-							<code>section</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#epigraph">epigraph</a>
-						</td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-epigraph">doc-epigraph</a>
-						</td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#epilogue">epilogue</a>
-						</td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-epilogue">doc-epilogue</a>
+							<a data-cite="dpub-aria#doc-endnotes">doc-endnotes</a>
 						</td>
 						<td></td>
 						<td>
@@ -532,11 +506,35 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#errata">errata</a>
+							<a data-cite="epub-ssv#epigraph">epigraph</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-errata">doc-errata</a>
+							<a data-cite="dpub-aria#doc-epigraph">doc-epigraph</a>
+						</td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#epilogue">epilogue</a>
+						</td>
+						<td></td>
+						<td>
+							<a data-cite="dpub-aria#doc-epilogue">doc-epilogue</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#errata">errata</a>
+						</td>
+						<td></td>
+						<td>
+							<a data-cite="dpub-aria#doc-errata">doc-errata</a>
 						</td>
 						<td></td>
 						<td>
@@ -549,14 +547,14 @@
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-example">doc-example</a>
+							<a data-cite="dpub-aria#doc-example">doc-example</a>
 						</td>
 						<td></td>
 						<td><code>aside</code>, <code>section</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#feedback">feedback</a>
+							<a data-cite="epub-ssv#feedback">feedback</a>
 						</td>
 						<td></td>
 						<td>
@@ -567,19 +565,18 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#figure">figure</a>
+							<a data-cite="epub-ssv#figure">figure</a>
 						</td>
 						<td></td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#figure">figure</a>
+							<a data-cite="wai-aria#figure">figure</a>
 						</td>
 						<td></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#fill-in-the-blank-problem"
-								>fill-in-the-blank-problem</a>
+							<a data-cite="epub-ssv#fill-in-the-blank-problem">fill-in-the-blank-problem</a>
 						</td>
 						<td></td>
 						<td>
@@ -590,18 +587,18 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#footnote">footnote</a>
+							<a data-cite="epub-ssv#footnote">footnote</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-footnote">doc-footnote</a>
+							<a data-cite="dpub-aria#doc-footnote">doc-footnote</a>
 						</td>
 						<td></td>
 						<td><code>aside</code>, <code>footer</code>, <code>header</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#footnotes">footnotes</a>
+							<a data-cite="epub-ssv#footnotes">footnotes</a>
 						</td>
 						<td></td>
 						<td>
@@ -612,11 +609,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#foreword">foreword</a>
+							<a data-cite="epub-ssv#foreword">foreword</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-foreword">doc-foreword</a>
+							<a data-cite="dpub-aria#doc-foreword">doc-foreword</a>
 						</td>
 						<td></td>
 						<td>
@@ -625,7 +622,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#frontmatter">frontmatter</a>
+							<a data-cite="epub-ssv#frontmatter">frontmatter</a>
 						</td>
 						<td></td>
 						<td>
@@ -636,7 +633,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#fulltitle">fulltitle</a>
+							<a data-cite="epub-ssv#fulltitle">fulltitle</a>
 						</td>
 						<td></td>
 						<td>
@@ -647,7 +644,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#general-problem">general-problem</a>
+							<a data-cite="epub-ssv#general-problem">general-problem</a>
 						</td>
 						<td></td>
 						<td>
@@ -658,11 +655,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#glossary">glossary</a>
+							<a data-cite="epub-ssv#glossary">glossary</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-glossary">doc-glossary</a>
+							<a data-cite="dpub-aria#doc-glossary">doc-glossary</a>
 						</td>
 						<td></td>
 						<td>
@@ -671,33 +668,33 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#glossterm">glossterm</a>
+							<a data-cite="epub-ssv#glossterm">glossterm</a>
 						</td>
 						<td></td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#term">term</a>
-						</td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#glossdef">glossdef</a>
-						</td>
-						<td></td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#definition">definition</a>
+							<a data-cite="wai-aria#term">term</a>
 						</td>
 						<td></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#glossref">glossref</a>
+							<a data-cite="epub-ssv#glossdef">glossdef</a>
+						</td>
+						<td></td>
+						<td></td>
+						<td>
+							<a data-cite="wai-aria#definition">definition</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#glossref">glossref</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-glossref">doc-glossref</a>
+							<a data-cite="dpub-aria#doc-glossref">doc-glossref</a>
 						</td>
 						<td></td>
 						<td>
@@ -706,7 +703,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#halftitle">halftitle</a>
+							<a data-cite="epub-ssv#halftitle">halftitle</a>
 						</td>
 						<td></td>
 						<td>
@@ -717,7 +714,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#halftitlepage">halftitlepage</a>
+							<a data-cite="epub-ssv#halftitlepage">halftitlepage</a>
 						</td>
 						<td></td>
 						<td>
@@ -728,7 +725,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#imprint">imprint</a>
+							<a data-cite="epub-ssv#imprint">imprint</a>
 						</td>
 						<td></td>
 						<td>
@@ -739,7 +736,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#imprimatur">imprimatur</a>
+							<a data-cite="epub-ssv#imprimatur">imprimatur</a>
 						</td>
 						<td></td>
 						<td>
@@ -750,18 +747,18 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index">index</a>
+							<a data-cite="epub-ssv#index">index</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-index">doc-index</a>
+							<a data-cite="dpub-aria#doc-index">doc-index</a>
 						</td>
 						<td></td>
 						<td><code>nav</code>, <code>section</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-headnotes">index-headnotes</a>
+							<a data-cite="epub-ssv#index-headnotes">index-headnotes</a>
 						</td>
 						<td></td>
 						<td>
@@ -772,7 +769,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-legend">index-legend</a>
+							<a data-cite="epub-ssv#index-legend">index-legend</a>
 						</td>
 						<td></td>
 						<td>
@@ -783,7 +780,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-group">index-group</a>
+							<a data-cite="epub-ssv#index-group">index-group</a>
 						</td>
 						<td></td>
 						<td>
@@ -794,7 +791,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-entry-list">index-entry-list</a>
+							<a data-cite="epub-ssv#index-entry-list">index-entry-list</a>
 						</td>
 						<td></td>
 						<td>
@@ -805,7 +802,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-entry">index-entry</a>
+							<a data-cite="epub-ssv#index-entry">index-entry</a>
 						</td>
 						<td></td>
 						<td>
@@ -816,7 +813,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-term">index-term</a>
+							<a data-cite="epub-ssv#index-term">index-term</a>
 						</td>
 						<td></td>
 						<td>
@@ -827,7 +824,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-editor-note">index-editor-note</a>
+							<a data-cite="epub-ssv#index-editor-note">index-editor-note</a>
 						</td>
 						<td></td>
 						<td>
@@ -838,7 +835,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-locator">index-locator</a>
+							<a data-cite="epub-ssv#index-locator">index-locator</a>
 						</td>
 						<td></td>
 						<td>
@@ -849,7 +846,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-locator-list">index-locator-list</a>
+							<a data-cite="epub-ssv#index-locator-list">index-locator-list</a>
 						</td>
 						<td></td>
 						<td>
@@ -860,7 +857,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-locator-range">index-locator-range</a>
+							<a data-cite="epub-ssv#index-locator-range">index-locator-range</a>
 						</td>
 						<td></td>
 						<td>
@@ -871,7 +868,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-xref-preferred">index-xref-preferred</a>
+							<a data-cite="epub-ssv#index-xref-preferred">index-xref-preferred</a>
 						</td>
 						<td></td>
 						<td>
@@ -882,7 +879,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-xref-related">index-xref-related</a>
+							<a data-cite="epub-ssv#index-xref-related">index-xref-related</a>
 						</td>
 						<td></td>
 						<td>
@@ -893,7 +890,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-term-category">index-term-category</a>
+							<a data-cite="epub-ssv#index-term-category">index-term-category</a>
 						</td>
 						<td></td>
 						<td>
@@ -904,7 +901,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#index-term-categories">index-term-categories</a>
+							<a data-cite="epub-ssv#index-term-categories">index-term-categories</a>
 						</td>
 						<td></td>
 						<td>
@@ -915,11 +912,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#introduction">introduction</a>
+							<a data-cite="epub-ssv#introduction">introduction</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-introduction">doc-introduction</a>
+							<a data-cite="dpub-aria#doc-introduction">doc-introduction</a>
 						</td>
 						<td></td>
 						<td>
@@ -928,7 +925,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#keyword">keyword</a>
+							<a data-cite="epub-ssv#keyword">keyword</a>
 						</td>
 						<td></td>
 						<td>
@@ -939,7 +936,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#keywords">keywords</a>
+							<a data-cite="epub-ssv#keywords">keywords</a>
 						</td>
 						<td></td>
 						<td>
@@ -950,7 +947,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#label">label</a>
+							<a data-cite="epub-ssv#label">label</a>
 						</td>
 						<td></td>
 						<td>
@@ -961,18 +958,18 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#landmarks">landmarks</a>
+							<a data-cite="epub-ssv#landmarks">landmarks</a>
 						</td>
 						<td></td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#directory">directory</a>
+							<a data-cite="wai-aria#directory">directory</a>
 						</td>
 						<td><code>ol</code>, <code>ul</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-objective">learning-objective</a>
+							<a data-cite="epub-ssv#learning-objective">learning-objective</a>
 						</td>
 						<td></td>
 						<td>
@@ -983,7 +980,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-objectives">learning-objectives</a>
+							<a data-cite="epub-ssv#learning-objectives">learning-objectives</a>
 						</td>
 						<td></td>
 						<td>
@@ -994,7 +991,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-outcome">learning-outcome</a>
+							<a data-cite="epub-ssv#learning-outcome">learning-outcome</a>
 						</td>
 						<td></td>
 						<td>
@@ -1005,7 +1002,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-outcomes">learning-outcomes</a>
+							<a data-cite="epub-ssv#learning-outcomes">learning-outcomes</a>
 						</td>
 						<td></td>
 						<td>
@@ -1016,7 +1013,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-resource">learning-resource</a>
+							<a data-cite="epub-ssv#learning-resource">learning-resource</a>
 						</td>
 						<td></td>
 						<td>
@@ -1027,7 +1024,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-resources">learning-resources</a>
+							<a data-cite="epub-ssv#learning-resources">learning-resources</a>
 						</td>
 						<td></td>
 						<td>
@@ -1038,7 +1035,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-standard">learning-standard</a>
+							<a data-cite="epub-ssv#learning-standard">learning-standard</a>
 						</td>
 						<td></td>
 						<td>
@@ -1049,7 +1046,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#learning-standards">learning-standards</a>
+							<a data-cite="epub-ssv#learning-standards">learning-standards</a>
 						</td>
 						<td></td>
 						<td>
@@ -1060,29 +1057,29 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#list">list</a>
+							<a data-cite="epub-ssv#list">list</a>
 						</td>
 						<td></td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#list">list</a>
-						</td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#list-item">list-item</a>
-						</td>
-						<td></td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#listitem">listitem</a>
+							<a data-cite="wai-aria#list">list</a>
 						</td>
 						<td></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#loa">loa</a>
+							<a data-cite="epub-ssv#list-item">list-item</a>
+						</td>
+						<td></td>
+						<td></td>
+						<td>
+							<a data-cite="wai-aria#listitem">listitem</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#loa">loa</a>
 						</td>
 						<td></td>
 						<td>
@@ -1093,7 +1090,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#loi">loi</a>
+							<a data-cite="epub-ssv#loi">loi</a>
 						</td>
 						<td></td>
 						<td>
@@ -1104,7 +1101,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#lot">lot</a>
+							<a data-cite="epub-ssv#lot">lot</a>
 						</td>
 						<td></td>
 						<td>
@@ -1115,7 +1112,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#lov">lov</a>
+							<a data-cite="epub-ssv#lov">lov</a>
 						</td>
 						<td></td>
 						<td>
@@ -1126,7 +1123,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#match-problem">match-problem</a>
+							<a data-cite="epub-ssv#match-problem">match-problem</a>
 						</td>
 						<td></td>
 						<td>
@@ -1137,8 +1134,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#multiple-choice-problem"
-								>multiple-choice-problem</a>
+							<a data-cite="epub-ssv#multiple-choice-problem">multiple-choice-problem</a>
 						</td>
 						<td></td>
 						<td>
@@ -1149,11 +1145,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#noteref">noteref</a>
+							<a data-cite="epub-ssv#noteref">noteref</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-noteref">doc-noteref</a>
+							<a data-cite="dpub-aria#doc-noteref">doc-noteref</a>
 						</td>
 						<td></td>
 						<td>
@@ -1162,11 +1158,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#notice">notice</a>
+							<a data-cite="epub-ssv#notice">notice</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-notice">doc-notice</a>
+							<a data-cite="dpub-aria#doc-notice">doc-notice</a>
 						</td>
 						<td></td>
 						<td>
@@ -1175,7 +1171,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#ordinal">ordinal</a>
+							<a data-cite="epub-ssv#ordinal">ordinal</a>
 						</td>
 						<td></td>
 						<td>
@@ -1186,7 +1182,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#other-credits">other-credits</a>
+							<a data-cite="epub-ssv#other-credits">other-credits</a>
 						</td>
 						<td></td>
 						<td>
@@ -1197,7 +1193,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#panel">panel</a>
+							<a data-cite="epub-ssv#panel">panel</a>
 						</td>
 						<td></td>
 						<td>
@@ -1208,7 +1204,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#panel-group">panel-group</a>
+							<a data-cite="epub-ssv#panel-group">panel-group</a>
 						</td>
 						<td></td>
 						<td>
@@ -1219,11 +1215,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#pagebreak">pagebreak</a>
+							<a data-cite="epub-ssv#pagebreak">pagebreak</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-pagebreak">doc-pagebreak</a>
+							<a data-cite="dpub-aria#doc-pagebreak">doc-pagebreak</a>
 						</td>
 						<td></td>
 						<td>
@@ -1232,22 +1228,22 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#page-list">page-list</a>
+							<a data-cite="epub-ssv#page-list">page-list</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-pagelist">doc-pagelist</a>
+							<a data-cite="dpub-aria#doc-pagelist">doc-pagelist</a>
 						</td>
 						<td></td>
 						<td><code>nav</code>, <code>section</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#part">part</a>
+							<a data-cite="epub-ssv#part">part</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-part">doc-part</a>
+							<a data-cite="dpub-aria#doc-part">doc-part</a>
 						</td>
 						<td></td>
 						<td>
@@ -1256,7 +1252,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#practice">practice</a>
+							<a data-cite="epub-ssv#practice">practice</a>
 						</td>
 						<td></td>
 						<td>
@@ -1267,7 +1263,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#practices">practices</a>
+							<a data-cite="epub-ssv#practices">practices</a>
 						</td>
 						<td></td>
 						<td>
@@ -1278,7 +1274,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#preamble">preamble</a>
+							<a data-cite="epub-ssv#preamble">preamble</a>
 						</td>
 						<td></td>
 						<td>
@@ -1289,24 +1285,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#preface">preface</a>
+							<a data-cite="epub-ssv#preface">preface</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-preface">doc-preface</a>
-						</td>
-						<td></td>
-						<td>
-							<code>section</code>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#prologue">prologue</a>
-						</td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-prologue">doc-prologue</a>
+							<a data-cite="dpub-aria#doc-preface">doc-preface</a>
 						</td>
 						<td></td>
 						<td>
@@ -1315,18 +1298,31 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#pullquote">pullquote</a>
+							<a data-cite="epub-ssv#prologue">prologue</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-pullquote">doc-pullquote</a>
+							<a data-cite="dpub-aria#doc-prologue">doc-prologue</a>
+						</td>
+						<td></td>
+						<td>
+							<code>section</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#pullquote">pullquote</a>
+						</td>
+						<td></td>
+						<td>
+							<a data-cite="dpub-aria#doc-pullquote">doc-pullquote</a>
 						</td>
 						<td></td>
 						<td><code>aside</code>, <code>section</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#question">question</a>
+							<a data-cite="epub-ssv#question">question</a>
 						</td>
 						<td></td>
 						<td>
@@ -1337,11 +1333,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#qna">qna</a>
+							<a data-cite="epub-ssv#qna">qna</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-qna">doc-qna</a>
+							<a data-cite="dpub-aria#doc-qna">doc-qna</a>
 						</td>
 						<td></td>
 						<td>
@@ -1350,11 +1346,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#backlink">backlink</a>
+							<a data-cite="epub-ssv#backlink">backlink</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-backlink">doc-backlink</a>
+							<a data-cite="dpub-aria#doc-backlink">doc-backlink</a>
 						</td>
 						<td></td>
 						<td>
@@ -1363,7 +1359,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#revision-history">revision-history</a>
+							<a data-cite="epub-ssv#revision-history">revision-history</a>
 						</td>
 						<td></td>
 						<td>
@@ -1374,7 +1370,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#seriespage">seriespage</a>
+							<a data-cite="epub-ssv#seriespage">seriespage</a>
 						</td>
 						<td></td>
 						<td>
@@ -1385,7 +1381,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#sound-area">sound-area</a>
+							<a data-cite="epub-ssv#sound-area">sound-area</a>
 						</td>
 						<td></td>
 						<td>
@@ -1396,7 +1392,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#subchapter">subchapter</a>
+							<a data-cite="epub-ssv#subchapter">subchapter</a>
 						</td>
 						<td></td>
 						<td>
@@ -1407,51 +1403,51 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#subtitle">subtitle</a>
+							<a data-cite="epub-ssv#subtitle">subtitle</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-subtitle">doc-subtitle</a>
+							<a data-cite="dpub-aria#doc-subtitle">doc-subtitle</a>
 						</td>
 						<td></td>
 						<td><code>h1</code>-<code>h6</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#table">table</a>
+							<a data-cite="epub-ssv#table">table</a>
 						</td>
 						<td></td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#table">table</a>
-						</td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#table-row">table-row</a>
-						</td>
-						<td></td>
-						<td></td>
-						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#row">row</a>
+							<a data-cite="wai-aria#table">table</a>
 						</td>
 						<td></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#table-cell">table-cell</a>
+							<a data-cite="epub-ssv#table-row">table-row</a>
 						</td>
 						<td></td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/wai-aria/#cell">cell</a>
+							<a data-cite="wai-aria#row">row</a>
 						</td>
 						<td></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#text-area">text-area</a>
+							<a data-cite="epub-ssv#table-cell">table-cell</a>
+						</td>
+						<td></td>
+						<td></td>
+						<td>
+							<a data-cite="wai-aria#cell">cell</a>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>
+							<a data-cite="epub-ssv#text-area">text-area</a>
 						</td>
 						<td></td>
 						<td>
@@ -1462,11 +1458,11 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#tip">tip</a>
+							<a data-cite="epub-ssv#tip">tip</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-tip">doc-tip</a>
+							<a data-cite="dpub-aria#doc-tip">doc-tip</a>
 						</td>
 						<td></td>
 						<td>
@@ -1475,7 +1471,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#title">title</a>
+							<a data-cite="epub-ssv#title">title</a>
 						</td>
 						<td></td>
 						<td>
@@ -1486,7 +1482,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#titlepage">titlepage</a>
+							<a data-cite="epub-ssv#titlepage">titlepage</a>
 						</td>
 						<td></td>
 						<td>
@@ -1497,18 +1493,18 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#toc">toc</a>
+							<a data-cite="epub-ssv#toc">toc</a>
 						</td>
 						<td></td>
 						<td>
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-toc">doc-toc</a>
+							<a data-cite="dpub-aria#doc-toc">doc-toc</a>
 						</td>
 						<td></td>
 						<td><code>nav</code>, <code>section</code></td>
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#toc-brief">toc-brief</a>
+							<a data-cite="epub-ssv#toc-brief">toc-brief</a>
 						</td>
 						<td></td>
 						<td>
@@ -1519,7 +1515,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#topic-sentence">topic-sentence</a>
+							<a data-cite="epub-ssv#topic-sentence">topic-sentence</a>
 						</td>
 						<td></td>
 						<td>
@@ -1530,7 +1526,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#true-false-problem">true-false-problem</a>
+							<a data-cite="epub-ssv#true-false-problem">true-false-problem</a>
 						</td>
 						<td></td>
 						<td>
@@ -1541,7 +1537,7 @@
 					</tr>
 					<tr>
 						<td>
-							<a href="https://www.w3.org/TR/epub-ssv/#volume">volume</a>
+							<a data-cite="epub-ssv#volume">volume</a>
 						</td>
 						<td></td>
 						<td>
@@ -1700,9 +1696,8 @@
 			<section id="sec-overload">
 				<h3>Do not overload roles</h3>
 
-				<p>Only use <strong>one digital publishing role</strong> per <a
-						href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code> attribute</a>
-					[[wai-aria]].</p>
+				<p>Only use <strong>one digital publishing role</strong> per <a data-cite="wai-aria#host_general_role"
+							><code>role</code> attribute</a> [[wai-aria]].</p>
 
 				<aside class="example" title="A section with a single DPUB-ARIA role">
 					<pre>&lt;section role="doc-chapter"></pre>
@@ -1714,13 +1709,12 @@
 					<pre>&lt;section role="doc-chapter region"></pre>
 				</aside>
 
-				<p class="note">The fallback must not be an <a href="https://www.w3.org/TR/wai-aria/#abstract_roles"
-						>Abstract roles</a> [[wai-aria]]. These roles are never allowed in the <code>role</code>
-					attribute.</p>
+				<p class="note">The fallback must not be an <a data-cite="wai-aria#abstract_roles">Abstract roles</a>
+					[[wai-aria]]. These roles are never allowed in the <code>role</code> attribute.</p>
 
-				<p>Unlike the <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
-						attribute</a> [[epub-3]], the order of roles is important, and only the first recognized role is
-					applied to an element.</p>
+				<p>Unlike the <a data-cite="epub-3#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
+					[[epub-3]], the order of roles is important, and only the first recognized role is applied to an
+					element.</p>
 			</section>
 
 			<section id="sec-repetition">
@@ -1822,15 +1816,14 @@
 			<section id="sec-hd">
 				<h3>Supply labels</h3>
 
-				<p>If a landmark role (e.g., <a href="https://www.w3.org/TR/dpub-aria/#doc-chapter"
-							><code>doc-chapter</code></a>, <a href="https://www.w3.org/TR/dpub-aria/#doc-part"
-							><code>doc-part</code></a>, <a href="https://www.w3.org/TR/dpub-aria/#doc-index"
+				<p>If a landmark role (e.g., <a data-cite="dpub-aria#doc-chapter"><code>doc-chapter</code></a>, <a
+						data-cite="dpub-aria#doc-part"><code>doc-part</code></a>, <a data-cite="dpub-aria#doc-index"
 							><code>doc-index</code></a> [[dpub-aria]]) does not include a label, assistive technologies
 					will only announce the generic name of the role in the landmarks.</p>
 
-				<p>To include a more descriptive label, use the <a
-						href="https://www.w3.org/TR/wai-aria/#aria-labelledby"><code>aria-labelledby</code>
-						attribute</a> [[wai-aria]] to associate the label with the role.</p>
+				<p>To include a more descriptive label, use the <a data-cite="wai-aria#aria-labelledby"
+							><code>aria-labelledby</code> attribute</a> [[wai-aria]] to associate the label with the
+					role.</p>
 
 				<aside class="example" title="Using the aria-labelledby attribute to provide a label">
 					<pre>&lt;section role="doc-index" aria-labelledby="idx01">
@@ -1839,9 +1832,8 @@
 &lt;/section></pre>
 				</aside>
 
-				<p>If a label is not available in the text, you can supply one in an <a
-						href="https://www.w3.org/TR/wai-aria/#aria-label"><code>aria-label</code> attribute</a>
-					[[wai-aria]].</p>
+				<p>If a label is not available in the text, you can supply one in an <a data-cite="wai-aria#aria-label"
+							><code>aria-label</code> attribute</a> [[wai-aria]].</p>
 
 				<aside class="example" title="Using the aria-label attribute to provide a label">
 					<pre>&lt;aside role="doc-tip" aria-label="Helpful Hint">
@@ -1868,17 +1860,15 @@
 			<section id="sec-body">
 				<h3>Do not override the <code>body</code> element</h3>
 
-				<p>The <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
-						attribute</a> [[epub-3]] may be used to inflect sectioning semantics on the [[html]] <a
-						href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"><code>body</code>
-						element</a> (e.g., to indicate front matter, or to avoid using sectioning elements), but this
-					practice is both invalid and harmful with ARIA roles.</p>
+				<p>The <a data-cite="epub-3#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[epub-3]] may
+					be used to inflect sectioning semantics on the [[html]] <a data-cite="html#the-body-element"
+							><code>body</code> element</a> (e.g., to indicate front matter, or to avoid using sectioning
+					elements), but this practice is both invalid and harmful with ARIA roles.</p>
 
-				<p>The <code>body</code> element has the implied role <a href="https://www.w3.org/TR/wai-aria/#document"
-							><code>document</code></a> [[wai-aria]], and <a
-						href="https://www.w3.org/TR/html-aria/#el-body">you cannot define any other role on it</a>
-					[[html-aria]]. Changing the role of the <code>body</code> element can affect the ability to read the
-					content for users of assistive technologies.</p>
+				<p>The <code>body</code> element has the implied role <a data-cite="wai-aria#document"
+							><code>document</code></a> [[wai-aria]], and <a data-cite="html-aria#el-body">you cannot
+						define any other role on it</a> [[html-aria]]. Changing the role of the <code>body</code>
+					element can affect the ability to read the content for users of assistive technologies.</p>
 			</section>
 
 			<section id="sec-lists">
@@ -1887,12 +1877,9 @@
 				<p>Assigning a role to an element overrides its default nature, so use care when applying roles to lists
 					and list items.</p>
 
-				<p>Just as [[html]] <a
-						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
-							><code>ol</code></a> and <a
-						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
-							><code>ul</code></a> list elements must contain list items, elements assigned a list role
-					must only contain elements assigned a list item role.</p>
+				<p>Just as [[html]] <a data-cite="html#the-ol-element"><code>ol</code></a> and <a
+						data-cite="html#the-ul-element"><code>ul</code></a> list elements must contain list items,
+					elements assigned a list role must only contain elements assigned a list item role.</p>
 
 				<aside class="example" title="Specifying list and listitem roles on elements">
 					<pre>&lt;div role="list">
@@ -1905,16 +1892,15 @@
 
 				<div class="note">
 					<p>Due to a change in the [[wai-aria]] roles model, list item roles defined in modules no longer
-						satisfy the requirement that the <a href="https://www.w3.org/TR/wai-aria/#list"
-								><code>list</code> role</a> have list item children. As a result, use of the <a
-							href="https://www.w3.org/TR/dpub-aria/#doc-biblioentry"><code>doc-biblioentry</code></a> and
-							<a href="https://www.w3.org/TR/dpub-aria/#doc-endnote"><code>doc-endnote</code></a> roles
-						[[dpub-aria]] is now deprecated.</p>
+						satisfy the requirement that the <a data-cite="wai-aria#list"><code>list</code> role</a> have
+						list item children. As a result, use of the <a data-cite="dpub-aria#doc-biblioentry"
+								><code>doc-biblioentry</code></a> and <a data-cite="dpub-aria#doc-endnote"
+								><code>doc-endnote</code></a> roles [[dpub-aria]] is now deprecated.</p>
 
 					<p>These roles are now implied on list items within sections that have a <a
-							href="https://www.w3.org/TR/dpub-aria/#doc-bibliography"><code>doc-bibliography</code></a>
-						or <a href="https://www.w3.org/TR/dpub-aria/#doc-endnotes"><code>doc-endnotes</code></a> role
-						[[dpub-aria]], respectively.</p>
+							data-cite="dpub-aria#doc-bibliography"><code>doc-bibliography</code></a> or <a
+							data-cite="dpub-aria#doc-endnotes"><code>doc-endnotes</code></a> role [[dpub-aria]],
+						respectively.</p>
 
 					<pre>&lt;section role="doc-bibliography">
    &lt;h2>Select Bibliography&lt;/h2>
@@ -1930,10 +1916,9 @@
 			<section id="sec-covers">
 				<h3>Cover role is for images</h3>
 
-				<p>Although the <a href="https://www.w3.org/TR/dpub-aria/#doc-cover"><code>doc-cover</code> role</a>
-					[[dpub-aria]] seems like it should be the same as the <a
-						href="https://www.w3.org/TR/epub-ssv/#cover"><code>cover</code> semantic</a> [[epub-ssv-11]], it
-					is actually related to the <a href="https://www.w3.org/TR/epub/#cover-image"
+				<p>Although the <a data-cite="dpub-aria#doc-cover"><code>doc-cover</code> role</a> [[dpub-aria]] seems
+					like it should be the same as the <a data-cite="epub-ssv#cover"><code>cover</code> semantic</a>
+					[[epub-ssv-11]], it is actually related to the <a data-cite="epub-3#cover-image"
 							><code>cover-image</code> semantic</a> [[epub-3]] used to identify cover images in the EPUB
 					package document. The role is used to identify an image that represents the cover.</p>
 
@@ -1945,16 +1930,14 @@
 				</aside>
 
 				<p><strong>Do not</strong> use this role to identify a section of content containing the cover. Placing
-					the role on an [[html]] <a
-						href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							><code>section</code> element</a>, for example, informs assistive technologies to treat the
-					element like they would an image. In practical terms, this means that none of its content will be
-					available.</p>
+					the role on an [[html]] <a data-cite="html#the-section-element"><code>section</code> element</a>,
+					for example, informs assistive technologies to treat the element like they would an image. In
+					practical terms, this means that none of its content will be available.</p>
 
 				<p>If a section of cover content needs to be identified as a landmark, you can use the <a
-						href="https://www.w3.org/TR/wai-aria/#aria-label"><code>aria-label</code></a> or <a
-						href="https://www.w3.org/TR/wai-aria/#aria-labelledby"><code>aria-labelledby</code></a>
-					attributes [[wai-aria]] with a <code>section</code> element.</p>
+						data-cite="wai-aria#aria-label"><code>aria-label</code></a> or <a
+						data-cite="wai-aria#aria-labelledby"><code>aria-labelledby</code></a> attributes [[wai-aria]]
+					with a <code>section</code> element.</p>
 
 				<aside class="example" title="Adding a label to a section to create a landmark">
 					<pre>&lt;section aria-label="Cover: As I Lay Dying. William Faulkner">
@@ -1962,12 +1945,10 @@
 &lt;/section></pre>
 				</aside>
 
-				<p class="note">For [[html]] <a
-						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
-							><code>div</code> elements</a>, the general <a href="https://www.w3.org/TR/wai-aria/#region"
-							><code>region</code> role</a> [[wai-aria]] is also needed. For more information about how to
-					use roles in content, refer to <a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
-					[[html-aria]].</p>
+				<p class="note">For [[html]] <a data-cite="html#the-div-element"><code>div</code> elements</a>, the
+					general <a data-cite="wai-aria#region"><code>region</code> role</a> [[wai-aria]] is also needed. For
+					more information about how to use roles in content, refer to <a
+						href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a> [[html-aria]].</p>
 			</section>
 		</section>
 	</body>

--- a/wg-notes/epub-aria-authoring/index.html
+++ b/wg-notes/epub-aria-authoring/index.html
@@ -35,17 +35,17 @@
 				localBiblio: {
 					"dpub-aria": {
 						"title": "Digital Publishing WAI-ARIA Module",
-						"url": "https://www.w3.org/TR/dpub-aria/",
+						"href": "https://www.w3.org/TR/dpub-aria/",
 						"publisher": "W3C"
 					},
 					"epub-3": {
 						"title": "EPUB 3",
-						"url": "https://www.w3.org/TR/epub/",
+						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
 					"wai-aria": {
 						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
-						"url": "https://www.w3.org/TR/wai-aria/",
+						"href": "https://www.w3.org/TR/wai-aria/",
 						"publisher": "W3C"
 					}
 				}

--- a/wg-notes/epub-aria-authoring/index.html
+++ b/wg-notes/epub-aria-authoring/index.html
@@ -72,10 +72,10 @@
 				they are properly applied for their intended purposes and audiences.</p>
 
 			<p>The key difference is that the <code>role</code> attribute bridges accessibility in content while the
-					<code>type</code> attribute provides hooks to enable <a data-cite="epub/#dfn-epub-reading-system"
+					<code>type</code> attribute provides hooks to enable <a data-cite="epub-3#dfn-epub-reading-system"
 					>reading system</a> behaviors. Omitting roles lessens the accessibility for users of <a
 					data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>, in other words, while
-				omitting types diminishes certain functionality in <a data-cite="epub/#dfn-epub-reading-system">reading
+				omitting types diminishes certain functionality in <a data-cite="epub-3#dfn-epub-reading-system">reading
 					systems</a> (e.g., pop-up footnotes or special presentations of the content).</p>
 
 			<p>The result is that the application of <code>epub:type</code> semantics is largely harmless, but
@@ -1722,11 +1722,11 @@
 
 				<p>Do not reapply a semantic just because your content has been chunked into separate files.</p>
 
-				<p>Although <a data-cite="epub/#dfn-epub-publication">EPUB publications</a> appear as single contiguous
+				<p>Although <a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> appear as single contiguous
 					documents to users when read, they are typically composed of many individual <a
-						data-cite="epub/#dfn-epub-content-document">EPUB content documents</a>. This practice keeps the
+						data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a>. This practice keeps the
 					amount of markup that has to be rendered small to reduce the load time in <a
-						data-cite="epub/#dfn-epub-reading-system">reading systems</a> (i.e., to minimize the time the
+						data-cite="epub-3#dfn-epub-reading-system">reading systems</a> (i.e., to minimize the time the
 					user has to wait for a document to appear). It is rare, at least for books, for an EPUB publication
 					to contain only one EPUB content document with all the content in it.</p>
 

--- a/wg-notes/epub-aria-authoring/index.html
+++ b/wg-notes/epub-aria-authoring/index.html
@@ -96,11 +96,11 @@
 				<p>This guide is not intended as a comprehensive overview of ARIA roles. For more information about ARIA
 					and how to apply it to HTML document, refer to [[wai-aria]] and [[html-aria]], respectively.</p>
 
-				<p>It also only applies to <a data-cite="epub-3/#dfn-epub-content-document">EPUB content documents</a>.
+				<p>It also only applies to <a data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a>.
 					The <code>epub:type</code> attribute is the only means of adding structural information to <a
-						data-cite="epub-3/#dfn-media-overlay-document">media overlay documents</a> so that features like
+						data-cite="epub-3#dfn-media-overlay-document">media overlay documents</a> so that features like
 					lists and tables can be navigated more efficiently. It is also required in the <a
-						data-cite="epub-3/#dfn-epub-navigation-document">EPUB navigation document</a> to identify key
+						data-cite="epub-3#dfn-epub-navigation-document">EPUB navigation document</a> to identify key
 					structures.</p>
 			</div>
 		</section>
@@ -1743,10 +1743,10 @@
 
 				<p>To counteract this destructuring effect, a common bad practice is to re-add or re-identify structures
 					in the belief that having this information in every document will be helpful to users (e.g., adding
-					an extra [[html]] <a data-lt="section"><code>section</code> element</a> around a chapter to indicate
-					it belongs to a part). All this practice does, however, is add repetition that is not only
-					disruptive when reading but can make the structure of the publication harder to follow. It is
-					therefore advised not to attempt to rebuild structures in these ways.</p>
+					an extra [[html]] <a data-cite="html#the-section-element"><code>section</code> element</a> around a
+					chapter to indicate it belongs to a part). All this practice does, however, is add repetition that
+					is not only disruptive when reading but can make the structure of the publication harder to follow.
+					It is therefore advised not to attempt to rebuild structures in these ways.</p>
 
 				<p>For example, consider a book that has five parts and each part contains five chapters. Structurally,
 					each chapter belongs to its part (i.e., is grouped with it), as in the following markup:</p>


### PR DESCRIPTION
I've made the changes to I mention in #2992 in this pull request.  In a nutshell:

- the "understanding this objective" sections will be in the new note
- the non-techniques will be in the new note
- the explanatory role stuff goes to the aria authoring guide

Once the understanding doc is further along we can add references to it.

Fixes #2992 

***

EPUB Accessibility:
- [Preview](https://raw.githack.com/w3c/epub-specs/editorial/issue-2992/epub34/a11y/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Feditorial%2Fissue-2992%2Fepub34%2Fa11y%2Findex.html)

EPUB Accessibility Techniques:
- [Preview](https://raw.githack.com/w3c/epub-specs/editorial/issue-2992/epub34/a11y-tech/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-tech%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Feditorial%2Fissue-2992%2Fepub34%2Fa11y-tech%2Findex.html)

EPUB type to Aria roles:
- [Preview](https://raw.githack.com/w3c/epub-specs/editorial/issue-2992/wg-notes/epub-aria-authoring/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fwg-notes%2Fepub-aria-authoring%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Feditorial%2Fissue-2992%2Fwg-notes34%2Fepub-aria-authoring%2Findex.html)
