### PR TITLE
Add section on filtering success criteria

### DIFF
--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -963,10 +963,12 @@ aside.sidebar {
 						<p>When it comes to determining if there are images to check, be careful about using only the
 							package document manifest. While the media types list in the manifest are a reliable
 							indicator for EPUB 2 publications, EPUB 3 allows <a data-cite="epub-3#sec-data-urls">data
-								links</a> [[epub-3]]. Data links allow the raw image data to be embedded directly in
-							EPUB 3 content documents meaning no manifest entry is required. Consequently, a search for
-							URLs that begin with "<code>data:</code>" will also be required to ensure there are no
-							images.</p>
+								links</a> [[epub-3]] and scripting.</p>
+						<p>Data links allow the raw image data to be embedded directly in EPUB 3 content documents
+							meaning no manifest entry is required. Consequently, a search for URLs that begin with
+								"<code>data:</code>" will also be required to ensure there are no images.</p>
+						<p>Scripts can be used both to draw images on the [[html]] [^canvas^] element and to inject data
+							links, neither of which would require a manifest entry.</p>
 					</div>
 				</section>
 

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -937,8 +937,8 @@ aside.sidebar {
 						applications beyond images. It is not possible to ignore the success criterion simply because an
 						EPUB publication does not contain any images.</p>
 
-					<p>There are many other success criteria like non-text content that can apply to images but also
-						apply to many other types of content. Success criteria related to the <a
+					<p>There are many other success criteria like non-text content that can apply to images and also
+						apply to other types of content. Success criteria related to the <a
 							data-cite="wcag2#use-of-color">use of color</a> and to <a data-cite="wcag2#contrast-minimum"
 							>contrast</a> [[wcag2]] are just a couple of examples. Images can also cause flashing
 						hazards and be used as links and buttons, bringing all those related success criteria into play,

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -908,74 +908,59 @@ aside.sidebar {
 		<section id="eval">
 			<h2>Evaluation considerations</h2>
 
-			<section id="content-type">
-				<h3>Content type application</h3>
+			<section id="eval-filter">
+				<h3>Filtering success criteria</h3>
 
-				<p>Although there are fifty six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]], it is
+				<p>Although there are fifty-six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]], it is
 					rarely the case that all of these will apply when evaluating an EPUB publication. WCAG breaks the
-					success critieria up by the <em>POUR</em> categorization &#8212; perceivable, operable,
+					success criteria up by the <em>POUR</em> categorization &#8212; perceivable, operable,
 					understanding, and robust &#8212; but many of the success criteria can also be categorized by the
 					type of content they apply to.</p>
 
 				<p>Between the EPUB package document and accessibility evaluation tools, it is possible to determine
 					what types of content are, and are not, present in a EPUB publication. With this information it is
-					possible to filter the success criteria that actually need to be checked.</p>
+					possible to filter out some success criteria that do not need to be checked, speeding up the
+					evaluation process.</p>
 
 				<section id="content-type-images">
 					<h4>Images</h4>
 
 					<p>Images are the most common form of non-text content found in EPUB publications. When it comes to
-						making them accessible, the most commonly recognized success criterion is <a
-							href="#content-type-non-text">non-text content (1.1.1)</a> [[wcag2]]. This success criterion
-						determines if alternative text and/or extended descriptions are required depending on the
-						information the images convey.</p>
+						making them accessible, the most recognized success criterion is <a
+							href="wcag2#content-type-non-text">non-text content (1.1.1)</a> [[wcag2]]. This success
+						criterion determines if alternative text and/or extended descriptions are required depending on
+						the information the images convey.</p>
 
-					<p>But this is not the only success criterion that covers images. Depending on the type of image and
-						how it used, the following [[wcag2]] success criteria could apply:</p>
+					<p>But sometimes overlooked is that the non-text content success criterion is not exclusive to
+						images. It also requires that audio and video have a label that describes the content of the
+						clip, for example. In fact, most success criteria that can apply to images also have
+						applications beyond images. It is not possible to ignore the success criterion simply because an
+						EPUB publication does not contain any images.</p>
 
-					<ul>
-						<li>
-							<a data-cite="wcag2#use-of-color">use of color (1.4.1)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#contrast-minimum">contrast minimum (1.4.3)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#three-flashes-or-below-threshold">three flashes or below threshold
-								(2.3.1)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#link-purpose-in-context">link purpose in context (2.4.4)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#label-in-name">label in name (2.5.3)</a>
-						</li>
-					</ul>
+					<p>There are many other success criteria like non-text content that can apply to images but also
+						apply to many other types of content. Success criteria related to the <a
+							data-cite="wcag2#use-of-color">use of color</a> and to <a data-cite="wcag2#contrast-minimum"
+							>contrast</a> [[wcag2]] are just a couple of examples. Images can also cause flashing
+						hazards and be used as links and buttons, bringing all those related success criteria into play,
+						too.</p>
 
-					<p>The above is only a sampling of some of the success criteria that apply to images. There are a
-						lot of ways that images can be used inaccessibly.</p>
-
-					<p>Complicating accessibility evaluations is that most of these success criteria have applications
-						beyond images. It is not possible to ignore them simply because an EPUB publication does not
-						contain any images. Not even the non-text content success criterion is exclusive to images, as
-						it also applies to audio and video.</p>
-
-					<p>The only success criteria that solely apply to images are:</p>
+					<p>There are only a couple of success criteria that solely apply to images and can reliably be
+						omitted from an accessibility evaluation for an EPUB publication without them:</p>
 
 					<ul>
 						<li>
 							<a data-cite="wcag2#images-of-text">images of text (1.4.5)</a>
 						</li>
 						<li>
-							<a data-cite="wcag2#images-of-text-enhanced">images of text enhanced (1.4.9)</a>
+							<a data-cite="wcag2#images-of-text-no-exception">images of text no exception (1.4.9)</a>
 						</li>
 					</ul>
 
-					<p>These are the only success criteria that can be reliably omitted from an accessibility evaluation
-						when an EPUB publication has no images.</p>
+					<p>And of these two images of text success criteria, the no exception one falls at level AAA so it
+						is already often skipped when only level AA conformance is required.</p>
 
 					<div class="note">
-						<p>When it comes to determing if there are images to check, be careful about using only the
+						<p>When it comes to determining if there are images to check, be careful about using only the
 							package document manifest. While the media types list in the manifest are a reliable
 							indicator for EPUB 2 publications, EPUB 3 allows <a data-cite="epub-3#sec-data-urls">data
 								links</a> [[epub-3]]. Data links allow the raw image data to be embedded directly in
@@ -988,14 +973,15 @@ aside.sidebar {
 				<section id="content-type-audio-video">
 					<h4>Audio and video</h4>
 
-					<p>EPUB publications support video-only, video with audio, and audio-only clips, but of the three
-						forms video with audio is by far the most common to encounter. That said, EPUB publications with
-						audio and video are in the minority. The resulting size of embedding audio and video clips often
-						causes distribution issues. Remote hosting of audio and video is sometimes used to mitigate this
-						problem, but that practice introduces its own barriers to access.</p>
+					<p>EPUB publications support video-only, video with audio, and audio-only clips. Of these forms,
+						video with audio is by far the most commonly used. That said, EPUB publications with audio and
+						video of any kind are in the minority of all publications produced. The resulting size of
+						embedding audio and video clips often causes distribution issues. Remote hosting of audio and
+						video is sometimes used to mitigate this problem, but that practice introduces its own barriers
+						to access.</p>
 
-					<p>The lack of both audio and video in an EPUB publication means the following [[wcag2]] success
-						criteria do not have to be evaluated:</p>
+					<p>Consequently, the following [[wcag2]] success criteria do not have to be evaluated for all the
+						EPUB publications that lack audio and video:</p>
 
 					<ul>
 						<li>
@@ -1047,29 +1033,29 @@ aside.sidebar {
 						against the audio and/or video content included.</p>
 
 					<p>These are not the only success criteria that have to be checked when audio and/or video are
-						present. There are additional success criteria that have multiple applications, such as the
-						description requirement in the <a data-cite="wcag2#non-text-content">non-text content (1.1.1)
-							success criterion</a> or the risk of seizures addressed in the <a
-							data-cite="wcag2#three-flashes-or-below-threshold">three flashes or below threshold (2.3.1)
-							success criterion</a>. As with <a href="#content-type-images">images</a>, how audio and
-						video are used will also influence which success criteria apply. A video used as a link, for
-						example, would require the <a data-cite="wcag2#link-purpose-in-context">link purpose in context
-							(2.4.4) success criterion</a> to be checked.</p>
+						present. As with <a href="#content-type-images">images</a>, there are additional success
+						criteria that have multiple applications. For example, the description requirement in the <a
+							data-cite="wcag2#non-text-content">non-text content (1.1.1) success criterion</a> and the
+						risk of seizures addressed in the <a data-cite="wcag2#three-flashes-or-below-threshold">three
+							flashes or below threshold (2.3.1) success criterion</a> could apply. How audio and video
+						are used will also influence which success criteria apply. A video used as a link, for example,
+						would require the <a data-cite="wcag2#link-purpose-in-context">link purpose in context (2.4.4)
+							success criterion</a> to be checked.</p>
 				</section>
 
 				<section id="content-type-scripting">
 					<h4>Scripted content</h4>
 
-					<p>Given the highly dynamic nature of the modern web it is no surprise that accessible scripting is
+					<p>Given the highly dynamic nature of the modern web, it is no surprise that accessible scripting is
 						the focus of many [[wcag2]] success criteria. But like the other types of content explored in
 						this section, the total number of success criteria that can apply to scripted content is greater
 						than the number of success criteria that solely focus on scripting. A script that injects and
-						image or audio or video into a publication, for example, requires that the new content meet all
-						applicable success criteria.</p>
+						image or audio or video into a publication, for example, also requires that the newly added
+						content meet all its applicable success criteria.</p>
 
-					<p>But the aim of this section is to identify content-specific success criteria. Consequently,
-						filtering the success criteria to those that can only apply when scripting is used yields the
-						following:</p>
+					<p>But the purpose of this section is to identify script-specific success criteria. Consequently,
+						filtering the success criteria to those at level A or AA that can only apply when scripting is
+						used yields the following:</p>
 
 					<ul>
 						<li>
@@ -1085,25 +1071,10 @@ aside.sidebar {
 							<a data-cite="wcag2#no-keyboard-trap">no keyboard trap (2.1.2)</a>
 						</li>
 						<li>
-							<a data-cite="wcag2#keyboard-no-exception">keyboard no exception (2.1.3)</a>
-						</li>
-						<li>
 							<a data-cite="wcag2#timing-adjustable">timing adjustable (2.2.1)</a>
 						</li>
 						<li>
 							<a data-cite="wcag2#pause-stop-hide">pause, stop, hide (2.2.2)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#no-timing">no timing (2.2.3)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#interruptions">interruptions (2.2.4)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#re-authenticating">re-authenticating (2.2.5)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#interruptions">timeouts (2.2.6)</a>
 						</li>
 						<li>
 							<a data-cite="wcag2#pointer-gestures">pointer gestures (2.5.1)</a>
@@ -1115,9 +1086,6 @@ aside.sidebar {
 							<a data-cite="wcag2#motion-actuation">motion actuation (2.5.4)</a>
 						</li>
 						<li>
-							<a data-cite="wcag2#concurrent-input-mechanisms">concurrent input mechanisms (2.5.6)</a>
-						</li>
-						<li>
 							<a data-cite="wcag2#dragging-movements">dragging movements (2.5.7)</a>
 						</li>
 						<li>
@@ -1125,9 +1093,6 @@ aside.sidebar {
 						</li>
 						<li>
 							<a data-cite="wcag2#on-input">on input (3.2.2)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#change-on-request">change on request (3.2.5)</a>
 						</li>
 						<li>
 							<a data-cite="wcag2#error-identification">error identification (3.3.1)</a>
@@ -1143,17 +1108,11 @@ aside.sidebar {
 								financial, data (3.3.4)</a>
 						</li>
 						<li>
-							<a data-cite="wcag2#error-prevention-all">error prevention all (3.3.6)</a>
-						</li>
-						<li>
 							<a data-cite="wcag2#redundant-entry">redundant entry (3.3.7)</a>
 						</li>
 						<li>
 							<a data-cite="wcag2#accessible-authentication-minimum">accessible authentication minimum
 								(3.3.8)</a>
-						</li>
-						<li>
-							<a data-cite="wcag2#accessible-authentication">accessible authentication (3.3.9)</a>
 						</li>
 						<li>
 							<a data-cite="wcag2#name-role-value">name, role, value (4.1.2)</a>
@@ -1170,27 +1129,20 @@ aside.sidebar {
 						a direct impact on the user experience in which case none of the success criteria would apply.
 						For example, the scripting of custom elements does not necessarily involve user interaction.</p>
 
-					<p>Determining if scripting is being used in an EPUB publication is best accomplished through the
-						package document manifest. If scripting is used in an EPUB content document, it has to be
-						declared in a <code>properties</code> attribute.</p>
+					<div class="note">
+						<p>Determining if scripting is being used in an EPUB publication is best accomplished through
+							the <a data-cite="epub-3#sec-manifest-elem">package document manifest</a> [[epub-3]]. If
+							scripting is used in an EPUB content document, it has to be declared in a <a
+								data-cite="epub-3#sec-item-resource-properties"><code>properties</code> attribute</a>
+							[[epub-3]].</p>
 
-					<aside class="example" title="Scripting declaration">
-						<pre>&lt;package &#8230;>
-   &lt;manifest>
-      &lt;item id="c01"
-               href="content/chapter01.html"
-               properties="scripted"
-               media-type="application/xhtml+xml"/>
-   &lt;/manifest>
-&lt;/package></pre>
-					</aside>
-
-					<p>These declarations, together with validation that they have been applied correctly, are more
-						reliable than trying to check manually for scripting. Scripting may take different forms: from
-						external script files, to scripts embedded using [[html]] [^script^] tags, to scripting inlined
-						in the markup using event handler attributes like {{HTMLElement/onclick}} and
-						{{HTMLElement/onkeypress}}. Trying to locate all the possibilities manually is prone to
-						mistakes.</p>
+						<p>These declarations, together with validation that they have been applied correctly, are more
+							reliable than trying to check manually for scripting. Scripting may take different forms:
+							from external script files, to scripts embedded using [[html]] [^script^] tags, to scripting
+							inlined in the markup using event handler attributes like {{HTMLElement/onclick}} and
+							{{HTMLElement/onkeypress}}. Trying to locate all the possibilities manually is prone to
+							mistakes.</p>
+					</div>
 				</section>
 			</section>
 

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -714,59 +714,289 @@ aside.sidebar {
 			<h2>Evaluation considerations</h2>
 
 			<section id="content-type">
-				<h3>Content type considerations</h3>
+				<h3>Content type application</h3>
 
-				<!--
 				<p>Although there are fifty six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]], it is
-					rarely the case that all of these will apply when evaluating an EPUB publication. Although WCAG
-					breaks the success critieria up by the <em>POUR</em> categorization &#8212; perceivable, operable,
-					understanding, and robust &#8212; many of the success criteria can also be categorized by the type
-					of content they apply to.</p>
+					rarely the case that all of these will apply when evaluating an EPUB publication. WCAG breaks the
+					success critieria up by the <em>POUR</em> categorization &#8212; perceivable, operable,
+					understanding, and robust &#8212; but many of the success criteria can also be categorized by the
+					type of content they apply to.</p>
 
-				<p>Accessible scripting is the focus of a number of success criteria given the highly dynamic nature of
-					the modern web. The following success criteria are all conditional on a publication even having
-					scripted content:</p>
+				<p>Between the EPUB package document and accessibility evaluation tools, it is possible to determine
+					what types of content are, and are not, present in a EPUB publication. With this information it is
+					possible to filter the success criteria that actually need to be checked.</p>
 
-				<ul>
-					<li>1.3.5 Identify Input Purpose</li>
-					<li>2.2.1 Timing Adjustable</li>
-					<li>2.2.2 Pause, Stop, Hide</li>
-					<li>2.5.1 Pointer Gestures</li>
-					<li>2.5.2 Pointer Cancellation</li>
-					<li>2.5.3 Label in Name</li>
-					<li>2.5.4 Motion Actuation</li>
-					<li>3.2.1 On Focus</li>
-					<li>3.2.2 On Input</li>
-					<li>3.2.4 Consistent Identification</li>
-					<li>3.3.1 Error Identification</li>
-					<li>3.3.2 Labels or Instructions</li>
-					<li>3.3.3 Error Suggestion</li>
-					<li>3.3.4 Error Prevention (Legal, Financial, Data)</li>
-					<li>3.3.7 Redundant Entry</li>
-					<li>3.3.8 Accessible Authentication (Minimum)</li>
-					<li>4.1.2 Name, Role, Value</li>
-					<li>4.1.3 Status Messages</li>
-				</ul>
+				<section id="content-type-images">
+					<h4>Images</h4>
 
-				<p>Most reflowable publications do not include scripts because scripting is now well supported in
-					reading systems and even when it does work the dynamic pagination of reflowable publications can
-					often break scripted interfaces. So, right away the number of success criteria to check drops from
-					56 to 39 for unscripted reflowable publications.</p>
+					<p>Images are the most common form of non-text content found in EPUB publications. When it comes to
+						making them accessible, the most commonly recognized success criterion is <a
+							href="#content-type-non-text">non-text content (1.1.1)</a> [[wcag2]]. This success criterion
+						determines if alternative text and/or extended descriptions are required depending on the
+						information the images convey.</p>
 
-				<p>Similarly, many novels consist only of text and headings, so all of the following success criteria
-					for mulitmedia would not need to be checked:</p>
+					<p>But this is not the only success criterion that covers images. Depending on the type of image and
+						how it used, the following [[wcag2]] success criteria could apply:</p>
 
-				<ul>
-					<li>1.1.1 Non-text Content</li>
-					<li>1.2.1 Audio-only and Video-only (Prerecorded)</li>
-					<li>1.2.2 Captions (Prerecorded)</li>
-					<li>1.2.3 Audio Description or Media Alternative (Prerecorded)</li>
-					<li>1.2.4 Captions (Live)</li>
-					<li>1.2.5 Audio Description (Prerecorded)</li>
-					<li>1.4.2 Audio Control</li>
-					<li>1.4.5 Images of Text</li>
-				</ul>
-				-->
+					<ul>
+						<li>
+							<a data-cite="wcag2#use-of-color">use of color (1.4.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#contrast-minimum">contrast minimum (1.4.3)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#three-flashes-or-below-threshold">three flashes or below threshold
+								(2.3.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#link-purpose-in-context">link purpose in context (2.4.4)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#label-in-name">label in name (2.5.3)</a>
+						</li>
+					</ul>
+
+					<p>The above is only a sampling of some of the success criteria that apply to images. There are a
+						lot of ways that images can be used inaccessibly.</p>
+
+					<p>Complicating accessibility evaluations is that most of these success criteria have applications
+						beyond images. It is not possible to ignore them simply because an EPUB publication does not
+						contain any images. Not even the non-text content success criterion is exclusive to images, as
+						it also applies to audio and video.</p>
+
+					<p>The only success criteria that solely apply to images are:</p>
+
+					<ul>
+						<li>
+							<a data-cite="wcag2#images-of-text">images of text (1.4.5)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#images-of-text-enhanced">images of text enhanced (1.4.9)</a>
+						</li>
+					</ul>
+
+					<p>These are the only success criteria that can be reliably omitted from an accessibility evaluation
+						when an EPUB publication has no images.</p>
+
+					<div class="note">
+						<p>When it comes to determing if there are images to check, be careful about using only the
+							package document manifest. While the media types list in the manifest are a reliable
+							indicator for EPUB 2 publications, EPUB 3 allows <a data-cite="epub-3#sec-data-urls">data
+								links</a> [[epub-3]]. Data links allow the raw image data to be embedded directly in
+							EPUB 3 content documents meaning no manifest entry is required. Consequently, a search for
+							URLs that begin with "<code>data:</code>" will also be required to ensure there are no
+							images.</p>
+					</div>
+				</section>
+
+				<section id="content-type-audio-video">
+					<h4>Audio and video</h4>
+
+					<p>EPUB publications support video-only, video with audio, and audio-only clips, but of the three
+						forms video with audio is by far the most common to encounter. That said, EPUB publications with
+						audio and video are in the minority. The resulting size of embedding audio and video clips often
+						causes distribution issues. Remote hosting of audio and video is sometimes used to mitigate this
+						problem, but that practice introduces its own barriers to access.</p>
+
+					<p>The lack of both audio and video in an EPUB publication means the following [[wcag2]] success
+						criteria do not have to be evaluated:</p>
+
+					<ul>
+						<li>
+							<a data-cite="wcag2#audio-only-and-video-only-prerecorded">audio-only and video-only
+								prerecorded (1.2.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#captions-prerecorded">captions prerecorded (1.2.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#audio-description-or-media-alternative-prerecorded">audio description or
+								media alternative prerecorded (1.2.3)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#captions-live">captions live (1.2.4)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#audio-description-prerecorded">audio description prerecorded (1.2.5)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#sign-language-prerecorded">sign language prerecorded (1.2.6)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#extended-audio-description">extended audio description prerecorded
+								(1.2.7)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#media-alternative-prerecorded">media alternative prerecorded (1.2.8)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#audio-only-live">audio-only live (1.2.9)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#audio-control">audio control (1.4.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#low-or-no-background-audio">low or no background audio (1.4.7)</a>
+						</li>
+					</ul>
+
+					<div class="note">
+						<p>Even when audio and video are present, the success criteria related to live streaming will
+							rarely ever apply. Refer to <a href="#live-media">the live media section</a> for more
+							information.</p>
+					</div>
+
+					<p>If either audio or video are present, then whether these success criteria apply becomes a matter
+						of what is represented by the content. They may not all apply, but each will have to be checked
+						against the audio and/or video content included.</p>
+
+					<p>These are not the only success criteria that have to be checked when audio and/or video are
+						present. There are additional success criteria that have multiple applications, such as the
+						description requirement in the <a data-cite="wcag2#non-text-content">non-text content (1.1.1)
+							success criterion</a> or the risk of seizures addressed in the <a
+							data-cite="wcag2#three-flashes-or-below-threshold">three flashes or below threshold (2.3.1)
+							success criterion</a>. As with <a href="#content-type-images">images</a>, how audio and
+						video are used will also influence which success criteria apply. A video used as a link, for
+						example, would require the <a data-cite="wcag2#link-purpose-in-context">link purpose in context
+							(2.4.4) success criterion</a> to be checked.</p>
+				</section>
+
+				<section id="content-type-scripting">
+					<h4>Scripted content</h4>
+
+					<p>Given the highly dynamic nature of the modern web it is no surprise that accessible scripting is
+						the focus of many [[wcag2]] success criteria. But like the other types of content explored in
+						this section, the total number of success criteria that can apply to scripted content is greater
+						than the number of success criteria that solely focus on scripting. A script that injects and
+						image or audio or video into a publication, for example, requires that the new content meet all
+						applicable success criteria.</p>
+
+					<p>But the aim of this section is to identify content-specific success criteria. Consequently,
+						filtering the success criteria to those that can only apply when scripting is used yields the
+						following:</p>
+
+					<ul>
+						<li>
+							<a data-cite="wcag2#identify-input-purpose">identify input purpose (1.3.5)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#content-on-hover-or-focus">content on hover or focus (1.4.13)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#keyboard">keyboard (2.1.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#no-keyboard-trap">no keyboard trap (2.1.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#keyboard-no-exception">keyboard no exception (2.1.3)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#timing-adjustable">timing adjustable (2.2.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#pause-stop-hide">pause, stop, hide (2.2.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#no-timing">no timing (2.2.3)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#interruptions">interruptions (2.2.4)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#re-authenticating">re-authenticating (2.2.5)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#interruptions">timeouts (2.2.6)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#pointer-gestures">pointer gestures (2.5.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#pointer-cancellation">pointer cancellation (2.5.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#motion-actuation">motion actuation (2.5.4)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#concurrent-input-mechanisms">concurrent input mechanisms (2.5.6)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#dragging-movements">dragging movements (2.5.7)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#on-focus">on focus (3.2.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#on-input">on input (3.2.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#change-on-request">change on request (3.2.5)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#error-identification">error identification (3.3.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#labels-or-instructions">labels or instructions (3.3.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#error-suggestion">error suggestion (3.3.3)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#error-prevention-legal-financial-data">error prevention legal,
+								financial, data (3.3.4)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#error-prevention-all">error prevention all (3.3.6)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#redundant-entry">redundant entry (3.3.7)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#accessible-authentication-minimum">accessible authentication minimum
+								(3.3.8)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#accessible-authentication">accessible authentication (3.3.9)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#name-role-value">name, role, value (4.1.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#status-message">status messages (4.1.3)</a>
+						</li>
+					</ul>
+
+					<p>Although these success criteria will not apply when scripting is not used, the opposite is not
+						typically true. Which success criteria apply depends heavily on what kind of scripting is used.
+						Scripting might not be tied to form elements, for example, in which case the success criteria to
+						ensure that forms and form elements are accessible will not apply. Scripting might not even have
+						a direct impact on the user experience in which case none of the success criteria would apply.
+						For example, the scripting of custom elements does not necessarily involve user interaction.</p>
+
+					<p>Determining if scripting is being used in an EPUB publication is best accomplished through the
+						package document manifest. If scripting is used in an EPUB content document, it has to be
+						declared in a <code>properties</code> attribute.</p>
+
+					<aside class="example" title="Scripting declaration">
+						<pre>&lt;package &#8230;>
+   &lt;manifest>
+      &lt;item id="c01"
+               href="content/chapter01.html"
+               properties="scripted"
+               media-type="application/xhtml+xml"/>
+   &lt;/manifest>
+&lt;/package></pre>
+					</aside>
+
+					<p>These declarations, together with validation that they have been applied correctly, are more
+						reliable than trying to check manually for scripting. Scripting may take different forms: from
+						external script files, to scripts embedded using [[html]] [^script^] tags, to scripting inlined
+						in the markup using event handler attributes like {{HTMLElement/onclick}} and
+						{{HTMLElement/onkeypress}}. Trying to locate all the possibilities manually is prone to
+						mistakes.</p>
+				</section>
 			</section>
 
 			<section id="eval-not-applicable">


### PR DESCRIPTION
This section has had me going in circles. It's a challenge to definitively say what SC apply to what types of content. It all depends on what the content is, how it's used, etc. Scripting can bring pretty much every success criteria into play, for example, because scripts can inject any type of content.

But rather than go down the rabbit hole of what can apply, what I've done is try to isolate the ones that definitely have no application unless the content type is present. That can be very small, only images of text definitely doesn't apply if there are no images, or lengthier in the case of all the scripting-specific SCs.

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/content-types/epub34/a11y-understand/index.html#eval-filter

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/content-types/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Fcontent-types%2Fepub34%2Fa11y-understand%2Findex.html)
