### PR TITLE
Move 1.2 strings to top of conformance list

### DIFF
--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1078,27 +1078,28 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>The following conformance strings are valid as of publication of this specification:</p>
+					<p id="conf-strings">The following conformance strings are valid as of publication of this
+						specification:</p>
 
 					<ul>
-						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level A</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level A</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level A</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level A</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AAA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level A</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AAA</li>
 						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level A</li>
 						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AA</li>
 						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AAA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AAA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AAA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level A</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level A</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level A</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</li>
 					</ul>
 
 					<div class="note">

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1081,27 +1081,38 @@
 					<p id="conf-strings">The following conformance strings are valid as of publication of this
 						specification:</p>
 
-					<ul>
-						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level A</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AAA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level A</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AAA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level A</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AA</li>
-						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AAA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level A</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level A</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level A</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</li>
-						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</li>
-					</ul>
-
+					<details open="">
+						<summary>For EPUB Accessibility 1.2</summary>
+						
+						<ul>
+							<li>EPUB Accessibility 1.2 - WCAG 2.2 Level A</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AA</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AAA</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.1 Level A</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AA</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AAA</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.0 Level A</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AA</li>
+							<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AAA</li>
+						</ul>
+					</details>
+					
+					<details>
+						<summary>For older versions</summary>
+						
+						<ul>
+							<li>EPUB Accessibility 1.1 - WCAG 2.2 Level A</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.1 Level A</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.0 Level A</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</li>
+							<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</li>
+						</ul>
+					</details>
+					
 					<div class="note">
 						<p>The list of valid conformance strings will increase as W3C releases new versions of WCAG.</p>
 

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -1025,25 +1025,14 @@
 						after <a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]], exactly matches
 						(i.e., both in case and spacing) the following pattern:</p>
 
-					<p class="conf-pattern">EPUB Accessibility <a href="#acc-ver"><var>A11Y-VER</var></a> - WCAG <a
-							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
-						><var>WCAG-LVL</var></a></p>
+					<p class="conf-pattern">EPUB Accessibility 1.2 - WCAG <a href="#wcag-ver"><var>WCAG-VER</var></a>
+						Level <a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
 
 					<p>
 						<i>where:</i>
 					</p>
 
 					<dl class="varlist">
-						<dt id="acc-ver">
-							<var>A11Y-VER</var>
-						</dt>
-						<dd>
-							<p>Specifies the version number of the EPUB Accessibility specification the publication
-								conforms to. The value MUST NOT be lower than <code>1.1</code> as the 1.0 version of
-								this specification used a different conformance identification scheme.</p>
-							<p>The value MUST be <code>1.2</code> to indicate conformance to this version of the
-								specification.</p>
-						</dd>
 						<dt id="wcag-ver">
 							<var>WCAG-VER</var>
 						</dt>
@@ -1078,48 +1067,26 @@
 &lt;/package></pre>
 					</aside>
 
-					<p id="conf-strings">The following conformance strings are valid as of publication of this
-						specification:</p>
+					<p id="conf-strings">The following strings are valid for identifying conformance to this
+						specification</p>
 
-					<details open="">
-						<summary>For EPUB Accessibility 1.2</summary>
-						
-						<ul>
-							<li>EPUB Accessibility 1.2 - WCAG 2.2 Level A</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AA</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AAA</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.1 Level A</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AA</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AAA</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.0 Level A</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AA</li>
-							<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AAA</li>
-						</ul>
-					</details>
-					
-					<details>
-						<summary>For older versions</summary>
-						
-						<ul>
-							<li>EPUB Accessibility 1.1 - WCAG 2.2 Level A</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AA</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.2 Level AAA</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.1 Level A</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.0 Level A</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</li>
-							<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</li>
-						</ul>
-					</details>
-					
+					<ul>
+						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.2 Level AAA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.1 Level AAA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level A</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AA</li>
+						<li>EPUB Accessibility 1.2 - WCAG 2.0 Level AAA</li>
+					</ul>
+
 					<div class="note">
-						<p>The list of valid conformance strings will increase as W3C releases new versions of WCAG.</p>
-
-						<p>In addition, <a href="https://www.w3.org/TR/wcag-3.0/">WCAG 3.0</a> is set to introduce new
-							level names (currently Bronze, Silver and Gold). Those names will likely replace A, AA, and
-							AAA in the string pattern, but conformance will be addressed after that specification
-							becomes a <a href="https://www.w3.org/policies/process/#RecsW3C">W3C Recommendation</a>.</p>
+						<p><a href="https://www.w3.org/TR/wcag-3.0/">WCAG 3.0</a> is set to introduce new level names
+							(currently Bronze, Silver and Gold). Those names will likely replace A, AA, and AAA in the
+							string pattern, but conformance will be addressed after that specification becomes a <a
+								href="https://www.w3.org/policies/process/#RecsW3C">W3C Recommendation</a>.</p>
 					</div>
 
 					<section class="informative">


### PR DESCRIPTION
I noticed that the list of conformance strings starts with the 1.1 strings first. Since this is the 1.2 standard, it seems more appropriate that the list begin with 1.2 conformance strings.

Also, since we recommend always conforming to the latest version of WCAG, I reordered the list so that the 2.2 identifiers are first, then 2.1, and finally 2.0.

Finally, to deemphasize old versions and to avoid the list of strings occupying greater and greater space, I added two details elements to group them. The first is open by default and lists the strings for the current version. The second is collapsed and will be where we can hide all the old identifiers that are still valid but not relevant to the current document anymore.

Thoughts on these changes welcome.

***

[Preview](https://raw.githack.com/w3c/epub-specs/editorial/conf-id-order/epub34/a11y/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Feditorial%2Fconf-id-order%2Fepub34%2Fa11y%2Findex.html)
