### PR TITLE
Add section on live media SCs

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -348,6 +348,32 @@
 				</section>
 			</section>
 
+			<section id="live-media">
+				<h3>Live media</h3>
+
+				<p>The purpose of the [[wcag2]] <a data-cite="wcag2#live-caption">Captions (Live) (1.2.4)</a> and <a
+						data-cite="wcag2#audio-only-live">Audio-only (Live) (1.2.9)</a> success criteria is to ensure
+					that users who are deaf or hard of hearing can access real-time presentations over the web. Typical
+					examples of content these success criteria apply to include live podcasts, concerts, and esport
+					events.</p>
+
+				<p>The live nature of these success criteria make their application to EPUB publications largely
+					theoretical. For one, EPUB does not support embedding live video streaming services which means the
+					only way to live stream video is to use JavaScript libraries. That immediately reduces the
+					reliability of playback since reading systems vary widely in what kind of scripting they will allow.
+					It is also not uncommon for a reading system that allows scripting to block access to the
+					network.</p>
+
+				<p>But an even simpler reason why live streaming is not used in EPUB publications is because the event
+					is likely to expire before many users will even purchase the publication. If the publisher is going
+					to host a live-streaming event, such as a question-and-answer session with the author, they are more
+					likely to link out to the event from promotional material in the front or back matter of the
+					publication. This also allows a recording of the event to be provided after it is over.</p>
+
+				<p>So, this is another case of success criteria that cannot be ruled out as never applying to EPUB
+					publications but in practice are unlikely to ever be encountered.</p>
+			</section>
+
 			<section id="meaningful-sequence">
 				<h3>Meaningful sequence</h3>
 


### PR DESCRIPTION
Live streaming is not likely to work in EPUB and really doesn't make a lot of sense to try and embed, so writing these two success criteria off as possible but extremely unlikely.

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/live-caption/epub34/a11y-understand/index.html#live-media

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/live-caption/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Flive-caption%2Fepub34%2Fa11y-understand%2Findex.html)
