### PR TITLE
Add section on consistent navigation

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -134,8 +134,83 @@
 			<section id="consistent-navigation">
 				<h3>Consistent navigation</h3>
 
-				<p>The [[wcag2]] <a data-cite="wcag2#consistent-navigation">consistent navigation success criterion
-						(3.2.3)</a> &#8230;</p>
+				<section id="consistent-navigation-application">
+					<h4>Application</h4>
+
+					<p>The [[wcag2]] <a data-cite="wcag2#consistent-navigation">consistent navigation success criterion
+							(3.2.3)</a> has a similar goal to the <a href="#consistent-help">consistent help success
+							criterion</a> but in this case the objective is to make it easier for users on the web to
+						find and use repeated navigational aids such as tables of contents, search boxes, and skip to
+						content links. Having these aids in the same location, and the links within them ordered in the
+						same way (when the links repeat), simplifies navigating a site.</p>
+
+					<p>But many of these kinds of navigation aids are not included in EPUB publications, at least in a
+						way that they fall on the publisher to make accessible (i.e., being available across multiple
+						content documents). It is the user's reading system that is going to make access to the table of
+						contents, or landmarks, or page list, or a search box consistently available in its user
+						interface. Likewise, information about what (virtual) page the user is on is handled by the
+						reading system. Even the EPUB equivalent of a skip to content link &#8212; a landmark to the
+						first page of body matter &#8212; is information for the reading system to use to advance the
+						user; it is not content the user directly encounters in the publication.</p>
+
+					<p>If the reading system were to change the order of access to these features in the middle of
+						reading a publication, that would be a failure of the reading system not the publisher.
+						Similarly, if it were to change the order of the links within a navigation element &#8212; for
+						example, change the order of the landmark links &#8212; that would also be a failure of the
+						reading system.</p>
+
+					<div class="note">
+						<p>Including the EPUB navigation document in the spine does not fall under the success criterion
+							because it is a one-time placement and not available across the other spine items.</p>
+					</div>
+				</section>
+
+				<section id="consistent-navigation-mini-toc">
+					<h4>Mini tables of contents</h4>
+
+					<p>The most common case where the consistent navigation success criterion applies to EPUB
+						publication is when chapters include mini tables of contents at their start. These are most
+						typically found in educational works to provide quick access to all the subsections of a major
+						topic.</p>
+
+					<p>In this case, the position of each of these mini tables of contents needs to be consistent
+						relative to any other content at the beginning of the chapter or section. If the first mini
+						table of contents occurs after the first chapter heading, for example, then the same pattern has
+						to be followed in each subsequent chapter.</p>
+
+					<p>It is also worth noting that the pattern of placement has to be consistent, not that the same
+						elements always have to appear. For example, if some chapters have a title followed by an
+						epigraph, followed by an image to illustrate the concept being covered before the mini table of
+						contents is provided, then it is acceptable if some chapters omit the epigraph and/or image so
+						long as the order of the elements before the navigation is always consistent. It would only be a
+						failure if the mini table of contents is sometimes placed before the heading, or between the
+						epigraph and image.</p>
+
+					<p>The order of links within the mini tables of contents is not likely going to be relevant to check
+						for this success criterion. Because each chapter's content is unique, the links are never going
+						to be repeated from one chapter to the next so there is not a consistent order that has to be
+						maintained.</p>
+				</section>
+
+				<section id="consistent-navigation-page-numbering">
+					<h4>Page numbering</h4>
+
+					<p>Although page numbers provide a form of static navigation aid &#8212; indicating to the user
+						where they are in a publication &#8212; consistent placement of them is in reflowable EPUB
+						publications is out of scope for this success criterion. Page break markers in these documents
+						will occur arbitrarily at locations that typically correspond to a statically paginated
+						equivalent, like a print copy of the book.</p>
+
+					<p>The consistent identification of page break markers in reflowable publications is more typically
+						a concern of the reading system, as it will provide the user the page number somewhere in its
+						user interface.</p>
+
+					<div class="note">
+						<p>Page number location can be a concern with fixed-layout publications, particularly if they
+							reproduce print-equivalent page headers and footers. Refer to [[[epub-fxl-a11y]]]
+							[[epub-fxl-a11y]] for more information.</p>
+					</div>
+				</section>
 			</section>
 
 			<section id="meaningful-sequence">

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -196,7 +196,7 @@
 					<h4>Page numbering</h4>
 
 					<p>Although page numbers provide a form of static navigation aid &#8212; indicating to the user
-						where they are in a publication &#8212; consistent placement of them is in reflowable EPUB
+						where they are in a publication &#8212; their consistent placement in reflowable EPUB
 						publications is out of scope for this success criterion. Page break markers in these documents
 						will occur arbitrarily at locations that typically correspond to a statically paginated
 						equivalent, like a print copy of the book.</p>


### PR DESCRIPTION
Another new section. If anyone can think of any other repeating navigation aids, let me know.

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/consistent-nav/epub34/a11y-understand/index.html#consistent-navigation

(Edit: fixed the links to the right branch name.)

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/consistent-nav/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Fconsistent-nav%2Fepub34%2Fa11y-understand%2Findex.html)
