### PR TITLE
add section for authentication success criteria

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -89,12 +89,100 @@
 		<section id="wcag">
 			<h2>WCAG success criteria</h2>
 
-			<section id="accessible-authentication">
-				<h3>Accessible Authentication</h3>
+			<section id="authentication">
+				<h3>Authentication</h3>
 
-				<p>The [[wcag2]] accessible authentication success criteria &#8212; both the <a
-						data-cite="wcag2#accessible-authentication-minimum">minimum (3.3.8)</a> and <a
-						data-cite="wcag2#accessible-authentication-enhanced">enhanced (3.3.9)</a> &#8230;</p>
+				<section id="authentication-application">
+					<h4>Application</h4>
+
+					<p>There are two [[wcag2]] accessible authentication success criteria &#8212; a <a
+							data-cite="wcag2#accessible-authentication-minimum">minimum (3.3.8)</a> and an <a
+							data-cite="wcag2#accessible-authentication-enhanced">enhanced (3.3.9)</a> version &#8212; as
+						well as a related success criterion for <a data-cite="wcag2#re-authenticating">re-authentication
+							(2.2.5)</a>. These have a combined goal of ensuring that users with certain cognitive
+						disabilities are provided an easy-to-use and accessible login method for protected web sites,
+						and that information is not lost if users have to reauthenticate themselves.</p>
+
+					<p>Not all users are able to remember usernames and passwords, transcribe verification access codes,
+						or solve puzzles to gain entry which is why it is important that logins do not rely solely on
+						methods that require these kinds of cognitive capabilities. It is also vital to ensure that
+						users do not lose any information they have input if they are required to reauthenticate as this
+						could prevent some users from being able to complete the task (i.e., they may continue to reach
+						the time out just trying to re-enter the lost information).</p>
+
+					<p>It is not common that these success criteria will apply to EPUB publications, however. When a
+						login is required, the more typical scenario is that a vendor will require users to log in to
+						their reading system to access their publications. In this case, if the login does not meet the
+						requirements of the minimum success criterion, then it is the reading system that is not
+						accessible, not the individual publications it provides access to. Similarly, if the reading
+						system loses the current state of a quiz or task at the time it forces reauthentication, there
+						is nothing the publication can do about this.</p>
+
+					<p>Even in the case of EPUB publications served through a learning management system (LMS), it is
+						more typical for the user to log in to the LMS. The LMS may use that information to track their
+						activity, but again it is rarely the publications within the LMS that are secured.</p>
+
+					<p>One major reason that EPUB publications typically do not build in login requirements is because
+						scripting support is not guaranteed. The reading system is more reliably going to have a
+						connection to, or be able to connect to, the user's network. It is also more capable of being
+						able to store information for later transmission to a publisher's server when a connection is
+						not immediately available, as persistent storage is also not commonly available within EPUB
+						publications. The lack of persistent state also means that a login in one EPUB content document
+						likely will not persist into any of the others. That means a user might, for example, have to
+						log in at the end of every chapter to complete embedded quizzes.</p>
+				</section>
+
+				<section id="authentication-locating">
+					<h4>Locating</h4>
+
+					<p>Despite the potential drawbacks of adding authentication to EPUB publications, nothing prevents a
+						publisher from using logins. They are much rarer than on the web because a publication belongs
+						to one user and so it does not have to be blocked internally from public access and there is no
+						question if the user is human or not. Authentication typically only matters in the case where
+						the publisher has to collect information; for example, from quizzes and other interactive
+						content.</p>
+
+					<p>For these reasons, it is unlikely that logins will be found outside of educational material,
+						which can help narrow down when to look for them. Since a login will typically require the user
+						to have an account with the publisher, they are less likely to be found in general reading
+						material.</p>
+
+					<p>But, while it may be highly uncommon to find logins, their possibility cannot be ignored when
+						performing an accessibility review.</p>
+
+					<p>Unfortunately, there is no quick way to determine if a publication has a login attached to any of
+						its content short of manually checking. The only useful aid that an EPUB publication provides is
+						the scripting designation that has to be expressed in the package document manifest.</p>
+
+					<aside class="example" title="Scripted content document designation">
+						<pre>&lt;package xmlns="http://www.idpf.org/2007/opf" &#8230;>
+   &lt;manifest>
+      &lt;item id="chap01" href="xhtml/chapter01.html" media-type="application/xhtml+xml" properties="scripted"/>
+      &#8230;
+   &lt;/manifest>
+   &#8230;
+&lt;/package></pre>
+					</aside>
+
+					<p>Knowing which files are scripted may help reduce the amount of work involved in finding logins,
+						but that is only if scripting is used sparingly in the publication. If most or all of the EPUB
+						content documents are scripted, it might be easier to read the JavaScript files. Even without a
+						strong knowledge of scripting, the names of the various functions might provide clues to their
+						purpose. For example, a function with "login" in its name would be a major flag to look more
+						deeply into what the scripting is doing.</p>
+
+					<p>Ultimately, direct testing of all scripted content for accessibility is always advised (i.e., not
+						trying to gauge the accessibility by looking only at the markup), so as long as an assessment is
+						thorough in this regard any logins should be found in due course.</p>
+
+					<p>If a login is found, checking for a reauthentication requirement may still take some work. It
+						should never be assumed that lack of mention of a timed session means that users will not be
+						prompted to reauthenticate after a certain amount of time, or a certain amount of time without
+						activity being registered. Verifying if there is a timeout, and checking what happens after
+						reauthenticating, may require inspecting code to understand when a timeout is triggered. If the
+						evaluator is not the publisher of the content, it may be faster to check with publisher whether
+						session timeouts can occur and how best to test them.</p>
+				</section>
 			</section>
 
 			<section id="bypass-blocks">


### PR DESCRIPTION
Adds the section on authentication - covering the two accessible authentication success criteria plus the related success criterion on reauthentication.

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/authentication/epub34/a11y-understand/index.html#authentication

Comments always welcome on these changes.

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/authentication/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Fauthentication%2Fepub34%2Fa11y-understand%2Findex.html)
