### PR TITLE
Add understanding document and reflow description

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -250,59 +250,67 @@
 			<section id="reflow">
 				<h3>Reflow</h3>
 
-				<p>The [[wcag2]] <a data-cite="wcag2#reflow">reflow success criterion (1.4.10)</a> seeks to ensure that
-					content remains readable for users with low vision as they enlarge it. It requires that there be no
-					loss of information or readability for vertically scrolling content at a width equivalent to 320 CSS
-					pixels.</p>
+				<section id="reflow-application">
+					<h4>Application</h4>
 
-				<div class="note">
-					<p>As EPUB reading systems do not support horizontally scrolling text, and such content is rarely
-						produced even on the web generally, the requirement for horizontally scrolling content at a
-						height of 256 CSS pixels is not discussed in this section.</p>
-				</div>
+					<p>The [[wcag2]] <a data-cite="wcag2#reflow">reflow success criterion (1.4.10)</a> seeks to ensure
+						that content remains readable for users with low vision as they enlarge it. It requires that
+						there be no loss of information or readability for vertically scrolling content at a width
+						equivalent to 320 <a data-cite="wcag2#dfn-css-pixels">CSS pixels</a> [[wcag2]].</p>
 
-				<p>The first thing to note about this success criterion is that the "scrolling" aspect of the definition
-					applies to all EPUB publications whether they are read in a reading system that lays out the content
-					in a scrolling manner or whether the reading system dynamically paginates the content. Dynamic
-					pagination is just a feature of EPUB that takes a vertically scrolled document and splits it up for
-					reading in a book-like manner.</p>
+					<div class="note">
+						<p>As EPUB reading systems do not support horizontally scrolling text, and such content is
+							rarely produced even on the web generally, the requirement for horizontally scrolling
+							content at a height of 256 CSS pixels is not discussed in this section.</p>
+					</div>
 
-				<p>The second thing to note is that the width and height sizes do not refer to the actual screen
-					resolution of the device. The emphasis of the success criterion is on equivalence up to these sizes,
-					which is why it notes that a viewport with a width of 1280 CSS pixels is equivalent to a width of
-					320 CSS pixels when it is zoomed to 400%. The example is just a common screen resolution and
-					exhibits easy math to the 320 CSS pixel maximum.</p>
+					<p>The first thing to note about this success criterion is that the "scrolling" aspect of the
+						definition applies to all EPUB publications whether they are read in a reading system that lays
+						out the content in a scrolling manner or whether the reading system dynamically paginates the
+						content. Dynamic pagination is just a feature of EPUB that takes a vertically scrolled document
+						and splits it up for reading in a book-like manner.</p>
 
-				<p>What happens when zooming a 1280 CSS pixel viewport beyond 320 CSS pixels is out of scope, as is
-					zooming any other starting resolution after it exceeds 320 CSS pixels in width. The success
-					criterion is not saying that all viewports greater in width than 320 CSS pixels are out of
-					scope.</p>
+					<p>The second thing to note is that the width and height sizes do not refer to the actual screen
+						resolution of the device. The emphasis of the success criterion is on equivalence up to these
+						sizes, which is why it notes that a viewport with a width of 1280 CSS pixels is equivalent to a
+						width of 320 CSS pixels when it is zoomed to 400%. The example is just a common screen
+						resolution and exhibits easy math to the 320 CSS pixel maximum.</p>
 
-				<p>The good thing about reflowable EPUB publications when it comes to meeting this success criterion is
-					that they were designed to work exactly in the manner it expects. A reflowable EPUB publication is
-					expected to work on many different device screens and with many different user preferences applied.
-					The content has to reflow to fit within the paginated environment that reading systems provide as
-					users rarely can scroll the content &#8212; if it does not fit in the viewport, it is typically
-					inaccessible to all users. Publishers are typically already aware of these reflow issues and how to
-					ensure their content does not break.</p>
+					<p>What happens when zooming a 1280 CSS pixel viewport beyond 320 CSS pixels is out of scope, as is
+						zooming any other starting resolution after it exceeds 320 CSS pixels in width. The success
+						criterion is not saying that all viewports greater in width than 320 CSS pixels are out of
+						scope.</p>
 
-				<p>It does not mean that all reflowable EPUB publications get an automatic pass on this success
-					criterion, but only that the circumstances where the content will not reflow are not common.</p>
+					<p>The good thing about reflowable EPUB publications when it comes to meeting this success criterion
+						is that they were designed to work exactly in the manner it anticipates. A reflowable EPUB
+						publication is expected to work on many different device screens and with many different user
+						preferences applied. The content has to reflow to fit within the paginated environment that
+						reading systems provide as users rarely can scroll the content &#8212; if the content does not
+						fit in the viewport, it is typically inaccessible to all users. Publishers are typically already
+						aware of these reflow issues and how to ensure their content does not break.</p>
 
-				<p>The most likely source of failure is going to arise with container elements, such as with the
-					[[html]] [^aside^], [^div^], [^nav^] and similar elements used to group content. When these elements
-					are assigned fixed widths, their ability to adapt to changes in zoom diminish.</p>
+					<p>It does not mean that all reflowable EPUB publications get an automatic pass on this success
+						criterion, but only that the circumstances where the content will not reflow are not common.</p>
+				</section>
 
-				<p>The content of an [[html]] [^aside^] element used as a sidebar, for example, will reflow by default
-					to so that its content fits the available screen space. But if a width, or a minimum width, greater
-					than 320 CSS pixels is assigned via CSS, then as the content is zoomed the dimensions of the
-					viewport may become smaller than the width of the <code>aside</code>.</p>
+				<section id="reflow-container-widths">
+					<h4>Container widths</h4>
 
-				<aside class="example" title="Problematic container width settings">
-					<p>In the first CSS rule, the width declaration does not allow the sidebar to shrink below 500px. In
-						the second, the minimum width declaration similarly would stop the sidebar from shrinking below
-						480px (assuming that 1em is equal to 16px in this case).</p>
-					<pre>aside.sidebar {
+					<p>The most likely source of failure for the reflow success criterion is going to arise with
+						container elements, such as with the [[html]] [^aside^], [^div^], [^nav^] and similar elements
+						used to group content. When these elements are assigned fixed widths, their ability to adapt to
+						changes in zoom diminish.</p>
+
+					<p>The content of an [[html]] [^aside^] element used as a sidebar, for example, will reflow by
+						default to so that its content fits the available screen space. But if a width, or a minimum
+						width, greater than 320 CSS pixels is assigned, then as the content is zoomed the dimensions of
+						the viewport may become smaller than the width of the <code>aside</code>.</p>
+
+					<aside class="example" title="Problematic container width settings">
+						<p>In the first CSS rule, the width declaration does not allow the sidebar to shrink below
+							500px. In the second, the minimum width declaration similarly would stop the sidebar from
+							shrinking below 480px (assuming that 1em is equal to 16px in this case).</p>
+						<pre>aside.sidebar {
    width: 500px
 }
 
@@ -310,85 +318,107 @@ aside.sidebar {
 	min-width: 30em;
 }
 </pre>
-				</aside>
+					</aside>
 
-				<p>When a user zooms their publication, what typically will happen with EPUB reading systems is that the
-					sidebar will extend outside the boundary of the page/viewport, causing its text to be cut off and
-					becomes inaccessible.</p>
+					<p>When a user zooms their publication, what typically will happen with EPUB reading systems is that
+						the sidebar will extend outside the boundary of the page/viewport, causing its text to be cut
+						off and become inaccessible.</p>
 
-				<p>But even the sidebar is made scrollable using the CSS <code>overflow</code> property, the result
-					still fails this success criterion because the content now requires scrolling on the x axis to reach
-					the hidden overflow text.</p>
+					<p>But even if the sidebar is made scrollable using <a data-cite="css-overflow#overflow-properties"
+							>CSS overflow properties</a> [[css-overflow]], the result still fails this success criterion
+						because the content now requires scrolling on the x axis to reach the hidden overflow text.</p>
 
-				<aside class="example" title="Invalid scrolling">
-					<p>The previous CSS rule is modified to allow scrolling but the content cannot require scrolling and
-						meet the success criterion.</p>
-					<pre>aside.sidebar {
+					<aside class="example" title="Invalid scrolling">
+						<p>The previous CSS rule is modified to allow scrolling but since the content will require
+							scrolling on the x-axis it will fail the success criterion.</p>
+						<pre>aside.sidebar {
    width: 500px;
    overflow: scroll
 }
 </pre>
-				</aside>
+					</aside>
 
-				<p>Any hoped-for value in assigning fixed widths to container elements in reflowable content is
-					generally going to be offset by the problems it will cause with the reflow success criterion. If a
-					size must be specified (e.g., to ensure that boxes of content always fill the width of the
-					viewport), the more accessible way is to use a unit that adapts to changes in the viewport. Setting
-					a percentage (<code>%</code>) or viewport width (<code>vw</code>) no greater than 100 percent of the
-					viewport size will avoid scroll bars appearing as the content is zoomed.</p>
+					<p>Any hoped-for value in assigning fixed widths to container elements in reflowable content is
+						generally going to be offset by the problems it will cause with the reflow success criterion. If
+						a size must be specified (e.g., to ensure that boxes of content always fill the width of the
+						viewport), the more accessible way is to use a unit that adapts to changes in the viewport.
+						Setting a percentage (<code>%</code>) or viewport width (<code>vw</code>) no greater than 100
+						percent of the viewport size will avoid scroll bars appearing as the content is zoomed.</p>
 
-				<p>When testing this success criterion, be aware that app-based reading systems typically do not allow
-					zooming of reflowable content. They are more likely to support font size increases up to 400% of the
-					default, but increasing the font size is not the same as zooming the content.</p>
+					<div class="note">
+						<p>Container elements can require vertical scrolling. The reflow success criterion only requires
+							that the content not require scrolling on the opposite axis.</p>
+					</div>
+				</section>
 
-				<p>The reflow success criterion does not, in fact, specify requirements on the font size as the content
-					is enlarged. The requirement for text to enlarge up to 200% is instead addressed by the [[wcag2]] <a
-						data-cite="wcag2#resize-text">resize text success criterion</a>. Large words, hyperlinks, code
-					examples, and other strings of contiguous text with no break points can also pose problems for
-					reflow as the viewport reaches 320 CSS pixels, but the text is not required to stay the same font
-					size as the content is enlarged. The font size could, for example, be reduced using a media query so
-					that it stays at 200% the original size as the viewport nears 320 CSS pixels.</p>
+				<section id="reflow-font-size">
+					<h4>Font size</h4>
 
-				<div class="note">
-					<p>For a more detailed description of the interaction between the reflow and resize text success
-						criteria, refer to the <a
-							href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#resize-text">reflow
-							understanding document explanation of the two</a>.</p>
-				</div>
+					<p>When testing this success criterion, be aware that app-based reading systems typically do not
+						allow zooming of reflowable content. They are more likely to support font size increases up to
+						400% of the default, but increasing the font size is not the same as zooming the content.</p>
 
-				<p>Other strategies to prevent large text strings causing scrolling include using the [[html]] [^wbr^]
-					element to specify word break locations, using the CSS <code>overflow-wrap</code> and
-						<code>word-break</code> properties, or using the Unicode soft hyphen character.</p>
+					<p>The reflow success criterion does not, in fact, specify requirements on the font size as the
+						content is enlarged. The requirement for text to enlarge up to 200% is instead addressed by the
+						[[wcag2]] <a data-cite="wcag2#resize-text">resize text success criterion</a>.</p>
 
-				<p>Not all content is required to reflow as it is enlarged. The success criterion makes an exception for
-					content that would lose its meaning if it were reflowed. For reflowable publications, the most
-					common content that requires two-dimensional layout are diagrams, charts, maps and similar
-					images.</p>
+					<div class="note">
+						<p>For a more detailed description of the interaction between the reflow and resize text success
+							criteria, refer to the <a
+								href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#resize-text">reflow
+								understanding document explanation of the two</a>.</p>
+					</div>
+				</section>
 
-				<p>Data tables are also exempt due to their grid nature, but the individual cells within them are not.
-					This means that it would not be unreasonable for the user to have to scroll to reach all the
-					columns, but the content with a column must not require scrolling in two dimensions to read.</p>
+				<section id="reflow-large-text-strings">
+					<h4>Large text strings</h4>
 
-				<p>Content that can be scrolled in two dimensions needs to always be checked that it has been authored
-					so that it can indeed be scrolled this way. Reading systems will often try to compress tables to fit
-					the available space, for example, but when that cannot be done the overflow outside the page
-					boundary will not be accessible. A common practice to avoid this is to wrap the two-dimensional
-					content in a container that allows scrolling (e.g., a <code>table</code> can be placed inside a
-						<code>div</code> that provides it more space for rendering and includes scrollbars to move
-					around the columns and rows). But when using this practice, content that does not depend on two
-					dimensions for comprehension cannot be captured in the scroll. If a table has a caption, for
-					example, only the table can scroll on the x axis to meet the success criterion; the text of the
-					caption cannot require scrolling.</p>
+					<p>Large words, hyperlinks, code examples, and other strings of contiguous text with no break points
+						can also pose problems for reflow as the viewport reaches 320 CSS pixels, but the text is not
+						required to stay the same font size as the content is enlarged. The font size could, for
+						example, be reduced using a media query so that it stays at 200% the original size as the
+						viewport nears 320 CSS pixels.</p>
 
-				<div class="note">
-					<p>Vertically scrolling content can contain content that requires vertical scrolling. The reflow
-						success criterion only requires that the content not require scrolling on the opposite axis.</p>
-				</div>
+					<p>Other strategies to prevent large text strings causing scrolling include using the [[html]]
+						[^wbr^] element to specify word break locations, using the CSS <code>overflow-wrap</code> and
+							<code>word-break</code> properties, or using the Unicode soft hyphen character.</p>
+				</section>
 
-				<p>Although the reflow success criterion does not pose a lot of problems for reflowable EPUB
-					publications, it is one of the most problematic to meet for fixed-layout EPUB publications as
-					reading systems do not reflow the content of a fixed-layout page as it is zoomed. The issues with
-					fixed layouts and reflow are discussed in [[[epub-fxl-a11y]]] [[epub-fxl-a11y]].</p>
+				<section id="reflow-exempt-content">
+					<h4>Exempt content</h4>
+
+					<p>Not all content is required to reflow as it is enlarged. The success criterion makes an exception
+						for content that would lose its meaning if it were reflowed. For reflowable publications, the
+						most common content that requires two-dimensional layout are diagrams, charts, maps and similar
+						images.</p>
+
+					<p>Data tables are also exempt due to their grid nature, but the individual cells within them are
+						not. This means that it would not be unreasonable for the user to have to scroll to reach all
+						the columns, but the content with a column must not require scrolling in two dimensions to
+						read.</p>
+
+					<p>Content that can be scrolled in two dimensions needs to always be checked that it has been
+						authored so that it can indeed be scrolled this way. Reading systems will often try to compress
+						tables to fit the available space, for example, but when that cannot be done the overflow
+						outside the page boundary will not be accessible. A common practice to avoid this is to wrap the
+						two-dimensional content in a container that allows scrolling (e.g., a <code>table</code> can be
+						placed inside a <code>div</code> that provides it more space for rendering and includes
+						scrollbars to move around the columns and rows). But when using this practice, content that does
+						not depend on two dimensions for comprehension cannot be captured in the scroll. If a table has
+						a caption, for example, only the table can scroll on the x axis to meet the success criterion;
+						the text of the caption cannot require scrolling.</p>
+				</section>
+
+				<section id="reflow-fxl">
+					<h4>Fixed layouts</h4>
+
+					<p>Although the reflow success criterion does not pose a lot of problems for reflowable EPUB
+						publications, it is one of the most problematic to meet for fixed-layout EPUB publications as
+						reading systems do not reflow the content of a fixed-layout page as it is zoomed.</p>
+
+					<p>This guide does not address the problems with making fixed-layout publication accessible. For
+						more information on this topic, refer to [[[epub-fxl-a11y]]] [[epub-fxl-a11y]].</p>
+				</section>
 			</section>
 		</section>
 		<section id="epub">

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -1,0 +1,622 @@
+<!DOCTYPE html>
+<html lang="en-US">
+	<head>
+		<meta charset="utf-8" />
+		<title>Understanding EPUB Accessibility 1.2</title>
+		<meta name="color-scheme" content="light dark" />
+		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../../common/js/fix-errata.js" class="remove"></script>
+		<script src="../../common/js/css-inline.js" class="remove"></script>
+		<script class="remove">
+			var respecConfig = {
+				group: "pm",
+				wgPublicList: "public-pm-wg",
+				specStatus: "ED",
+				shortName: "epub-a11y-understand-12",
+				noRecTrack: true,
+				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
+                copyrightStart: "2026",
+				editors:[ {
+					name: "Matt Garrish",
+					company: "DAISY Consortium",
+                    companyURL: "https://daisy.org",
+					w3cid: 51655
+				}],
+				includePermalinks: true,
+				permalinkEdge: true,
+				permalinkHide: false,
+				github: {
+					repoURL: "https://github.com/w3c/epub-specs",
+					branch: "main"
+				},
+				profile: "web-platform",
+				localBiblio: {
+					"epub-3": {
+						"title": "EPUB 3",
+						"href": "https://www.w3.org/TR/epub/",
+						"publisher": "W3C"
+					},
+					"wai-aria": {
+						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
+						"href": "https://www.w3.org/TR/wai-aria/",
+						"publisher": "W3C"
+					},
+					"wcag2": {
+						"title": "Web Content Accessibility Guidelines (WCAG) 2",
+						"href": "https://www.w3.org/TR/WCAG2/",
+						"publisher": "W3C"
+					}
+				},
+				postProcess: [fixErrataField]
+			};</script>
+		<style>
+			pre {
+				white-space: break-spaces !important;
+			}</style>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>The Understanding EPUB Accessibility guide provides information on how to evaluate the accessible content
+				conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against reflowable EPUB
+				publications.</p>
+		</section>
+		<section id="sotd"></section>
+		<section id="intro">
+			<h2>Introduction</h2>
+
+			<section id="overview">
+				<h3>Overview</h3>
+
+				<p>&#8230;</p>
+			</section>
+
+			<section id="scope">
+				<h3>Scope</h3>
+
+				<p>This document is limited in focus to <a data-cite="epub-3#sec-reflowable">reflowable EPUB
+						publications</a> [[epub-3]].</p>
+
+				<p>It does not provide techniques for meeting the objectives of [[[epub-a11y-12]]. Refer to
+					[[[epub-a11y-tech-12]]] for more information about how to meet specific success criteria and
+					objectives.</p>
+
+				<p>Although, in many cases, the guidance will also prove useful for evaluating <a
+						data-cite="epub-3#sec-fixed-layouts">fixed-layout EPUB publications</a> [[epub-3]], making those
+					kinds of publications accessible presents unique challenges. Guidance on making fixed layouts more
+					accessible is instead provided in [[[epub-fxl-a11y]]] [[epub-fxl-a11y]].</p>
+			</section>
+		</section>
+		<section id="wcag">
+			<h2>WCAG success criteria</h2>
+
+			<section id="accessible-authentication">
+				<h3>Accessible Authentication</h3>
+
+				<p>The [[wcag2]] accessible authentication success criteria &#8212; both the <a
+						data-cite="wcag2#accessible-authentication-minimum">minimum (3.3.8)</a> and <a
+						data-cite="wcag2#accessible-authentication-enhanced">enhanced (3.3.9)</a> &#8230;</p>
+			</section>
+
+			<section id="bypass-blocks">
+				<h3>Bypass blocks</h3>
+
+				<p>Web sites are constructed very differently from EPUB publications. A typical web site wraps the
+					content of each page within a repeating template, for example. This template gives each page a
+					consistent look and feel, but users are rarely interested in the wrapper content after visiting the
+					first page. Visual readers can typically skip past the site header, navigation bars, search boxes,
+					and other helpful but seldom-used features to get right to the content.</p>
+
+				<p>To provide the same ease of access to readers who would have to navigate sequentially through the
+					repetitive content, the [[wcag2]] <a href="https://www.w3.org/TR/WCAG/#bypass-blocks">bypass blocks
+						success criterion (2.4.1)</a> requires a means of bypassing the repeated content in a set of
+					pages. This success criterion does not apply to typical EPUB publications, however, as EPUB content
+					documents do not repeat content in the same way that web sites do.</p>
+
+				<p>Each new content document might begin with similar content, such as learning objectives or key terms,
+					but this content is part of the body of the publication and not identical to what came before.
+					Consequently, it is not required to add a link to skip it. (Secondary content still needs to be
+					identified in accordance with <a href="https://www.w3.org/TR/WCAG/#info-and-relationships">success
+						criterion 1.3.1</a>, however.)</p>
+
+				<div class="note">
+					<p>If an EPUB publication were to reproduce a set of web pages with their full site trappings, then
+						success criterion 2.4.1 would apply, but this practice is not common.</p>
+				</div>
+			</section>
+
+			<section id="consistent-help">
+				<h3>Consistent help</h3>
+
+				<p>The [[wcag2]] <a data-cite="wcag2#consistent-help">consistent help success criterion (3.2.6)</a>
+					&#8230;</p>
+			</section>
+
+			<section id="consistent-navigation">
+				<h3>Consistent navigation</h3>
+
+				<p>The [[wcag2]] <a data-cite="wcag2#consistent-navigation">consistent navigation success criterion
+						(3.2.3)</a> &#8230;</p>
+			</section>
+
+			<section id="meaningful-sequence">
+				<h3>Meaningful sequence</h3>
+
+				<p>The [[wcag2]] <a data-cite="wcag2#meaningful-sequence">meaningful sequence success criterion
+						(1.3.2)</a> specifies that each web page have a meaningful order (i.e., that the visual
+					presentation of the content match the underlying markup).</p>
+
+				<p>As EPUB allows two <a data-cite="epub-3/#dfn-epub-content-document">EPUB content documents</a> to be
+					rendered together in a <a data-cite="epub/#spread">synthetic spread</a> [[epub-3]], the order of
+					content within a single document cannot always be evaluated in isolation. Content might span
+					visually from one document to the next. For example, a sidebar might span the bottom of two
+					pages.</p>
+
+				<p>Ordering each document separately by the visual display will lead to users of <a
+						data-cite="epub-a11y#dfn-assistive-technology">assistive technologies</a> encountering gaps
+					between the start and end of the spanned text. If the markup cannot be arranged to provide a more
+					logical reading experience (e.g., the beginning of the spanned content at the end of the first page
+					followed by the conclusion at the start of the next), another means of satisfying this criteria will
+					be necessary to avoid failure (e.g., a hyperlink could be provided to allow a user to jump from the
+					break point on the first page to the continuation on the next).</p>
+			</section>
+
+			<section id="multiple-ways">
+				<h3>Multiple ways</h3>
+
+				<p>The [[wcag2]] <a data-cite="wcag2#multiple-ways">multiple ways success criterion</a> requires that
+					web users are able to locate content within a set of pages on a site. This ensures that there are at
+					least two ways to reach any information.</p>
+
+				<p>This requirement is equally helpful for reading digital publications like EPUB because without
+					multiple ways to reach into a publication a user would have to manually swipe or click from page to
+					page to read. If this were the case, readers of print books would have better access, as they could
+					read page to page or flip through the pages using the page numbers to locate a passage they are
+					looking for.</p>
+
+				<p>Fortunately, EPUB publications, unlike web site, will typically always minimally meet this success
+					criterion both because of the way they are constructed and because of common affordances offered by
+					reading systems.</p>
+
+				<p>From an authoring perspective, the primary requirements are to list all <a
+						data-cite="epub/#sec-spine-elem">all EPUB content documents in the spine</a> and to ensure that
+					users have a secondary means of <a data-cite="epub/#sec-itemref-elem">accessing all non-linear
+						documents</a> [[epub-3]]. This ensures that users have a means of accessing all the content
+					either by paging through the publication, for linear content, or following hyperlinks to reach any
+					non-linear content a reading system might not show in the default presentation.</p>
+
+				<p>EPUB's requirement for a table of contents provides the second method of access. It is possible that
+					a publication could fail this success criterion by proividing an incomplete table of contents, but
+					such occurrences are rare. (Refer to the <a href="#sec-toc-completeness">note on the completeness of
+						the table of contents</a> for further discussion.)</p>
+
+				<p>While these two basic requirements of EPUB satisfy the need for multiple ways to access the content
+					on their own, publications often contain additional methods of access, such as:</p>
+
+				<ul>
+					<li>topical indexes;</li>
+					<li>static page break markers;</li>
+					<li><a data-cite="epub-3/#sec-nav-pagelist">a page list</a> [[epub-3]].</li>
+				</ul>
+
+				<p>Reading systems also facilitate access into the content through text search capability and also via
+					the ability to jump to dynamically generated pages.</p>
+
+				<section id="sec-toc-completeness" class="notoc">
+					<h4>Note about the table of contents</h4>
+
+					<p>A common question about the EPUB table of contents is what completeness it needs to have with
+						respect to the headings of the publication. Although the obvious answer is to create a simple
+						aggregation of all the headings for all the sections, practically there are several usability
+						challenges to this approach.</p>
+
+					<p>Factors such as device screen sizes can make the table of contents for publications with a deep
+						hierarchy of headings unreadable, so headings below a certain depth get trimmed to improve the
+						readability. Further, <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not
+						always provide structured access to the headings in the table of contents, or provide shortcuts
+						to navigate the links. The result is that users have to listen to each link one at a time to
+						find where they want to go, a tedious and time-consuming process.</p>
+
+					<p>Although it is expected that reading systems will improve access to the table of contents as
+						accessibility support for EPUB evolves — making complete tables of contents usable by everyone —
+						there are legitimate usability reasons why they are not provided now.</p>
+
+					<p>When opting not to provide links to all the headings, it is best to optimize the links that are
+						provided to improve the overall reading experience. Some considerations on how to achieve this
+						include:</p>
+
+					<ul>
+						<li>
+							<p>ensuring that there is at least one link to every <a
+									data-cite="epub/#dfn-epub-content-document">EPUB content document</a> — allowing the
+								user to reach each document simplifies navigation to the minor headings within them;
+								and</p>
+						</li>
+						<li>
+							<p>only omitting minor headings from the table of contents — although a subjective decision,
+								there is often a level of diminishing value for navigation (e.g., fourth level and lower
+								headings often only delimit short subsections on a topic).</p>
+						</li>
+					</ul>
+				</section>
+			</section>
+
+			<section id="redundant-entry">
+				<h3>Redundant entry</h3>
+
+				<p>The [[wcag2]] <a data-cite="wcag2#redundant-entry">redundant entry success criterion (3.3.7)</a>
+					&#8230;</p>
+			</section>
+
+			<section id="reflow">
+				<h3>Reflow</h3>
+
+				<p>The [[wcag2]] <a data-cite="wcag2#reflow">reflow success criterion (1.4.10)</a> seeks to ensure that
+					content remains readable for users with low vision as they enlarge it. It requires that there be no
+					loss of information or readability for vertically scrolling content at a width equivalent to 320 CSS
+					pixels.</p>
+
+				<div class="note">
+					<p>As EPUB reading systems do not support horizontally scrolling text, and such content is rarely
+						produced even on the web generally, the requirement for horizontally scrolling content at a
+						height of 256 CSS pixels is not discussed in this section.</p>
+				</div>
+
+				<p>The first thing to note about this success criterion is that the "scrolling" aspect of the definition
+					applies to all EPUB publications whether they are read in a reading system that lays out the content
+					in a scrolling manner or whether the reading system dynamically paginates the content. Dynamic
+					pagination is just a feature of EPUB that takes a vertically scrolled document and splits it up for
+					reading in a book-like manner.</p>
+
+				<p>The second thing to note is that the width and height sizes do not refer to the actual screen
+					resolution of the device. The emphasis of the success criterion is on equivalence up to these sizes,
+					which is why it notes that a viewport with a width of 1280 CSS pixels is equivalent to a width of
+					320 CSS pixels when it is zoomed to 400%. The example is just a common screen resolution and
+					exhibits easy math to the 320 CSS pixel maximum.</p>
+
+				<p>What happens when zooming a 1280 CSS pixel viewport beyond 320 CSS pixels is out of scope, as is
+					zooming any other starting resolution after it exceeds 320 CSS pixels in width. The success
+					criterion is not saying that all viewports greater in width than 320 CSS pixels are out of
+					scope.</p>
+
+				<p>The good thing about reflowable EPUB publications when it comes to meeting this success criterion is
+					that they were designed to work exactly in the manner it expects. A reflowable EPUB publication is
+					expected to work on many different device screens and with many different user preferences applied.
+					The content has to reflow to fit within the paginated environment that reading systems provide as
+					users rarely can scroll the content &#8212; if it does not fit in the viewport, it is typically
+					inaccessible to all users. Publishers are typically already aware of these reflow issues and how to
+					ensure their content does not break.</p>
+
+				<p>It does not mean that all reflowable EPUB publications get an automatic pass on this success
+					criterion, but only that the circumstances where the content will not reflow are not common.</p>
+
+				<p>The most likely source of failure is going to arise with container elements, such as with the
+					[[html]] [^aside^], [^div^], [^nav^] and similar elements used to group content. When these elements
+					are assigned fixed widths, their ability to adapt to changes in zoom diminish.</p>
+
+				<p>The content of an [[html]] [^aside^] element used as a sidebar, for example, will reflow by default
+					to so that its content fits the available screen space. But if a width, or a minimum width, greater
+					than 320 CSS pixels is assigned via CSS, then as the content is zoomed the dimensions of the
+					viewport may become smaller than the width of the <code>aside</code>.</p>
+
+				<aside class="example" title="Problematic container width settings">
+					<p>In the first CSS rule, the width declaration does not allow the sidebar to shrink below 500px. In
+						the second, the minimum width declaration similarly would stop the sidebar from shrinking below
+						480px (assuming that 1em is equal to 16px in this case).</p>
+					<pre>aside.sidebar {
+   width: 500px
+}
+
+aside.sidebar {
+	min-width: 30em;
+}
+</pre>
+				</aside>
+
+				<p>When a user zooms their publication, what typically will happen with EPUB reading systems is that the
+					sidebar will extend outside the boundary of the page/viewport, causing its text to be cut off and
+					becomes inaccessible.</p>
+
+				<p>But even the sidebar is made scrollable using the CSS <code>overflow</code> property, the result
+					still fails this success criterion because the content now requires scrolling on the x axis to reach
+					the hidden overflow text.</p>
+
+				<aside class="example" title="Invalid scrolling">
+					<p>The previous CSS rule is modified to allow scrolling but the content cannot require scrolling and
+						meet the success criterion.</p>
+					<pre>aside.sidebar {
+   width: 500px;
+   overflow: scroll
+}
+</pre>
+				</aside>
+
+				<p>Any hoped-for value in assigning fixed widths to container elements in reflowable content is
+					generally going to be offset by the problems it will cause with the reflow success criterion. If a
+					size must be specified (e.g., to ensure that boxes of content always fill the width of the
+					viewport), the more accessible way is to use a unit that adapts to changes in the viewport. Setting
+					a percentage (<code>%</code>) or viewport width (<code>vw</code>) no greater than 100 percent of the
+					viewport size will avoid scroll bars appearing as the content is zoomed.</p>
+
+				<p>When testing this success criterion, be aware that app-based reading systems typically do not allow
+					zooming of reflowable content. They are more likely to support font size increases up to 400% of the
+					default, but increasing the font size is not the same as zooming the content.</p>
+
+				<p>The reflow success criterion does not, in fact, specify requirements on the font size as the content
+					is enlarged. The requirement for text to enlarge up to 200% is instead addressed by the [[wcag2]] <a
+						data-cite="wcag2#resize-text">resize text success criterion</a>. Large words, hyperlinks, code
+					examples, and other strings of contiguous text with no break points can also pose problems for
+					reflow as the viewport reaches 320 CSS pixels, but the text is not required to stay the same font
+					size as the content is enlarged. The font size could, for example, be reduced using a media query so
+					that it stays at 200% the original size as the viewport nears 320 CSS pixels.</p>
+
+				<div class="note">
+					<p>For a more detailed description of the interaction between the reflow and resize text success
+						criteria, refer to the <a
+							href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#resize-text">reflow
+							understanding document explanation of the two</a>.</p>
+				</div>
+
+				<p>Other strategies to prevent large text strings causing scrolling include using the [[html]] [^wbr^]
+					element to specify word break locations, using the CSS <code>overflow-wrap</code> and
+						<code>word-break</code> properties, or using the Unicode soft hyphen character.</p>
+
+				<p>Not all content is required to reflow as it is enlarged. The success criterion makes an exception for
+					content that would lose its meaning if it were reflowed. For reflowable publications, the most
+					common content that requires two-dimensional layout are diagrams, charts, maps and similar
+					images.</p>
+
+				<p>Data tables are also exempt due to their grid nature, but the individual cells within them are not.
+					This means that it would not be unreasonable for the user to have to scroll to reach all the
+					columns, but the content with a column must not require scrolling in two dimensions to read.</p>
+
+				<p>Content that can be scrolled in two dimensions needs to always be checked that it has been authored
+					so that it can indeed be scrolled this way. Reading systems will often try to compress tables to fit
+					the available space, for example, but when that cannot be done the overflow outside the page
+					boundary will not be accessible. A common practice to avoid this is to wrap the two-dimensional
+					content in a container that allows scrolling (e.g., a <code>table</code> can be placed inside a
+						<code>div</code> that provides it more space for rendering and includes scrollbars to move
+					around the columns and rows). But when using this practice, content that does not depend on two
+					dimensions for comprehension cannot be captured in the scroll. If a table has a caption, for
+					example, only the table can scroll on the x axis to meet the success criterion; the text of the
+					caption cannot require scrolling.</p>
+
+				<div class="note">
+					<p>Vertically scrolling content can contain content that requires vertical scrolling. The reflow
+						success criterion only requires that the content not require scrolling on the opposite axis.</p>
+				</div>
+
+				<p>Although the reflow success criterion does not pose a lot of problems for reflowable EPUB
+					publications, it is one of the most problematic to meet for fixed-layout EPUB publications as
+					reading systems do not reflow the content of a fixed-layout page as it is zoomed. The issues with
+					fixed layouts and reflow are discussed in [[[epub-fxl-a11y]]] [[epub-fxl-a11y]].</p>
+			</section>
+		</section>
+		<section id="epub">
+			<h2>EPUB objectives</h2>
+
+			<section id="page-nav">
+				<h3>Page navigation</h3>
+
+				<section id="page-breaks">
+					<h4>Page breaks</h4>
+
+					<p>Inserting <a data-cite="epub-a11y#sec-page-breaks">page break markers</a> [[epub-a11y]] into an
+							<a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> provides users with context
+						about where they are in the text. <a data-cite="epub-a11y#dfn-assistive-technology">Assistive
+							technologies</a> [[epub-a11y]] can use this information to announce the current page number
+						the user is on, for example, if the user wants to cite something on the page.</p>
+
+					<p>The inclusion of page break markers can also allow users to move quickly forwards and backwards
+						by page without having to access the page list each time.</p>
+
+					<p>The inclusion of these markers also simplifies the creation of a <a href="#page-list">page
+							list</a>, as they provide easily referenced destinations for the links.</p>
+				</section>
+
+				<section id="page-list">
+					<h4>Page list</h4>
+
+					<p>The <a data-cite="epub-a11y#sec-page-list">page list</a> [[epub-a11y]] is the primary means of
+						navigating to page break locations as it provides a list of links to each of the static page
+						break locations in the <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a>.</p>
+
+					<p><a data-cite="epub-3#dfn-epub-reading-system">Reading systems</a> typically use this list to
+						generate a "go to page" interface in which users can plug in the page number that they wish to
+						move to, but sometimes offer users the ability to access the full list and select the page
+						number to go to.</p>
+
+					<p>Without a page list, page navigation becomes extremely difficult as it would rely on navigating
+						the individual <a href="#page-breaks">page break markers</a> (if they are even present).</p>
+				</section>
+
+				<section id="page-source">
+					<h4>Page source</h4>
+
+					<p>Users need to know the <a data-cite="epub-a11y#sec-page-src">source of the pagination</a>
+						[[epub-a11y]] in an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> to determine
+						whether it will be useful for their needs. Print publications, for example, produced in both
+						hard and soft cover editions will have different pagination. Different editions of the same book
+						often also have different pagination.</p>
+
+					<p>Including a recognizable identifier for the statically paginated source, such as its ISBN or
+						ISSN, ensures that users can determine which version the pagination corresponds to.</p>
+				</section>
+			</section>
+
+			<section id="sync-media">
+				<h3>Synchronized text-audio playback</h3>
+
+				<section id="completeness">
+					<h4>Completeness</h4>
+
+					<p>Although it is possible for users who require a publication in audio form to use text-to-speech
+						playback, the experience is considerably poorer than when pre-recorded narration is provided.
+						Text-to-speech engines have limited built-in vocabularies, causing them to mangle and
+						mispronounce most uncommon words they encounter. As a result users have to have words repeated
+						and spelled out to make sense of the content, slowing down their reading and reducing
+						comprehension.</p>
+
+					<p>For this reason, it is important to provide narration for the full text of a publication in
+						addition to the full text. Users can then decide which reading modality they prefer &#8212;
+						text, audio, or a mix of the two.</p>
+				</section>
+
+				<section id="escapability">
+					<h4>Escapability</h4>
+
+					<p>When reading visually, users can quickly move through, and escape from, highly structured content
+						such as sidebars, lists, and figures. Visual readers can skim lists and quickly return to the
+						primary narrative once they locate the desired information, for example. The same is true for
+						reading figures and sidebars, as they are visually offset from the primary narrative so easily
+						jumped into and out of.</p>
+
+					<p>The same ease of escaping from content is only possible if <a
+							data-cite="epub-3#dfn-epub-publication">EPUB publications</a> include structural semantics
+						in the synchronized text/audio format. Users might not be able to escape from lists, sidebars,
+						figures, and other highly structured content, without the structural semantics of those elements
+						being available.</p>
+
+					<p>When the synchronized text-audio playback instructions include this information, <a
+							data-cite="epub-3#dfn-epub-reading-system">reading systems</a> can simplify playback for
+						auditory readers to enable a comparable reading experience.</p>
+				</section>
+
+				<section id="nav-doc">
+					<h4>Navigation document</h4>
+
+					<p>Reading systems typically provide their own interfaces to the navigation aids in the EPUB
+						navigation document. For example, they open the table of contents as a specialized interface on
+						top of the content the user is reading.</p>
+
+					<p>To access these interfaces, users typically rely on text-to-speech playback, when available, to
+						hear the entries.</p>
+
+					<p>Providing synchronized text-audio playback for the EPUB navigation document provides reading
+						systems the ability to use auditory labels for the links, improving the experience for auditory
+						readers.</p>
+				</section>
+
+				<section id="sync-reading-order">
+					<h4>Reading order</h4>
+
+					<p>Every <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> has a default reading order
+						that allows users to progress through the content. The default reading order consists of two
+						parts: the order of references in the spine provides a high-level progression through the <a
+							data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a> that make up the
+						publication, while the markup within each EPUB content document provides the default progression
+						through the content elements (i.e., as represented in the document object model [[?dom]]).</p>
+
+					<p>For many languages, the default reading order also matches the logical reading order &#8212; the
+						way that users will naturally follow the narrative. It ensures that readers can follow the
+						primary narrative and that they encounter secondary content where the author intended it to be
+						read. The default reading order also establishes some less obvious relations, like the progress
+						within a table from cell to cell and row to row.</p>
+
+					<p>If the sequence of the synchronized text-audio playback does not match this progression, it can
+						cause confusion for readers, whether they are only listening to the audio or trying to also
+						follow visually.</p>
+
+					<p>Ordering the playback to match the default reading order is the safest way to ensure that users
+						can follow the text. In some cases, however, strict adherence to this practice can result in a
+						suboptimal reading experience (e.g., playback of a table by column instead of row might make
+						more natural sense in some cases). These publications have a logical reading order that cannot
+						match the default order of the elements of the host format.</p>
+
+					<p>The goal of this objective is not to forbid alternate presentations, but to ensure that
+						deviations are only made to better represent the logical reading order of the content.</p>
+				</section>
+
+				<section id="skippability">
+					<h4>Skippability</h4>
+
+					<p>Being able to read the primary narrative of a work without interruption is central to reading
+						comprehension. <a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> are typically
+						structured to visually represent secondary information such as page break markers and footnotes
+						outside the main narrative flow (e.g., by using different background colors or placement so
+						readers can filter this information visually out while reading).</p>
+
+					<p>Readers who prefer auditory playback, however, cannot skip this information with the same ease in
+						a linear audio-based reading experience. And, without structural semantics, synchronized
+						text-audio playback cannot offer skipping content either.</p>
+
+					<p>When the synchronized text-audio playback instructions include structural semantics, however, <a
+							data-cite="epub-3#dfn-epub-reading-system">reading systems</a> can create reading
+						experiences that allow users to decide which secondary content to skip by default.</p>
+				</section>
+			</section>
+		</section>
+		<section id="eval">
+			<h2>Evaluation considerations</h2>
+
+			<section id="content-type">
+				<h3>Content type considerations</h3>
+
+				<!--
+				<p>Although there are fifty six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]], it is
+					rarely the case that all of these will apply when evaluating an EPUB publication. Although WCAG
+					breaks the success critieria up by the <em>POUR</em> categorization &#8212; perceivable, operable,
+					understanding, and robust &#8212; many of the success criteria can also be categorized by the type
+					of content they apply to.</p>
+
+				<p>Accessible scripting is the focus of a number of success criteria given the highly dynamic nature of
+					the modern web. The following success criteria are all conditional on a publication even having
+					scripted content:</p>
+
+				<ul>
+					<li>1.3.5 Identify Input Purpose</li>
+					<li>2.2.1 Timing Adjustable</li>
+					<li>2.2.2 Pause, Stop, Hide</li>
+					<li>2.5.1 Pointer Gestures</li>
+					<li>2.5.2 Pointer Cancellation</li>
+					<li>2.5.3 Label in Name</li>
+					<li>2.5.4 Motion Actuation</li>
+					<li>3.2.1 On Focus</li>
+					<li>3.2.2 On Input</li>
+					<li>3.2.4 Consistent Identification</li>
+					<li>3.3.1 Error Identification</li>
+					<li>3.3.2 Labels or Instructions</li>
+					<li>3.3.3 Error Suggestion</li>
+					<li>3.3.4 Error Prevention (Legal, Financial, Data)</li>
+					<li>3.3.7 Redundant Entry</li>
+					<li>3.3.8 Accessible Authentication (Minimum)</li>
+					<li>4.1.2 Name, Role, Value</li>
+					<li>4.1.3 Status Messages</li>
+				</ul>
+
+				<p>Most reflowable publications do not include scripts because scripting is now well supported in
+					reading systems and even when it does work the dynamic pagination of reflowable publications can
+					often break scripted interfaces. So, right away the number of success criteria to check drops from
+					56 to 39 for unscripted reflowable publications.</p>
+
+				<p>Similarly, many novels consist only of text and headings, so all of the following success criteria
+					for mulitmedia would not need to be checked:</p>
+
+				<ul>
+					<li>1.1.1 Non-text Content</li>
+					<li>1.2.1 Audio-only and Video-only (Prerecorded)</li>
+					<li>1.2.2 Captions (Prerecorded)</li>
+					<li>1.2.3 Audio Description or Media Alternative (Prerecorded)</li>
+					<li>1.2.4 Captions (Live)</li>
+					<li>1.2.5 Audio Description (Prerecorded)</li>
+					<li>1.4.2 Audio Control</li>
+					<li>1.4.5 Images of Text</li>
+				</ul>
+				-->
+			</section>
+
+			<section id="eval-not-applicable">
+				<h3>Reporting inapplicable success criteria</h3>
+
+				<p>If a success criterion does not apply to an EPUB publication, it should never be reported as an
+					unqualified pass. Doing so would give the false impression that the publication contains the
+					inapplicable content and that it was found to be conforming.</p>
+
+				<p>When reporting success criteria that do not apply to a publication, it is recommended to label their
+					status as "not applicable" (or an equivalent language-specific term). If a "pass" value must be
+					assigned by the reporting template used, then a comment should be included that clearly states that
+					the publication contains no applicable content.</p>
+			</section>
+		</section>
+		<section id="index"></section>
+	</body>
+</html>

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -476,7 +476,7 @@ aside.sidebar {
 			<section id="sync-media">
 				<h3>Synchronized text-audio playback</h3>
 
-				<section id="completeness">
+				<section id="sync-completeness">
 					<h4>Completeness</h4>
 
 					<p>Although it is possible for users who require a publication in audio form to use text-to-speech
@@ -491,7 +491,7 @@ aside.sidebar {
 						text, audio, or a mix of the two.</p>
 				</section>
 
-				<section id="escapability">
+				<section id="sync-escapability">
 					<h4>Escapability</h4>
 
 					<p>When reading visually, users can quickly move through, and escape from, highly structured content
@@ -511,7 +511,7 @@ aside.sidebar {
 						auditory readers to enable a comparable reading experience.</p>
 				</section>
 
-				<section id="nav-doc">
+				<section id="sync-nav-doc">
 					<h4>Navigation document</h4>
 
 					<p>Reading systems typically provide their own interfaces to the navigation aids in the EPUB
@@ -556,7 +556,7 @@ aside.sidebar {
 						deviations are only made to better represent the logical reading order of the content.</p>
 				</section>
 
-				<section id="skippability">
+				<section id="sync-skippability">
 					<h4>Skippability</h4>
 
 					<p>Being able to read the primary narrative of a work without interruption is central to reading


### PR DESCRIPTION
Rather than spring a giant document on people like the metadata guide, I'm going to try and build this one up by piecework.

Most of the text in the document is a direct copy over from the sections I removed in #2995. I wouldn't suggest spending a lot of time reading it over yet as I'll probably do more edits on these as I expand the document.

The empty placeholder sections are just success criteria that were mentioned in the open issues. There may be others. We can figure that out as we go.

I decided to try and tackle the reflow section first since I figured it would be the most headache inducing. That's the main one to review for this pull request. Let me know if you think anything doesn't sound right.

I put a small scope section in for now, too, but I'm going to wait on an overview until it's clearer what all we're going to address with this document.

***

[Preview](https://raw.githack.com/w3c/epub-specs/add/a11y-understanding/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fadd%2Fa11y-understanding%2Fepub34%2Fa11y-understand%2Findex.html)
