### PR TITLE
Add section on inapplicable success criteria

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -772,26 +772,27 @@ aside.sidebar {
 			<section id="eval-not-applicable">
 				<h3>Reporting inapplicable success criteria</h3>
 
-				<p>[[[epub-a11y-12]]] [[epub-a11y-12]] does not define a format for evaluation reports. Evaluators have the flexibility to use a format that best meets personal and/or regional reporting
-					needs. In general, though, it is expected that the report will list all of the WCAG success
-					criteria that were evaluated and the result of testing for each. For any criteria that were not met, include an explanation of what caused the failure.</p>
+				<p>[[[epub-a11y-12]]] [[epub-a11y-12]] does not define a format for evaluation reports. Evaluators have
+					the flexibility to use a format that best meets personal and/or regional reporting needs. In
+					general, though, it is expected that the report will list all the WCAG success criteria that were
+					evaluated and the result of testing for each. For any criteria that were not met, an explanation of
+					what caused the failure is typically also provided.</p>
 
-				<p>While this form of reporting is traditional for any kind of web content accessibility evaluation,
-					evaluators sometimes incorrectly assume that success criteria that do not apply to the content
-					should receive a pass. The idea being to confirm that the content meets all the requirements of WCAG
-					for the specified level.</p>
+				<p>While this form of reporting is traditional for accessibility evaluations, confusion sometimes arises
+					around how to report success criteria that do not apply to the content. The content does not fail
+					these success criteria, but it only passes because it is not relevant to check. The content does not
+					pass because the requirements have been met.</p>
 
-				<p>But if a success criterion does not apply to an EPUB publication, it should never be reported as an
-					unqualified pass. Doing so gives the false impression that the publication contains the inapplicable
-					content and that it was found to be conforming. A basic text novel, for example, should not have an
-					evaluation report that says that text alternatives are provided for all the audio and video content.
-					This kind of false reporting is not just misleading to users but could make regulators question
-					whether a proper evaluation was even carried out.</p>
+				<p>A basic text novel, for example, should not have an evaluation report that says that text
+					alternatives are provided for all the audio and video content. This kind of false reporting is not
+					just misleading to users but could make regulators question whether a proper evaluation was even
+					carried out.</p>
 
-				<p>When reporting success criteria that do not apply to a publication, it is strongly advised to label
-					their status as "not applicable" (or an equivalent language-specific term). If a reporting template
-					only allows "pass" or "fail" options, then include a comment that clearly states that the
-					publication contains no applicable content.</p>
+				<p>The best way to avoid this problem is to assign a "not applicable" result (or an equivalent
+					language-specific term) to success criteria that do not apply to an EPUB publication. If the
+					reporting template only allows pass or fail results, then the success criteria should not be
+					reported as an unqualified pass. Use the comment field to indicate which success criteria are not
+					applicable.</p>
 			</section>
 		</section>
 		<section id="index"></section>

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -772,11 +772,9 @@ aside.sidebar {
 			<section id="eval-not-applicable">
 				<h3>Reporting inapplicable success criteria</h3>
 
-				<p>[[[epub-a11y-12]]] [[epub-a11y-12]] does not define a format for creating evaluation so that
-					evaluators have the flexibility to use templates that best meet personal and/or regional reporting
-					needs. In general, though, it is expected that an evaluation report will list all the WCAG success
-					criteria that were evaluated, the result of testing each, and, for any success criteria that failed,
-					an explanation of what caused the failure.</p>
+				<p>[[[epub-a11y-12]]] [[epub-a11y-12]] does not define a format for evaluation reports. Evaluators have the flexibility to use a format that best meets personal and/or regional reporting
+					needs. In general, though, it is expected that the report will list all of the WCAG success
+					criteria that were evaluated and the result of testing for each. For any criteria that were not met, include an explanation of what caused the failure.</p>
 
 				<p>While this form of reporting is traditional for any kind of web content accessibility evaluation,
 					evaluators sometimes incorrectly assume that success criteria that do not apply to the content

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -772,16 +772,28 @@ aside.sidebar {
 			<section id="eval-not-applicable">
 				<h3>Reporting inapplicable success criteria</h3>
 
-				<!--
-				<p>If a success criterion does not apply to an EPUB publication, it should never be reported as an
-					unqualified pass. Doing so would give the false impression that the publication contains the
-					inapplicable content and that it was found to be conforming.</p>
+				<p>[[[epub-a11y-12]]] [[epub-a11y-12]] does not define a format for creating evaluation so that
+					evaluators have the flexibility to use templates that best meet personal and/or regional reporting
+					needs. In general, though, it is expected that an evaluation report will list all the WCAG success
+					criteria that were evaluated, the result of testing each, and, for any success criteria that failed,
+					an explanation of what caused the failure.</p>
 
-				<p>When reporting success criteria that do not apply to a publication, it is recommended to label their
-					status as "not applicable" (or an equivalent language-specific term). If a "pass" value must be
-					assigned by the reporting template used, then a comment should be included that clearly states that
-					the publication contains no applicable content.</p>
-				-->
+				<p>While this form of reporting is traditional for any kind of web content accessibility evaluation,
+					evaluators sometimes incorrectly assume that success criteria that do not apply to the content
+					should receive a pass. The idea being to confirm that the content meets all the requirements of WCAG
+					for the specified level.</p>
+
+				<p>But if a success criterion does not apply to an EPUB publication, it should never be reported as an
+					unqualified pass. Doing so gives the false impression that the publication contains the inapplicable
+					content and that it was found to be conforming. A basic text novel, for example, should not have an
+					evaluation report that says that text alternatives are provided for all the audio and video content.
+					This kind of false reporting is not just misleading to users but could make regulators question
+					whether a proper evaluation was even carried out.</p>
+
+				<p>When reporting success criteria that do not apply to a publication, it is strongly advised to label
+					their status as "not applicable" (or an equivalent language-specific term). If a reporting template
+					only allows "pass" or "fail" options, then include a comment that clearly states that the
+					publication contains no applicable content.</p>
 			</section>
 		</section>
 		<section id="index"></section>


### PR DESCRIPTION
This pull request updates some prose I had started when I was first structuring the document.


A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/inapplicable-sc/epub34/a11y-understand/index.html#eval-not-applicable

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/inapplicable-sc/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Finapplicable-sc%2Fepub34%2Fa11y-understand%2Findex.html)
