### PR TITLE
Update editors list

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -21,6 +21,26 @@
 					company: "DAISY Consortium",
                     companyURL: "https://daisy.org",
 					w3cid: 51655
+				}, {
+					name: "George Kerscher",
+					company: "DAISY Consortium",
+					companyURL: "https://daisy.org",
+					w3cid: 1460
+				}, {
+					name: "Charles LaPierre",
+					company: "Benetech",
+					companyURL: "https://benetech.org",
+					w3cid: 72055
+				}, {
+					name: "Gregorio Pellegrino",
+					company: "Fondazione LIA",
+					companyURL: "https://www.fondazionelia.org",
+					w3cid: 97111
+				}, {
+					name: "Avneesh Singh",
+					company: "DAISY Consortium",
+					companyURL: "https://daisy.org",
+					w3cid: 75336
 				}],
 				includePermalinks: true,
 				permalinkEdge: true,


### PR DESCRIPTION
Matches the list to the other two a11y docs since these are a set.

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/editors/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Feditors%2Fepub34%2Fa11y-understand%2Findex.html)
