### PR TITLE
Remove statement that we still maintain prefixed css properties

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -251,8 +251,7 @@
 				<section id="sec-overview-relations-css">
 					<h4>Relationship to CSS</h4>
 
-					<p>EPUB 3 supports CSS as defined by the CSS Working Group Snapshot [[csssnapshot]]. EPUB 3 also
-						maintains some prefixed CSS properties, to ensure consistent support for global languages.</p>
+					<p>EPUB 3 supports CSS as defined by the CSS Working Group Snapshot [[csssnapshot]].</p>
 				</section>
 
 				<section id="sec-overview-relations-mathml">


### PR DESCRIPTION
I noticed in the "Relationship to CSS" section that we still have a sentence claiming that we maintain a set of prefixed properties. Since those were all moved to the outdated section, I think we can just drop the sentence now.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/3035.html" title="Last updated on Jun 30, 2026, 1:26 PM UTC (e4025e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/3035/13e251b...e4025e7.html" title="Last updated on Jun 30, 2026, 1:26 PM UTC (e4025e7)">Diff</a>