### PR TITLE
Fix glossterm HTML usage context.

### DIFF
--- a/wg-notes/ssv/index.html
+++ b/wg-notes/ssv/index.html
@@ -1158,7 +1158,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>The glossterm property is implied on
-							[=dd=] elements within a [=dl=] element marked with the <a href="#glossary">glossary</a>
+							[=dt=] elements within a [=dl=] element marked with the <a href="#glossary">glossary</a>
 							property.</p>
 					</dd>
 					<dd>


### PR DESCRIPTION
Since `dl[epub:type="glossary"] > dd` is specified as implied to be _glossdef_, I assume _glossterm_ should be implied from `... > dt`.