### PR TITLE
Fixes term links

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2501,7 +2501,9 @@
 									<li>
 										<code>META-INF/signatures.xml</code>
 									</li>
-									<li> [= <code>package document</code> =] </li>
+									<li>
+										<code>[= package document =]</code>
+									</li>
 								</ul>
 
 								<p>EPUB creators MAY subsequently encrypt signed resources using the Decryption
@@ -11121,7 +11123,7 @@ html.my-document-playing * {
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is listed in the [[EPUB spine | spine=]. It is a
+						<p>The resource is an XHTML document. It is listed in the [= EPUB spine | spine=]. It is a
 							[=publication resource=] on the manifest plane, a [=container resource=], an [=EPUB content
 							document=] on the [=spine plane=], and is not present on the [=content plane=]. No fallback
 							is necessary.</p>


### PR DESCRIPTION
Currently these two term links are not rendered:

([section](https://www.w3.org/TR/epub-33/#sec-encryption.xml-encryption))
<img width="359" height="86" alt="Screenshot of EPUB 3.3 spec showing a link of `package document` term that is not rendered" src="https://github.com/user-attachments/assets/6a1ea74f-f02e-4b29-8b13-2683205a83c1" />

([section](https://www.w3.org/TR/epub-33/#publication-resources-example))
<img width="836" height="107" alt="Screenshot of EPUB 3.3 spec showing a link of `EPUB spine` term that is not rendered" src="https://github.com/user-attachments/assets/d65e0d82-81fc-41e3-aaca-acd6e62510dd" />
