### PR TITLE
Sectioning errors in export/import section

### DIFF
--- a/epub34/annotations/index.html
+++ b/epub34/annotations/index.html
@@ -1212,21 +1212,22 @@
                 Such implementations may safely ignore the context
                 declarations and are not required to dereference the respective URLs.
             </p>
+        </section>
+
+        <section>
+            <h2>Sharing AnnotationSets</h2>
+            <p> An AnnotationSet can be shared as a detached file, or embedded in an EPUB package.
+                The advantage of detached annotations is that they can be shared independently of the publication,
+                and that they can be associated with a publication without modifying it.
+                The advantage of embedded annotations is that they are always available to users of the publication,
+                without any need to import them.
+            </p>
+
+            <p class="note">
+                Reading Systems are not required to store annotations with such a format: this format is for export and import purposes.
+            </p>
 
             <section>
-
-                <p> An AnnotationSet can be shared as a detached file, or embedded in an EPUB package.
-                    The advantage of detached annotations is that they can be shared independently of the publication,
-                    and that they can be associated with a publication without modifying it.
-                    The advantage of embedded annotations is that they are always available to users of the publication,
-                    without any need to import them.
-
-                <p class="note">
-                    Reading Systems are not required to store annotations with such a format: this format is for export and import purposes.
-                </p>
-
-                </p>
-
                 <h2>Detached annotations</h2>
 
                 <p> For packaging the set of constituent resources that comprise an AnnotationSet,


### PR DESCRIPTION
Some `section` elements were wrongly placed, creating inaccurate structuring.

---

See:

* For EPUB Annotations 1.0:
    * [Preview](https://raw.githack.com/w3c/epub-specs/annotations/sectioning-editorial-error/epub34/annotations/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fannotations%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fannotations%2Fsectioning-editorial-error%2Fepub34%2Fannotations%2Findex.html)
