### PR TITLE
Fix unmarked normative refs

### DIFF
--- a/epub34/authoring/biblio.js
+++ b/epub34/authoring/biblio.js
@@ -74,6 +74,11 @@ var biblio = {
 		"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",
 		"date": "2017-04-13"
 	},
+	"iso14977": {
+		"title": "ISO/IEC 14977:1996 — Information technology — Syntactic metalanguage — Extended BNF",
+		"href": "https://www.iso.org/standard/26153.html",
+		"date": "1996-12"
+	},
 	"iso22424": {
 		"title": "ISO/IEC TS 22424-1:2020 — Digital publishing — EPUB3 preservation",
 		"href": "https://www.iso.org/standard/73163.html",
@@ -88,6 +93,10 @@ var biblio = {
 		"title": "ISO/IEC 19757-4: NVDL (Namespace-based Validation Dispatching Language)",
 		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c038615_ISO_IEC_19757-4_2006(E).zip",
 		"date": "2006-06-01"
+	},
+	"marc-relators": {
+		"title": "MARC Code List for Relators",
+		"href": "https://www.loc.gov/marc/relators/relaterm.html"
 	},
 	"odf": {
 		"title": "Open Document Format for Office Applications (OpenDocument) v1.0",

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11317,7 +11317,8 @@ EPUB/images/cover.png</pre>
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">Candidate Recommendation</a>
 					of 2026-07-21</summary>
 				<ul>
-					<li>22-July-2026: Added missing normative references identified during the CR transition.</li>
+					<li>22-July-2026: Added missing normative references identified during the CR transition. See <a
+							href="https://github.com/w3c/epub-specs/pull/3040">pull request 3040</a>.</li>
 				</ul>
 			</details>
 

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -3162,10 +3162,9 @@
 						of an OPTIONAL prefix separated from a reference by a colon.</p>
 
 					<table class="productionset">
-						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
-							<code>xsd:</code>.</caption>
+						<caption>(EBNF productions [[iso14977]])<br /> All terminal symbols are in the Unicode Block
+							'Basic Latin' (U+0000 to U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+								<code>xsd:</code>.</caption>
 						<tbody>
 							<tr>
 								<td id="compact-url.ebnf.compact-url">
@@ -3275,10 +3274,9 @@
 						prefix-to-URL mappings of the form:</p>
 
 					<table class="productionset">
-						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-							U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
-							<code>xsd:</code>.</caption>
+						<caption>(EBNF productions [[iso14977]])<br /> All terminal symbols are in the Unicode Block
+							'Basic Latin' (U+0000 to U+007F).<br /> XML Schema datatypes [[xmlschema-2]] use the prefix
+								<code>xsd:</code>.</caption>
 						<tbody>
 							<tr>
 								<td id="prefix.ebnf.def">
@@ -3448,8 +3446,8 @@
 										<td>Primarily used in the <a href="#attrdef-scheme"><code>scheme</code>
 												attribute</a> to indicate that creator and contributor roles are defined
 											in the the <a href="https://www.loc.gov/marc/relators/relaterm.html">MARC
-												relators code list</a>. Can be used to reference other vocabularies
-											published by the Library of Congress.</td>
+												relators code list</a> [[marc-relators]]. Can be used to reference other
+											vocabularies published by the Library of Congress.</td>
 									</tr>
 									<tr>
 										<td>media</td>
@@ -3461,8 +3459,8 @@
 										<td>onix</td>
 										<td>http://www.editeur.org/ONIX/book/codelists/<wbr />current.html#</td>
 										<td>Used in the <code>scheme</code> attribute to identify the <a
-												href="https://ns.editeur.org/onix/en">ONIX code list</a> a value
-											corresponds to.</td>
+												href="https://ns.editeur.org/onix/en">ONIX code list</a> [[onix]] a
+											value corresponds to.</td>
 									</tr>
 									<tr>
 										<td>rendition</td>
@@ -3474,7 +3472,7 @@
 										<td>schema</td>
 										<td>http://schema.org/</td>
 										<td>To declare properties from the <a href="https://schema.org">Schema.org
-												vocabulary</a>.</td>
+												vocabulary</a> [[schema-org]].</td>
 									</tr>
 								</tbody>
 							</table>
@@ -10497,9 +10495,8 @@ EPUB/images/cover.png</pre>
 						<p>The value of the [^meta/content^] attribute [[html]] after <a data-cite="xml#AVNormalize"
 								>whitespace normalization</a>&#160;[[xml]] MUST be of the following form:</p>
 						<table class="productionset">
-							<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-									14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
-								to U+007F).</caption>
+							<caption>(EBNF productions [[iso14977]])<br /> All terminal symbols are in the Unicode Block
+								'Basic Latin' (U+0000 to U+007F).</caption>
 							<tbody>
 								<tr>
 									<td id="viewport.ebnf.def">

--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -11313,7 +11313,15 @@ EPUB/images/cover.png</pre>
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue%20is%3Aclosed%20label%3ASpec-EPUB3%20closed%3A2025-02-11..2027-02-11%20-label%3AErrata"
 					>Working Group's issue tracker</a>.</p>
 
-			<details id="changes-epub-33" open="open">
+			<details id="changes-cr-20260721" open="open">
+				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">Candidate Recommendation</a>
+					of 2026-07-21</summary>
+				<ul>
+					<li>22-July-2026: Added missing normative references identified during the CR transition.</li>
+				</ul>
+			</details>
+
+			<details id="changes-epub-33">
 				<summary>Substantive changes since <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a></summary>
 				<ul>
 					<li>18-June-2026: Added watermarking to privacy considerations. See <a


### PR DESCRIPTION
I took a look at the [link report](https://labs.w3.org/normative-references/check?url=https%3A%2F%2Fwww.w3.org%2FTR%2F2026%2FCR-epub-34-20260721%2F) mentioned in the transition request and these looked like the only references that could be made normative.

Most of the items it flagged were in the iana registrations where we wouldn't use normative or informative references.

Do you think we should add a new substantive changes section to the change log to mention this @iherman? If we were updating a REC I think we'd have to note this as a class 2 change and log it, but it doesn't seem all that substantive when we're just tidying up a CR doc.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/3040.html" title="Last updated on Jul 8, 2026, 2:14 AM UTC (a4c7094)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/3040/c986f2e...a4c7094.html" title="Last updated on Jul 8, 2026, 2:14 AM UTC (a4c7094)">Diff</a>