### PR TITLE
Add watermarking to privacy considerations

### DIFF
--- a/epub34/authoring/biblio.js
+++ b/epub34/authoring/biblio.js
@@ -117,6 +117,12 @@ var biblio = {
 		"href": "https://www.w3.org/TR/wai-aria/",
 		"publisher": "W3C"
 	},
+	"watermark-privacy": {
+		"title": "Privacy Principles for Digital Watermarking Version 1.0",
+		"href": "https://cdt.org/wp-content/uploads/copyright/20080529watermarking.pdf",
+		"publisher": "Center for Democracy &amp; Technology",
+		"date": "May 2008"
+	},
 	"wcag2": {
 		"title": "Web Content Accessibility Guidelines (WCAG) 2",
 		"href": "https://www.w3.org/TR/WCAG2/",

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -318,17 +318,18 @@
 						<dfn class="export">container root URL</dfn>
 					</dt>
 					<dd>
-						<p>The [=url-concept|URL=]&#160;[[url]] of the [=root directory=] representing the [=OCF abstract
-							container=]. Although the container root URL is implementation specific, its properties are
-							defined in <a href="#sec-container-iri"></a>.</p>
+						<p>The <a data-cite="url#url-concept">URL</a>&#160;[[url]] of the [=root directory=]
+							representing the [=OCF abstract container=]. Although the container root URL is
+							implementation specific, its properties are defined in <a href="#sec-container-iri"
+							></a>.</p>
 					</dd>
 
 					<dt>
 						<dfn class="export">content URL</dfn>
 					</dt>
 					<dd>
-						<p> The [=url-concept|URL=] of a file or directory in the [=OCF abstract container=], defined in <a
-								href="#sec-container-iri"></a>. </p>
+						<p> The <a data-cite="url#url-concept">URL</a> of a file or directory in the [=OCF abstract
+							container=], defined in <a href="#sec-container-iri"></a>. </p>
 					</dd>
 
 					<dt>
@@ -1921,8 +1922,9 @@
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The [=container root
-						URL=] is the [=URL=]&#160;[[url]] of the [=root directory=]. Although the container root URL is
-						implementation-specific, it MUST have the following properties:</p>
+						URL=] is the <a data-cite="url#url-concept">URL</a>&#160;[[url]] of the [=root directory=].
+						Although the container root URL is implementation-specific, it MUST have the following
+						properties:</p>
 
 					<ul id="sec-root-url-properties">
 						<li id="sec-container-iri-root-parse"

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -9605,11 +9605,11 @@ html.my-document-playing * {
 						<p>Network access can also allow third-party content to exploit the user.</p>
 					</dd>
 
-					<dt>Securing content with digital rights management</dt>
+					<dt>Securing content with digital rights management and watermarks</dt>
 					<dd>
 						<p>The encryption and decryption of EPUB publications using digital rights management schemes
 							could allow personally identifiable information about the user, what vendors they use, and
-							their reading choices to be relayed to third parties.</p>
+							their reading choices to be relayed to third parties. The same is true of watermarks.</p>
 					</dd>
 				</dl>
 
@@ -9715,6 +9715,10 @@ html.my-document-playing * {
 				<p>When digital rights management schemes have to be used, prefer schemes that do not utilize or
 					transmit information about the user or their content to external parties to perform encryption or
 					decryption.</p>
+
+				<p>When watermarking has to be used, follow industry best practices for privacy such as those defined in
+						<a href="https://cdt.org/wp-content/uploads/copyright/20080529watermarking.pdf">Privacy
+						Principles for Digital Watermarking</a> [[watermark-privacy]].</p>
 
 				<p>To maximally reduce security and privacy risks, EPUB publications SHOULD be produced with the goal of
 					long-term preservation. EPUB publications created this way are normally self-contained, not
@@ -11314,6 +11318,8 @@ EPUB/images/cover.png</pre>
 			<details id="changes-epub-33" open="open">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
+					<li>18-June-2026: Added watermarking to privacy considerations. See <a
+							href="https://github.com/w3c/epub-specs/issues/3021">issue 3021</a>.</li>
 					<li>04-May-2026: Fixed outdated section number reference to ZIP64 extensions in the ZIP application
 						note. See <a href="https://github.com/w3c/epub-specs/issues/2993">issue 2993</a>.</li>
 					<li>15-Apr-2026: Added recommendation against using variable bitrate MP3 files with media overlays.

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -318,7 +318,7 @@
 						<dfn class="export">container root URL</dfn>
 					</dt>
 					<dd>
-						<p>The [=URL=]&#160;[[url]] of the [=root directory=] representing the [=OCF abstract
+						<p>The [=url-concept|URL=]&#160;[[url]] of the [=root directory=] representing the [=OCF abstract
 							container=]. Although the container root URL is implementation specific, its properties are
 							defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
@@ -327,7 +327,7 @@
 						<dfn class="export">content URL</dfn>
 					</dt>
 					<dd>
-						<p> The [=URL=] of a file or directory in the [=OCF abstract container=], defined in <a
+						<p> The [=url-concept|URL=] of a file or directory in the [=OCF abstract container=], defined in <a
 								href="#sec-container-iri"></a>. </p>
 					</dd>
 


### PR DESCRIPTION
Here's some possible text to address the watermarking issue.

Fixes #3021


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/3026.html" title="Last updated on Jun 18, 2026, 1:42 PM UTC (04de917)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/3026/92b8046...04de917.html" title="Last updated on Jun 18, 2026, 1:42 PM UTC (04de917)">Diff</a>