### PR TITLE
Add section for redundant entry

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -243,8 +243,43 @@
 			<section id="redundant-entry">
 				<h3>Redundant entry</h3>
 
-				<p>The [[wcag2]] <a data-cite="wcag2#redundant-entry">redundant entry success criterion (3.3.7)</a>
-					&#8230;</p>
+				<p>The goal of the [[wcag2]] <a data-cite="wcag2#redundant-entry">redundant entry success criterion
+						(3.3.7)</a> is to prevent users from having to enter the same information again when completing
+					a multi-step process on the web. This reduces memory requirements and stress for users with
+					cognitive and learning disabilities.</p>
+
+				<p>A common example of when this success criterion applies to web content is when checking out at an
+					ecommerce store. Users' billing and shipping addresses are most often the same, so requiring them to
+					re-input the same information in separate steps increases the cognitive difficulty of the checkout
+					process. A checkbox to automatically use the billing address as the shipping address is now a
+					ubiquitous pattern to avoid this issue.</p>
+
+				<p>But this is one of the WCAG success criteria that has greater application on the web than in the
+					world of digital publications. The primary reason is that few publications contain multi-step
+					processes that collect the same information at different steps.</p>
+
+				<p>A multi-step process does not require a change in documents, or for the current document to fully
+					refresh, so it is possible that users will encounter them in publications. All that is required is
+					that a sequence of steps are required to complete a task. But the most common case of collecting
+					information in an EPUB publication is when quizzes are embedded. These are not typically split up so
+					that users have to complete one part of the quiz before the next becomes available, however.</p>
+
+				<p>It is even rarer that the same information would be asked for in multiple parts of a quiz. The
+					questions themselves are not likely to repeat unless the purpose of the quiz is to test memorization
+					skills, or to see if users change their perceptions based on other stimuli such as a picture. But in
+					these cases, it is essential for the user to answer the question anew each time it occurs, so such
+					tests would fall within the exemptions for the success criterion.</p>
+
+				<p>It is still important when encountering an embedded multi-part quiz to make a quick check that there
+					are no requests for the user to repeat non-essential information. Nothing can be ruled out, even if
+					repeated entry of information is unlikely. A publisher might ask the user to input their name or a
+					student ID at the end of each part of a quiz, for example, in which case the field should be
+					repopulated with the information the user entered the first time.</p>
+
+				<p>In a similar way, there may be aspects of interactive games that have redundant entry aspects to
+					them, particularly for memorization games that require the user to re-enter the same information to
+					progress through the stages. But these are also likely to fall under the essential re-entry
+					exception.</p>
 			</section>
 
 			<section id="reflow">

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -254,31 +254,52 @@
 					process. A checkbox to automatically use the billing address as the shipping address is now a
 					ubiquitous pattern to avoid this issue.</p>
 
-				<p>But this is one of the WCAG success criteria that has greater application on the web than in the
-					world of digital publications. The primary reason is that few publications contain multi-step
-					processes that collect the same information at different steps.</p>
-
 				<p>A multi-step process does not require a change in documents, or for the current document to fully
-					refresh, so it is possible that users will encounter them in publications. All that is required is
-					that a sequence of steps are required to complete a task. But the most common case of collecting
-					information in an EPUB publication is when quizzes are embedded. These are not typically split up so
-					that users have to complete one part of the quiz before the next becomes available, however.</p>
+					refresh, so it is common that users will encounter them in digital publications. The most common
+					example is in interactive content such as quizzes and games. All that is required is that a sequence
+					of steps are required to complete the quiz or game and at any step the user could have to input the
+					same information again to proceed.</p>
 
-				<p>It is even rarer that the same information would be asked for in multiple parts of a quiz. The
+				<p>A common case where this success criterion applies is when a quiz gets validated and allows users to
+					fix any errors they made and try again, or requires users to complete all the fields correctly
+					before it can be evaluated or submitted. In the case of fixing errors, the user should not have to
+					re-answer all the questions they got correct, nor should they have to guess what incorrect answer
+					they selected the first time. A quiz that allows the user to retry should only reset when it is
+					essential that the user start over again &#8212; for example, if new questions will have to be
+					solved or if the goal is to help in memorization of the information. Similarly, if information is
+					missing or invalid so the quiz cannot be evaluated, the user should not have to complete it again in
+					full just to address the invalid fields.</p>
+
+				<div class="note">
+					<p>Identifying and fixing input errors is covered by the <a data-cite="wcag2#error-identification"
+							>error identification (3.3.1)</a>, <a data-cite="wcag2#error-suggestion">error suggestion
+							(3.3.3)</a>, and <a data-cite="wcag2#error-prevention">error prevention (3.3.4)</a> success
+						criteria.</p>
+				</div>
+
+				<p>Not all quizzes will provide users an opportunity to correct their answers, of course. If only a
+					score is presented after submitting, for example, or if the answers are submitted to a learning
+					management system for evaluation by a course instructor, then the user does not have to re-enter
+					their data again and the redundant entry success criterion will not apply.</p>
+
+				<p>Where redundant entry is less applicable to digital publications is in requesting the same
+					information be input in a quiz (like the case of identical billing and shipping addresses). The
 					questions themselves are not likely to repeat unless the purpose of the quiz is to test memorization
 					skills, or to see if users change their perceptions based on other stimuli such as a picture. But in
 					these cases, it is essential for the user to answer the question anew each time it occurs, so such
-					tests would fall within the exemptions for the success criterion.</p>
+					tests would fall within the exceptions for the success criterion.</p>
 
-				<p>It is still important when encountering an embedded multi-part quiz to make a quick check that there
-					are no requests for the user to repeat non-essential information. Nothing can be ruled out, even if
-					repeated entry of information is unlikely. A publisher might ask the user to input their name or a
-					student ID at the end of each part of a quiz, for example, in which case the field should be
-					repopulated with the information the user entered the first time.</p>
+				<p>It is still important when encountering an embedded quiz to do a quick check that there are no
+					requests for the user to repeat information. Nothing can be ruled out, even if repeated entry of
+					personal information like on ecommerce sites is unlikely. A publisher could ask the user to input
+					their name or a student ID at the end of each part of a quiz to verify they are the one completing
+					the test, for example, in which case the field should be repopulated with the information the user
+					entered the first time. It is just not currently common for publications to send information out to
+					publisher systems.</p>
 
 				<p>In a similar way, there may be aspects of interactive games that have redundant entry aspects to
 					them, particularly for memorization games that require the user to re-enter the same information to
-					progress through the stages. But these are also likely to fall under the essential re-entry
+					progress to higher stages. But these are also likely to fall under the essential re-entry
 					exception.</p>
 			</section>
 


### PR DESCRIPTION
See if you agree with my interpretation of this one. Since it hinges on multi-step processes, and those are pretty rare in publications, I can't think of a lot of cases for it. But I'm not completely confident about my take on it.

What I can't be sure of from the definition is if this would apply to a quiz where, for example, you can fix your answers and submit again. Does the process of validation and resubmission turn a basic test into a process in which you have to ensure that the information the user submitted is still set? Sometimes I think yes, other times no, since it's almost never required to redo a quiz or even to finish one (outside of an LMS, perhaps, but that still wouldn't be a content level requirement but a course one).

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/redundant-entry/epub34/a11y-understand/index.html#redundant-entry

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/redundant-entry/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Fredundant-entry%2Fepub34%2Fa11y-understand%2Findex.html)
