### PR TITLE
url-concept -> concept-url

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -318,7 +318,7 @@
 						<dfn class="export">container root URL</dfn>
 					</dt>
 					<dd>
-						<p>The <a data-cite="url#url-concept">URL</a>&#160;[[url]] of the [=root directory=]
+						<p>The <a data-cite="url#concept-url">URL</a>&#160;[[url]] of the [=root directory=]
 							representing the [=OCF abstract container=]. Although the container root URL is
 							implementation specific, its properties are defined in <a href="#sec-container-iri"
 							></a>.</p>
@@ -328,7 +328,7 @@
 						<dfn class="export">content URL</dfn>
 					</dt>
 					<dd>
-						<p> The <a data-cite="url#url-concept">URL</a> of a file or directory in the [=OCF abstract
+						<p> The <a data-cite="url#concept-url">URL</a> of a file or directory in the [=OCF abstract
 							container=], defined in <a href="#sec-container-iri"></a>. </p>
 					</dd>
 
@@ -1922,7 +1922,7 @@
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The [=container root
-						URL=] is the <a data-cite="url#url-concept">URL</a>&#160;[[url]] of the [=root directory=].
+						URL=] is the <a data-cite="url#concept-url">URL</a>&#160;[[url]] of the [=root directory=].
 						Although the container root URL is implementation-specific, it MUST have the following
 						properties:</p>
 


### PR DESCRIPTION
The linkchecker, ran on the CR version of the authoring spec, has flagged the url-concept fragment id for the URL spec. Indeed, the editors have changed it for concept-url, see https://url.spec.whatwg.org/#concept-url.

I will change that in the /TR version manually, to avoid problems with merge


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/3032.html" title="Last updated on Jun 30, 2026, 6:32 AM UTC (a9bbc83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/3032/3e78c15...a9bbc83.html" title="Last updated on Jun 30, 2026, 6:32 AM UTC (a9bbc83)">Diff</a>