### PR TITLE
Add section on success criteria filtering

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -5,7 +5,6 @@
 		<title>EPUB Accessibility Techniques 1.2</title>
 		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
@@ -107,8 +106,7 @@
 						"href": "https://www.w3.org/TR/WCAG2/",
 						"publisher": "W3C"
 					}
-				},
-				postProcess: [fixErrataField]
+				}
 			};</script>
 		<style>
 			pre {

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -1130,9 +1130,6 @@ aside.sidebar {
 												(1.4.13)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#keyboard">keyboard (2.1.1)</a>
-										</li>
-										<li>
 											<a data-cite="wcag2#no-keyboard-trap">no keyboard trap (2.1.2)</a>
 										</li>
 										<li>

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -12,7 +12,7 @@
 				group: "pm",
 				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
-				shortName: "epub-a11y-tech-12",
+				shortName: "epub-a11y-understand-12",
 				noRecTrack: true,
 				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
                 copyrightStart: "2026",

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -939,12 +939,12 @@ aside.sidebar {
 						organized by whether they improve the perceivability, operability, understanding, or robustness
 						of the content.</p>
 
-					<p>Why this organization matters is because success criteria across multiple categories can apply to
-						different content types, the most common being images, audio, video, and interactive content.
-						The <a data-cite="wcag2#non-text-content">non-text content success criterion</a>, for example,
-						can apply to all these types of content: static images and dynamic images drawn on an [[html]]
-						[^canvas^] element need alternative text and/or descriptions; audio and video need labels to
-						describe the nature of the content.</p>
+					<p>This organization matters because success criteria across multiple categories can apply to
+						different content types. The <a data-cite="wcag2#non-text-content">non-text content success
+							criterion</a>, for example, can apply to images, audio, video, and interactive content. It
+						requires that static images and dynamic images drawn on an [[html]] [^canvas^] element have
+						alternative text and/or descriptions. And for audio and video, it requires labels to describe
+						the nature of the content.</p>
 
 					<p>At the same time, there are various success criteria that only apply to a single type of content.
 						The <a data-cite="wcag2#time-based-media">time-based media success criteria</a>, for example,
@@ -958,14 +958,14 @@ aside.sidebar {
 						to an EPUB publication because so much depends on the nature of the content. But it is possible
 						to help steer evaluators away from success criteria that do not apply.</p>
 
-					<p>The <a href="#eval-not-applicable">mapping table provided in this section</a> identifies success
-						criteria that cannot apply when images, audio, video, and scripted content are not present.
-						While it is possible to encounter these types of content in EPUB publications, they were chosen
-						for analysis because there are many more publications that omit them than have them.</p>
+					<p>Many publications do not contain images, audio, video, or scripted content. The <a
+							href="#eval-filter-table">filtering table</a> identifies success criteria that can be
+						skipped when they are not present in EPUB publications. </p>
 
-					<p>It is possible to determine what types of content are, and are not, present in a EPUB publication
-						using validation tools and by inspecting the package document. With this information these
-						success criteria can be filtered out of an evaluation when they do not apply.</p>
+					<p>It is possible to determine what types of content are present, or not present, in an EPUB
+						publication by using validation tools and inspecting the package document. With this
+						information, the <a href="#eval-filter-table">filtering table</a> can be used to skip any
+						success criteria that do not apply.</p>
 				</section>
 
 				<section id="eval-filter-identify">
@@ -1031,7 +1031,7 @@ aside.sidebar {
 				</section>
 
 				<section id="eval-filter-table">
-					<h4>Content-specific success criteria</h4>
+					<h4>Filtering table</h4>
 
 					<p>The following table provides a list of success criteria that can be skipped if an EPUB
 						publication does not contain the specified type of content.</p>

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -932,8 +932,8 @@ aside.sidebar {
 			<section id="eval-filter">
 				<h3>Filtering success criteria</h3>
 
-				<section id="eval-filter-overview">
-					<h4>Overview</h4>
+				<section id="eval-filter-intro">
+					<h4>Introduction</h4>
 
 					<p>There are fifty-six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]]. They are
 						organized by whether they improve the perceivability, operability, understanding, or robustness

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -966,10 +966,6 @@ aside.sidebar {
 					<p>It is possible to determine what types of content are, and are not, present in a EPUB publication
 						using validation tools and by inspecting the package document. With this information these
 						success criteria can be filtered out of an evaluation when they do not apply.</p>
-
-					<p>But when using this section as a guide, do not try to reverse the guidance when the content types
-						are present. As already noted, there are many more success criteria than can apply to these
-						content types than just the ones that are exclusive to them.</p>
 				</section>
 
 				<section id="eval-filter-identify">
@@ -1041,7 +1037,7 @@ aside.sidebar {
 						publication does not contain the specified type of content.</p>
 
 					<div class="caution">
-						<p>This table does not provide a list of all the success criteria have to be checked if the
+						<p>This table does not provide a list of all the success criteria have to be checked when the
 							specified content types are present. The <a
 								href="https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize">How to
 								Meet WCAG (Quick Reference) guide</a> provides the ability to filter WCAG success

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -5,14 +5,14 @@
 		<title>Understanding EPUB Accessibility 1.2</title>
 		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../../common/js/fix-errata.js" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
+		<script src="../../common/js/add-caution-hd.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
 				group: "pm",
 				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
-				shortName: "epub-a11y-understand-12",
+				shortName: "epub-a11y-tech-12",
 				noRecTrack: true,
 				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
                 copyrightStart: "2026",
@@ -56,6 +56,12 @@
 						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
+					"ops-201": {
+						"title": "Open Publication Structure 2.0.1",
+						"href": "http://idpf.org/epub/20/spec/OPS_2.0.1_draft.htm",
+						"date": "04 September 2010",
+						"publisher": "IDPF"
+					},
 					"wai-aria": {
 						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
 						"href": "https://www.w3.org/TR/wai-aria/",
@@ -67,11 +73,26 @@
 						"publisher": "W3C"
 					}
 				},
-				postProcess: [fixErrataField]
+				preProcess:[inlineCustomCSS],
+				postProcess: [addCautionHeaders]
 			};</script>
 		<style>
 			pre {
 				white-space: break-spaces !important;
+			}
+			table.zebra tbody th {
+				vertical-align: text-top;
+				background-color: inherit !important;
+				color: inherit !important;
+			}
+			table.zebra td {
+				vertical-align: text-top;
+			}
+			table.zebra p:before {
+				content: '•';
+				font-size: 120%;
+				margin-left: 1.1rem;
+				padding-right: 0.6rem;
 			}</style>
 	</head>
 	<body>
@@ -908,60 +929,281 @@ aside.sidebar {
 		<section id="eval">
 			<h2>Evaluation considerations</h2>
 
-			<section id="content-type">
-				<h3>Content type considerations</h3>
+			<section id="eval-filter">
+				<h3>Filtering success criteria</h3>
 
-				<!--
-				<p>Although there are fifty six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]], it is
-					rarely the case that all of these will apply when evaluating an EPUB publication. Although WCAG
-					breaks the success critieria up by the <em>POUR</em> categorization &#8212; perceivable, operable,
-					understanding, and robust &#8212; many of the success criteria can also be categorized by the type
-					of content they apply to.</p>
+				<section id="eval-filter-overview">
+					<h4>Overview</h4>
 
-				<p>Accessible scripting is the focus of a number of success criteria given the highly dynamic nature of
-					the modern web. The following success criteria are all conditional on a publication even having
-					scripted content:</p>
+					<p>There are fifty-six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]]. They are
+						organized by whether they improve the perceivability, operability, understanding, or robustness
+						of the content as these categories best describe the focus of the success criteria.</p>
 
-				<ul>
-					<li>1.3.5 Identify Input Purpose</li>
-					<li>2.2.1 Timing Adjustable</li>
-					<li>2.2.2 Pause, Stop, Hide</li>
-					<li>2.5.1 Pointer Gestures</li>
-					<li>2.5.2 Pointer Cancellation</li>
-					<li>2.5.3 Label in Name</li>
-					<li>2.5.4 Motion Actuation</li>
-					<li>3.2.1 On Focus</li>
-					<li>3.2.2 On Input</li>
-					<li>3.2.4 Consistent Identification</li>
-					<li>3.3.1 Error Identification</li>
-					<li>3.3.2 Labels or Instructions</li>
-					<li>3.3.3 Error Suggestion</li>
-					<li>3.3.4 Error Prevention (Legal, Financial, Data)</li>
-					<li>3.3.7 Redundant Entry</li>
-					<li>3.3.8 Accessible Authentication (Minimum)</li>
-					<li>4.1.2 Name, Role, Value</li>
-					<li>4.1.3 Status Messages</li>
-				</ul>
+					<p>Why this organization matters is because success criteria across multiple categories can apply to
+						different content types, the most common being images, audio, video, and interactive content.
+						The <a data-cite="wcag2#non-text-content">non-text content success criterion</a>, for example,
+						can apply to all these types of content: static images and dynamic images drawn on an [[html]]
+						[^canvas^] element need alternative text and/or descriptions; audio and video need labels to
+						describe the nature of the content.</p>
 
-				<p>Most reflowable publications do not include scripts because scripting is now well supported in
-					reading systems and even when it does work the dynamic pagination of reflowable publications can
-					often break scripted interfaces. So, right away the number of success criteria to check drops from
-					56 to 39 for unscripted reflowable publications.</p>
+					<p>At the same time, there are various success criteria that only apply to a single type of content.
+						The <a data-cite="wcag2#time-based-media">time-based media success criteria</a>, for example,
+						only apply to audio and video.</p>
 
-				<p>Similarly, many novels consist only of text and headings, so all of the following success criteria
-					for mulitmedia would not need to be checked:</p>
+					<p>When carrying out an accessibility evaluation, it is important to know the possible applications
+						of each success criterion. This avoids both mistakenly missing critical checks and wasting time
+						on success criteria that cannot apply the content.</p>
 
-				<ul>
-					<li>1.1.1 Non-text Content</li>
-					<li>1.2.1 Audio-only and Video-only (Prerecorded)</li>
-					<li>1.2.2 Captions (Prerecorded)</li>
-					<li>1.2.3 Audio Description or Media Alternative (Prerecorded)</li>
-					<li>1.2.4 Captions (Live)</li>
-					<li>1.2.5 Audio Description (Prerecorded)</li>
-					<li>1.4.2 Audio Control</li>
-					<li>1.4.5 Images of Text</li>
-				</ul>
-				-->
+					<p>It is not possible for a document like this to determine exactly which success criteria can apply
+						to an EPUB publication because so much depends on the nature of the content. But it is possible
+						to help steer evaluators away from success criteria that do not apply.</p>
+
+					<p>The <a href="#eval-not-applicable">mapping table provided in this section</a> identifies success
+						criteria that cannot apply when images, audio, video, and scripted content are not present.
+						While it is possible to encounter these types of content in EPUB publications, they were chosen
+						for analysis because there are many more publications that omit them.</p>
+
+					<p>Between the EPUB package document and accessibility evaluation tools, it is possible to determine
+						what types of content are, and are not, present in a EPUB publication. With this information
+						these success criteria can be filtered out of an evaluation.</p>
+
+					<p>But when using this section as a guide, do not try to reverse the guidance when the content types
+						are present. As already noted, there are many more success criteria than can apply to these
+						content types than just the ones that are exclusive to them.</p>
+				</section>
+
+				<section id="eval-filter-identify">
+					<h4>Identifying content types</h4>
+
+					<p>Before attempting to filter the success criteria it is critical to be sure what content an EPUB
+						publication contains. The traditional way to verify this is through the <a
+							data-cite="epub-3#sec-manifest-elem">package document manifest</a> [[epub-3]]. Each manifest
+						item has to list its media type in a <a data-cite="epub-3#attrdef-item-media-type"
+								><code>media-type</code> attribute</a>, so all that is required is a knowledge of which
+						media types define which type of content.</p>
+
+					<p>The media types often aid in understanding the nature of the listed resources, as the start of
+						each usually classifies the type. Image formats, for example, begin with "<code>image/</code>",
+						while audio formats begin with "<code>audio/</code>". EPUB also maintains a list of core media
+						types which also generally limits the number of formats that are used.</p>
+
+					<div class="note">
+						<p>Refer to <a data-cite="epub-3#sec-core-media-types">EPUB 3's core media types</a> [[epub-3]]
+							and <a data-cite="ops-201#Section1.3.7">EPUB 2's core media types</a> [[ops-201]] for more
+							information.</p>
+					</div>
+
+					<p>Unfortunately, the package document manifest is an imperfect way of assessing the content of an
+						EPUB 3 publication. It only works well for EPUB 2 publications because EPUB 2 lacks the more
+						advanced content options of EPUB 3.</p>
+
+					<p>Determining whether there are images in an EPUB publication is a prime example of how the
+						manifest can fail. Scripts can be used to draw images on the [[html]] [^canvas^] element or to
+						create interactive charts or games. These kinds of images will not be listed in the manifest
+						because they are created using native html functionality.</p>
+
+					<p>Similarly, <a href="epub-3#sec-data-urls">data URLs</a> allow raw image data to be embedded
+						directly in html, once again bypassing a manifest entry. A search for URLs that begin with
+							"<code>data:</code>" might not even be sufficient as a script could dynamically insert an
+						image this way.</p>
+
+					<p>Scripting is also problematic because it limits the ability of validators to check whether
+						resources are missing from the manifest. If an [[html]] [^audio^] or [^video^] element is
+						dynamically written into an html file, for example, a validator might only report the
+						corresponding audio or video file in the EPUB package as an unused resource in a usage message.
+						Usage messages are not usually emitted by default making the issue easy to miss. Moreover, if
+						the script writes a reference to a remotely hosted resource, the validator will not report
+						anything at all.</p>
+
+					<p>In an odd twist, although scripting makes the package document manifest less reliable for
+						detecting non-text content, the package document is the best way to detect if scripting is used.
+						When scripting is used in an EPUB content document, no matter what form it takes, it has to be
+						declared in a <a data-cite="epub-3#sec-item-resource-properties"><code>properties</code>
+							attribute</a> [[epub-3]].</p>
+
+					<p>Scripts are not always stored in standalone JavaScript files, so it can be quite difficult to
+						determine if scripting is present without the help of a validator. Scripts embedded using
+						[[html]] [^script^] tags and scripting inlined in the markup using event handler attributes like
+						{{HTMLElement/onclick}} and {{HTMLElement/onkeypress}} are a couple of ways that scripting can
+						be present at the content level. Trying to locate these possibilities manually is prone to
+						mistakes. But so long as the EPUB publication is validated prior to carrying out an
+						accessibility evaluation, detecting scripting will be straightfoward.</p>
+				</section>
+
+				<section id="eval-filter-table">
+					<h4>Content-specific success criteria</h4>
+
+					<p>The following table provides a list of success criteria that can be skipped if an EPUB
+						publication does not contain the specified type of content.</p>
+
+					<div class="caution">
+						<p>This table does not provide a list of all the success criteria have to be checked if the
+							specified content types are present. The <a
+								href="https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize">How to
+								Meet WCAG (Quick Reference) guide</a> provides the ability to filter WCAG success
+							criteria to show all that apply to different content types as do evaluation tools.</p>
+					</div>
+
+					<table class="zebra">
+						<colgroup>
+							<col style="width: 30%;" />
+							<col style="width: 70%" />
+						</colgroup>
+						<thead>
+							<tr>
+								<th>EPUB publication does not contain</th>
+								<th>Level A and AA success criteria that can be skipped</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th>Images</th>
+								<td>
+									<p>
+										<a data-cite="wcag2#images-of-text">images of text (1.4.5)</a>
+									</p>
+								</td>
+							</tr>
+
+							<tr>
+								<th>Audio and video</th>
+								<td>
+									<ul>
+										<li>
+											<a data-cite="wcag2#audio-only-and-video-only-prerecorded">audio-only and
+												video-only prerecorded (1.2.1)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#captions-prerecorded">captions prerecorded (1.2.2)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#audio-description-or-media-alternative-prerecorded"
+												>audio description or media alternative prerecorded (1.2.3)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#captions-live">captions live (1.2.4)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#audio-description-prerecorded">audio description
+												prerecorded (1.2.5)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#sign-language-prerecorded">sign language prerecorded
+												(1.2.6)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#extended-audio-description">extended audio description
+												prerecorded (1.2.7)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#media-alternative-prerecorded">media alternative
+												prerecorded (1.2.8)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#audio-only-live">audio-only live (1.2.9)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#audio-control">audio control (1.4.2)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#low-or-no-background-audio">low or no background audio
+												(1.4.7)</a>
+										</li>
+									</ul>
+								</td>
+							</tr>
+
+							<tr>
+								<th>Scripting</th>
+								<td>
+									<ul>
+										<li>
+											<a data-cite="wcag2#identify-input-purpose">identify input purpose
+												(1.3.5)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#content-on-hover-or-focus">content on hover or focus
+												(1.4.13)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#keyboard">keyboard (2.1.1)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#no-keyboard-trap">no keyboard trap (2.1.2)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#timing-adjustable">timing adjustable (2.2.1)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#pointer-gestures">pointer gestures (2.5.1)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#pointer-cancellation">pointer cancellation (2.5.2)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#motion-actuation">motion actuation (2.5.4)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#dragging-movements">dragging movements (2.5.7)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#on-focus">on focus (3.2.1)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#on-input">on input (3.2.2)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#error-identification">error identification (3.3.1)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#labels-or-instructions">labels or instructions
+												(3.3.2)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#error-suggestion">error suggestion (3.3.3)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#error-prevention-legal-financial-data">error prevention
+												legal, financial, data (3.3.4)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#redundant-entry">redundant entry (3.3.7)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#accessible-authentication-minimum">accessible
+												authentication minimum (3.3.8)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#name-role-value">name, role, value (4.1.2)</a>
+										</li>
+										<li>
+											<a data-cite="wcag2#status-message">status messages (4.1.3)</a>
+										</li>
+									</ul>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+
+					<p>If an EPUB publication does not contain any of the above content types, and does not use CSS
+						animations, the following Level A and AA success criteria will also not apply:</p>
+
+					<ul>
+						<li>
+							<a data-cite="wcag2#non-text-content">non-text content (1.1.1)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#non-text-contrast">non-text contrast (1.4.11)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#pause-stop-hide">pause, stop, hide (2.2.2)</a>
+						</li>
+						<li>
+							<a data-cite="wcag2#three-flashes-or-below-threshold">three flashes or below threshold
+								(2.3.1)</a>
+						</li>
+					</ul>
+				</section>
 			</section>
 
 			<section id="eval-not-applicable">

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -1044,7 +1044,7 @@ aside.sidebar {
 							criteria to show all that apply to different content types as do evaluation tools.</p>
 					</div>
 
-					<table class="zebra">
+					<table class="zebra" id="sc-filter-table">
 						<colgroup>
 							<col style="width: 30%;" />
 							<col style="width: 70%" />

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -937,7 +937,7 @@ aside.sidebar {
 
 					<p>There are fifty-six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]]. They are
 						organized by whether they improve the perceivability, operability, understanding, or robustness
-						of the content as these categories best describe the focus of the success criteria.</p>
+						of the content.</p>
 
 					<p>Why this organization matters is because success criteria across multiple categories can apply to
 						different content types, the most common being images, audio, video, and interactive content.

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -961,11 +961,11 @@ aside.sidebar {
 					<p>The <a href="#eval-not-applicable">mapping table provided in this section</a> identifies success
 						criteria that cannot apply when images, audio, video, and scripted content are not present.
 						While it is possible to encounter these types of content in EPUB publications, they were chosen
-						for analysis because there are many more publications that omit them.</p>
+						for analysis because there are many more publications that omit them than have them.</p>
 
-					<p>Between the EPUB package document and accessibility evaluation tools, it is possible to determine
-						what types of content are, and are not, present in a EPUB publication. With this information
-						these success criteria can be filtered out of an evaluation.</p>
+					<p>It is possible to determine what types of content are, and are not, present in a EPUB publication
+						using validation tools and by inspecting the package document. With this information these
+						success criteria can be filtered out of an evaluation when they do not apply.</p>
 
 					<p>But when using this section as a guide, do not try to reverse the guidance when the content types
 						are present. As already noted, there are many more success criteria than can apply to these
@@ -982,10 +982,11 @@ aside.sidebar {
 								><code>media-type</code> attribute</a>, so all that is required is a knowledge of which
 						media types define which type of content.</p>
 
-					<p>The media types often aid in understanding the nature of the listed resources, as the start of
-						each usually classifies the type. Image formats, for example, begin with "<code>image/</code>",
-						while audio formats begin with "<code>audio/</code>". EPUB also maintains a list of core media
-						types which also generally limits the number of formats that are used.</p>
+					<p>The media types themselves typically aid in understanding the nature of the listed resources, as
+						the start of each usually classifies the type. Image formats, for example, begin with
+							"<code>image/</code>", while audio formats begin with "<code>audio/</code>". EPUB also
+						maintains a list of core media types which also limits the number of formats that are actually
+						used in publications.</p>
 
 					<div class="note">
 						<p>Refer to <a data-cite="epub-3#sec-core-media-types">EPUB 3's core media types</a> [[epub-3]]
@@ -1014,6 +1015,9 @@ aside.sidebar {
 						Usage messages are not usually emitted by default making the issue easy to miss. Moreover, if
 						the script writes a reference to a remotely hosted resource, the validator will not report
 						anything at all.</p>
+
+					<p>Evaluators will always have to be aware of these limitations and be on the lookout for content
+						that is not listed in the manifest.</p>
 
 					<p>In an odd twist, although scripting makes the package document manifest less reliable for
 						detecting non-text content, the package document is the best way to detect if scripting is used.


### PR DESCRIPTION
Okay, new attempt. Instead of subsections for each content type and having to re-explain the limitations, I've restructured it so there is now an intro to explain once what we're trying to achieve. I then put all the guidance on identifying the content types into a separate section. And there's a final section with a table to cover the content types and what can be excluded.

The non-text content still doesn't fit with the table since it's additive. To put it in the table we'd have to re-list all the success criteria for the other content types. If we assume that CSS animations are almost never used, we can also add a few other success criteria. So, I've listed these additional SC after the table to try and make this easier to follow.

A direct link to the preview for the new section is here:
https://raw.githack.com/w3c/epub-specs/understand/sc-filter/epub34/a11y-understand/index.html#eval-filter

Edit: I also removed the script to fix the errata links from this document and the techniques because notes don't get errata.

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/sc-filter/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Fsc-filter%2Fepub34%2Fa11y-understand%2Findex.html)
