### PR TITLE
Addiing "Software" as an alias to as:Application

### DIFF
--- a/epub34/annotations-vocab/index.context.jsonld
+++ b/epub34/annotations-vocab/index.context.jsonld
@@ -133,6 +133,7 @@
                 }
             }
         },
+        "Software": "http://www.w3.org/ns/ea#Software",
         "Target": {
             "@id": "http://www.w3.org/ns/ea#Target",
             "@context": {

--- a/epub34/annotations-vocab/index.html
+++ b/epub34/annotations-vocab/index.html
@@ -296,8 +296,7 @@
                 <dl class="terms">
                     <dt>Subclass of:</dt>
                     <dd><a href="http://xmlns.com/foaf/0.1/Person"><code>foaf:Person</code></a> ⊔&nbsp;<a
-                            href="http://xmlns.com/foaf/0.1/Organization"><code>foaf:Organization</code></a> ⊔&nbsp;<a
-                            href="http://www.w3.org/ns/activitystreams#Application"><code>as:Application</code></a></dd>
+                            href="http://xmlns.com/foaf/0.1/Organization"><code>foaf:Organization</code></a> ⊔&nbsp;<a href="#Software"><code>Software</code></a></dd>
                 </dl>
                 <dl class="terms">
                     <dt>Range of:</dt>
@@ -376,6 +375,20 @@
                     <dd><a href="#refinedBy"><code>refinedBy</code></a>, <a href="#selector"><code>selector</code></a></dd>
                     <dt>Domain of:</dt>
                     <dd><a href="#refinedBy"><code>refinedBy</code></a></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Relevant <code>@context</code>:</dt>
+                    <dd><a href="https://www.w3.org/ns/epub-anno.jsonld"><code>https://www.w3.org/ns/epub-anno.jsonld</code></a></dd>
+                </dl>
+            </section>
+            <section id="Software">
+                <h4><code>Software</code></h4>
+                <p><em>Software</em></p>
+                <div>This class is an "alias" of the <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-application"><code>as:Application</code></a> class, using a
+                    terminology more widely used in practice.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="http://www.w3.org/ns/activitystreams#Application"><code>as:Application</code></a></dd>
                 </dl>
                 <dl class="terms">
                     <dt>Relevant <code>@context</code>:</dt>

--- a/epub34/annotations-vocab/index.jsonld
+++ b/epub34/annotations-vocab/index.jsonld
@@ -12,6 +12,7 @@
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "vs": "http://www.w3.org/2003/06/sw-vocab-status/ns#",
+        "schema": "http://schema.org/",
         "jsonld": "http://www.w3.org/ns/json-ld#",
         "dc:date": {
             "@type": "xsd:date"
@@ -80,7 +81,7 @@
         "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/epub-anno-vocab-10/",
-    "dc:date": "2026-04-22",
+    "dc:date": "2026-05-19",
     "rdfs_properties": [{
         "@id": "ea:about",
         "@type": ["rdf:Property", "owl:ObjectProperty"],
@@ -428,7 +429,7 @@
         "@type": "rdfs:Class",
         "rdfs:subClassOf": {
             "@type": "owl:Class",
-            "owl:unionOf": ["foaf:Person", "foaf:Organization", "as:Application"]
+            "owl:unionOf": ["foaf:Person", "foaf:Organization", "ea:Software"]
         },
         "rdfs:label": "Creator of an EPUB Annotation",
         "rdfs:comment": {
@@ -497,6 +498,20 @@
             "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
         },
         "rdfs:isDefinedBy": "https://www.w3.org/TR/epub-anno-10/#dfn-selector",
+        "vs:term_status": "stable",
+        "mentioned": [{
+            "@id": "https://www.w3.org/ns/epub-anno.jsonld",
+            "@type": "jsonld:Context"
+        }]
+    }, {
+        "@id": "ea:Software",
+        "@type": "rdfs:Class",
+        "rdfs:subClassOf": ["as:Application"],
+        "rdfs:label": "Software",
+        "rdfs:comment": {
+            "@value": "<div>This class is an \"alias\" of the <a href=\"https://www.w3.org/TR/activitystreams-vocabulary/#dfn-application\"><code>as:Application</code></a> class, using a terminology more widely used in practice.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
         "vs:term_status": "stable",
         "mentioned": [{
             "@id": "https://www.w3.org/ns/epub-anno.jsonld",

--- a/epub34/annotations-vocab/index.ttl
+++ b/epub34/annotations-vocab/index.ttl
@@ -10,13 +10,15 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix jsonld: <http://www.w3.org/ns/json-ld#> .
 
 # Ontology definition
 ea: a owl:Ontology ;
     dc:title """EPUB Annotations Vocabulary 1.0"""@en ;
     dc:description """RDFS [[rdf-schema]] vocabulary formalizing the terms defined in the [[[epub-anno-10]]] specification. The vocabulary is a "profile" of the W3C [[[annotation-vocab]]]"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/epub-anno-vocab-10/> ;
-    dc:date "2026-04-22"^^xsd:date ;
+    dc:date "2026-05-19"^^xsd:date ;
 .
 
 # Property definitions
@@ -213,7 +215,7 @@ ea:Body a rdfs:Class ;
 .
 
 ea:Creator a rdfs:Class ;
-    rdfs:subClassOf [ a owl:Class; owl:unionOf (foaf:Person foaf:Organization as:Application) ] ;
+    rdfs:subClassOf [ a owl:Class; owl:unionOf (foaf:Person foaf:Organization ea:Software) ] ;
     rdfs:label "Creator of an EPUB Annotation" ;
     rdfs:comment """<div>JSON-LD serializations should use the terms <code>Person</code>, <code>Organization</code>, or <code>Software</code> for typing, as these are the only available creator types.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://www.w3.org/TR/epub-anno-10/#dfn-creator-object>, <http://www.w3.org/ns/ea#> ;
@@ -247,6 +249,14 @@ ea:Selector a rdfs:Class ;
     rdfs:label "EPUB Annotation selector" ;
     rdfs:comment """<div>A restrictive subset of selectors, usable in EPUB.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://www.w3.org/TR/epub-anno-10/#dfn-selector>, <http://www.w3.org/ns/ea#> ;
+    vs:term_status "stable" ;
+.
+
+ea:Software a rdfs:Class ;
+    rdfs:subClassOf as:Application ;
+    rdfs:label "Software" ;
+    rdfs:comment """<div>This class is an "alias" of the <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-application"><code>as:Application</code></a> class, using a terminology more widely used in practice.</div>"""^^rdf:HTML ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/ea#> ;
     vs:term_status "stable" ;
 .
 
@@ -332,6 +342,7 @@ ea:outline a rdfs:Resource ;
         ea:Generator,
         ea:Meta,
         ea:Selector,
+        ea:Software,
         ea:Target,
         ea:about,
         ea:blue,

--- a/epub34/annotations-vocab/index.yml
+++ b/epub34/annotations-vocab/index.yml
@@ -79,7 +79,7 @@ class:
       label: Creator of an EPUB Annotation
       comment: JSON-LD serializations should use the terms <code>Person</code>, <code>Organization</code>, or <code>Software</code> for typing, as these are the only available creator types.
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-creator-object
-      upper_value: [foaf:Person, foaf:Organization, as:Application]
+      upper_value: [foaf:Person, foaf:Organization, ea:Software]
       upper_union: true
 
     - id: FragmentSelector
@@ -102,6 +102,10 @@ class:
       defined_by: https://www.w3.org/TR/epub-anno-10/#dfn-selector
       upper_value: [ea:FragmentSelector, oa:CssSelector, oa:TextPositionSelector]
       upper_union: true
+
+    - id: Software
+      comment: This class is an "alias" of the <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-application"><code>as:Application</code></a> class, using a terminology more widely used in practice.
+      upper_value: as:Application
 
     - id: Target
       label: Target of an EPUB Annotation.


### PR DESCRIPTION
(This was forgotten): we use the ter "Software" for Generators but the OA refers to an activity stream term only. An alias is put into the vocabulary definition