### PR TITLE
Add the overview

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -56,8 +56,8 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>The Understanding EPUB Accessibility guide provides information on how to evaluate the accessible content
-				conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against reflowable EPUB
+			<p>The Understanding EPUB Accessibility 1.2 guide provides information on how to evaluate the accessible
+				content conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against reflowable EPUB
 				publications.</p>
 		</section>
 		<section id="sotd"></section>
@@ -67,7 +67,25 @@
 			<section id="overview">
 				<h3>Overview</h3>
 
-				<p>&#8230;</p>
+				<p>This document together with [[[epub-a11y-tech-12]]] [[epub-a11y-tech-12]] provide informative support
+					for implementing [[[epub-a11y-12]]] [[epub-a11y-12]]. This document provides general explanations of
+					the objectives and success criteria defined in EPUB Accessibility 1.2, while the EPUB Accessibility
+					Techniques 1.2 document details specific methods for meeting those requirements.</p>
+
+				<p>This document is divided into three parts. The <a href="#wcag">first part</a> covers WCAG [[wcag2]]
+					success criteria whose application to digital publications is ambiguous or that have been found to
+					have limited application. WCAG is heavily focused on making the web accessible so the explainer
+					documents that come with it rarely account for the differences with packaged web content such as is
+					found in EPUB publications.</p>
+
+				<p>The <a href="#epub">second part</a> explains the purpose of the additional <a
+						data-cite="epub-a11y-12#sec-epub-req">EPUB objectives</a> [[epub-a11y-12]]. These are
+					requirements not covered by WCAG as they are unique to EPUB publications.</p>
+
+				<p>And the <a href="#eval">final part</a> covers issues with evaluating EPUB publications. How to assess
+					EPUB publications is intentionally not covered by the standard because it is possible for
+					evaluations and reports to be done in different ways. But regardless of how evaluations are carried
+					out and reported, there are common issues that this document tries to help in understanding.</p>
 			</section>
 
 			<section id="scope">


### PR DESCRIPTION
This just fills in some prose in the empty overview section.

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/intro/epub34/a11y-understand/index.html#overview

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/intro/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Fintro%2Fepub34%2Fa11y-understand%2Findex.html)
