### PR TITLE
Add section on consistent help

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -127,8 +127,55 @@
 			<section id="consistent-help">
 				<h3>Consistent help</h3>
 
-				<p>The [[wcag2]] <a data-cite="wcag2#consistent-help">consistent help success criterion (3.2.6)</a>
-					&#8230;</p>
+				<p>The goal of the [[wcag2]] <a data-cite="wcag2#consistent-help">consistent help success criterion
+						(3.2.6)</a> is to ensure that when a help mechanism is provided across a set of pages, it is
+					consistently located for discovery by users. Consistent placement ensure that, for example,
+					non-visual users and users with cognitive disabilities can easily locate the help information if
+					they are having difficulty completing a task.</p>
+
+				<p>The application of this success criterion to EPUB publications, however, is nowhere near as prevalent
+					as it is for the web. First off, the success criterion is limited to the following types of
+					help:</p>
+
+				<ul>
+					<li>human contact details;</li>
+					<li>human contact mechanism;</li>
+					<li>self-help option;</li>
+					<li>a fully automated contact mechanism.</li>
+				</ul>
+
+				<p>It does not apply to instructional help that might be provided for forms &#8212; for example, for
+					embedded tests, quizzes, and other interactive content. Its focus is on help mechanisms such as a
+					phone number or email address to contact a site owner, or a link out to a frequently asked questions
+					site, or an option to open a chat window, or an embedded contact form.</p>
+
+				<div class="note">
+					<p>This success criterion does not require these kinds of help mechanisms; its focus is only on
+						their consistently placement when present.</p>
+				</div>
+
+				<p>It is not that these kinds of contact features will never occur in publications, but it is rare that
+					they are repeated across documents. When publishers provide help contact information, it is usually
+					only provided once, either in a front or back matter section. In this case, since the contact
+					information is not repeated there is no consistency issue.</p>
+
+				<div class="note">
+					<p>The success criterion does not require a publisher to be consistent in where they locate this
+						information from book to book, but it is helpful to users to place it in the same location.</p>
+				</div>
+
+				<p>But just because it is not common to repeat contact information does not mean it cannot occur. If a
+					publisher includes quizzes at the end of each chapter, they might choose to add their contact
+					information to the beginning or end of each quiz to make it easier for users to find and be able to
+					reach out to them. In this case, the placement has to be consistent. If the contact information is
+					at the start of the first quiz, it needs to be placed at the start of each subsequent quiz. It
+					cannot be at the start of some of the quizzes and at the end of others.</p>
+
+				<p>So, although rare, care needs to be taken not to skip evaluating an EPUB publication for consistent
+					help. Educational material is the most likely to have repeated contact information due to their
+					inclusion of tests, quizzes, and games, but any time embed interactive content is found a quick
+					check should be made that there is not a repeating help mechanism that falls under this success
+					criterion.</p>
 			</section>
 
 			<section id="consistent-navigation">


### PR DESCRIPTION
I keep trying to find a way to merge this with consistent navigation but they're slightly different than just having content in the same location - consistent navigation also has requirements for the navigation links within the aid. Maybe after I write up that section something will come to me, but for now I'm keeping them separate.

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/consistent-help/epub34/a11y-understand/index.html#consistent-help

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/consistent-help/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Fconsistent-help%2Fepub34%2Fa11y-understand%2Findex.html)
