### PR TITLE
Update workflows to build CR docs

### DIFF
--- a/.github/workflows/epub-a11y.yml
+++ b/.github/workflows/epub-a11y.yml
@@ -31,5 +31,5 @@ jobs:
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-pm-wg/2023Oct/0028.html
           W3C_BUILD_OVERRIDE: |
              shortName: epub-a11y-12
-             specStatus: CR
+             specStatus: CRD
              crEnd: 2026-10-19

--- a/.github/workflows/epub-a11y.yml
+++ b/.github/workflows/epub-a11y.yml
@@ -31,4 +31,5 @@ jobs:
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-pm-wg/2023Oct/0028.html
           W3C_BUILD_OVERRIDE: |
              shortName: epub-a11y-12
-             specStatus: WD
+             specStatus: CR
+             crEnd: 2026-10-19

--- a/.github/workflows/epub-authoring.yml
+++ b/.github/workflows/epub-authoring.yml
@@ -27,5 +27,5 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
              shortName: epub-34
-             specStatus: CR
+             specStatus: CRD
              crEnd: 2026-10-19

--- a/.github/workflows/epub-authoring.yml
+++ b/.github/workflows/epub-authoring.yml
@@ -27,4 +27,5 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
              shortName: epub-34
-             specStatus: WD
+             specStatus: CR
+             crEnd: 2026-10-19

--- a/.github/workflows/epub-rs.yml
+++ b/.github/workflows/epub-rs.yml
@@ -27,4 +27,6 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
              shortName: epub-rs-34
-             specStatus: WD
+             specStatus: CR
+             crEnd: 2026-10-19
+

--- a/.github/workflows/epub-rs.yml
+++ b/.github/workflows/epub-rs.yml
@@ -27,6 +27,6 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2025/03/13-pmwg-minutes.html#d175
           W3C_BUILD_OVERRIDE: |
              shortName: epub-rs-34
-             specStatus: CR
+             specStatus: CRD
              crEnd: 2026-10-19
 


### PR DESCRIPTION
Changes the yml files to set specStatus to CRD and add the crEnd date -- for when we start building drafts again. We could put the latter directly in the documents but it's probably simpler this way.