### PR TITLE
Updated the section on the pagination objectives

### DIFF
--- a/epub34/a11y-explain/index.html
+++ b/epub34/a11y-explain/index.html
@@ -8,99 +8,99 @@
 		<script src="../../common/js/css-inline.js" class="remove"></script>
 		<script src="../../common/js/add-caution-hd.js" class="remove"></script>
 		<script class="remove">
-			var respecConfig = {
-				group: "pm",
-				wgPublicList: "public-pm-wg",
-				specStatus: "ED",
-				shortName: "epub-a11y-explain-12",
-				subtitle: "A guide to understanding and evaluating accessible publications",
-				noRecTrack: true,
-				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-explain/",
+            var respecConfig = {
+                group: "pm",
+                wgPublicList: "public-pm-wg",
+                specStatus: "ED",
+                shortName: "epub-a11y-explain-12",
+                subtitle: "A guide to understanding and evaluating accessible publications",
+                noRecTrack: true,
+                edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-explain/",
                 copyrightStart: "2026",
-				editors:[ {
-					name: "Matt Garrish",
-					company: "DAISY Consortium",
+                editors:[ {
+                    name: "Matt Garrish",
+                    company: "DAISY Consortium",
                     companyURL: "https://daisy.org",
-					w3cid: 51655
-				}, {
-					name: "George Kerscher",
-					company: "DAISY Consortium",
-					companyURL: "https://daisy.org",
-					w3cid: 1460
-				}, {
-					name: "Charles LaPierre",
-					company: "Benetech",
-					companyURL: "https://benetech.org",
-					w3cid: 72055
-				}, {
-					name: "Gregorio Pellegrino",
-					company: "Fondazione LIA",
-					companyURL: "https://www.fondazionelia.org",
-					w3cid: 97111
-				}, {
-					name: "Avneesh Singh",
-					company: "DAISY Consortium",
-					companyURL: "https://daisy.org",
-					w3cid: 75336
-				}],
-				includePermalinks: true,
-				permalinkEdge: true,
-				permalinkHide: false,
-				github: {
-					repoURL: "https://github.com/w3c/epub-specs",
-					branch: "main"
-				},
-				profile: "web-platform",
-				localBiblio: {
-					"epub-3": {
-						"title": "EPUB 3",
-						"href": "https://www.w3.org/TR/epub/",
-						"publisher": "W3C"
-					},
-					"ops-201": {
-						"title": "Open Publication Structure 2.0.1",
-						"href": "http://idpf.org/epub/20/spec/OPS_2.0.1_draft.htm",
-						"date": "04 September 2010",
-						"publisher": "IDPF"
-					},
-					"wai-aria": {
-						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
-						"href": "https://www.w3.org/TR/wai-aria/",
-						"publisher": "W3C"
-					},
-					"wcag2": {
-						"title": "Web Content Accessibility Guidelines (WCAG) 2",
-						"href": "https://www.w3.org/TR/WCAG2/",
-						"publisher": "W3C"
-					}
-				},
-				preProcess:[inlineCustomCSS],
-				postProcess: [addCautionHeaders]
-			};</script>
+                    w3cid: 51655
+                }, {
+                    name: "George Kerscher",
+                    company: "DAISY Consortium",
+                    companyURL: "https://daisy.org",
+                    w3cid: 1460
+                }, {
+                    name: "Charles LaPierre",
+                    company: "Benetech",
+                    companyURL: "https://benetech.org",
+                    w3cid: 72055
+                }, {
+                    name: "Gregorio Pellegrino",
+                    company: "Fondazione LIA",
+                    companyURL: "https://www.fondazionelia.org",
+                    w3cid: 97111
+                }, {
+                    name: "Avneesh Singh",
+                    company: "DAISY Consortium",
+                    companyURL: "https://daisy.org",
+                    w3cid: 75336
+                }],
+                includePermalinks: true,
+                permalinkEdge: true,
+                permalinkHide: false,
+                github: {
+                    repoURL: "https://github.com/w3c/epub-specs",
+                    branch: "main"
+                },
+                profile: "web-platform",
+                localBiblio: {
+                    "epub-3": {
+                        "title": "EPUB 3",
+                        "href": "https://www.w3.org/TR/epub/",
+                        "publisher": "W3C"
+                    },
+                    "ops-201": {
+                        "title": "Open Publication Structure 2.0.1",
+                        "href": "http://idpf.org/epub/20/spec/OPS_2.0.1_draft.htm",
+                        "date": "04 September 2010",
+                        "publisher": "IDPF"
+                    },
+                    "wai-aria": {
+                        "title": "Accessible Rich Internet Applications (WAI-ARIA)",
+                        "href": "https://www.w3.org/TR/wai-aria/",
+                        "publisher": "W3C"
+                    },
+                    "wcag2": {
+                        "title": "Web Content Accessibility Guidelines (WCAG) 2",
+                        "href": "https://www.w3.org/TR/WCAG2/",
+                        "publisher": "W3C"
+                    }
+                },
+                preProcess:[inlineCustomCSS],
+                postProcess:[addCautionHeaders]
+            };</script>
 		<style>
 			pre {
-				white-space: break-spaces !important;
+			    white-space: break-spaces !important;
 			}
 			table.zebra tbody th {
-				vertical-align: text-top;
-				background-color: inherit !important;
-				color: inherit !important;
+			    vertical-align: text-top;
+			    background-color: inherit !important;
+			    color: inherit !important;
 			}
 			table.zebra td {
-				vertical-align: text-top;
+			    vertical-align: text-top;
 			}
 			table.zebra p:before {
-				content: '•';
-				font-size: 120%;
-				margin-left: 1.1rem;
-				padding-right: 0.6rem;
+			    content: '•';
+			    font-size: 120%;
+			    margin-left: 1.1rem;
+			    padding-right: 0.6rem;
 			}</style>
 	</head>
 	<body>
 		<section id="abstract">
-			<p>The EPUB Accessibility 1.2 Explainer provides information on how to understand and evaluate the
-				accessible publications conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against
-				reflowable EPUB publications.</p>
+			<p>The EPUB Accessibility 1.2 Explainer provides information on how to understand and
+				evaluate the accessible publications conformance requirements of [[[epub-a11y-12]]]
+				[[epub-a11y-12]] against reflowable EPUB publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="intro">
@@ -109,42 +109,47 @@
 			<section id="overview">
 				<h3>Overview</h3>
 
-				<p>This document together with [[[epub-a11y-tech-12]]] [[epub-a11y-tech-12]] provide informative support
-					for implementing [[[epub-a11y-12]]] [[epub-a11y-12]]. This document provides general explanation of
-					the "<a data-cite="epub-a11y-12#sec-accessible-pubs">Accessible publications</a>" section of EPUB
-					Accessibility 1.2, while the EPUB Accessibility Techniques 1.2 document details specific methods for
-					meeting those requirements.</p>
+				<p>This document together with [[[epub-a11y-tech-12]]] [[epub-a11y-tech-12]] provide
+					informative support for implementing [[[epub-a11y-12]]] [[epub-a11y-12]]. This
+					document provides general explanation of the "<a
+						data-cite="epub-a11y-12#sec-accessible-pubs">Accessible publications</a>"
+					section of EPUB Accessibility 1.2, while the EPUB Accessibility Techniques 1.2
+					document details specific methods for meeting those requirements.</p>
 
-				<p>This document is divided into three parts. The <a href="#wcag">first part</a> covers WCAG [[wcag2]]
-					success criteria whose application to digital publications is ambiguous or that have been found to
-					have limited application. WCAG is heavily focused on making the web accessible so the explainer
-					documents that come with it rarely account for the differences with packaged web content such as is
-					found in EPUB publications.</p>
+				<p>This document is divided into three parts. The <a href="#wcag">first part</a>
+					covers WCAG [[wcag2]] success criteria whose application to digital publications
+					is ambiguous or that have been found to have limited application. WCAG is
+					heavily focused on making the web accessible so the explainer documents that
+					come with it rarely account for the differences with packaged web content such
+					as is found in EPUB publications.</p>
 
 				<p>The <a href="#epub">second part</a> explains the purpose of the additional <a
-						data-cite="epub-a11y-12#sec-epub-req">EPUB objectives</a> [[epub-a11y-12]]. These are
-					requirements not covered by WCAG as they are unique to EPUB publications.</p>
+						data-cite="epub-a11y-12#sec-epub-req">EPUB objectives</a> [[epub-a11y-12]].
+					These are requirements not covered by WCAG as they are unique to EPUB
+					publications.</p>
 
-				<p>And the <a href="#eval">final part</a> covers issues with evaluating EPUB publications. How to assess
-					EPUB publications is intentionally not covered by the standard because it is possible for
-					evaluations and reports to be done in different ways. But regardless of how evaluations are carried
-					out and reported, there are common issues that this document tries to help in understanding.</p>
+				<p>And the <a href="#eval">final part</a> covers issues with evaluating EPUB
+					publications. How to assess EPUB publications is intentionally not covered by
+					the standard because it is possible for evaluations and reports to be done in
+					different ways. But regardless of how evaluations are carried out and reported,
+					there are common issues that this document tries to help in understanding.</p>
 			</section>
 
 			<section id="scope">
 				<h3>Scope</h3>
 
-				<p>This document is limited in focus to <a data-cite="epub-3#sec-reflowable">reflowable EPUB
-						publications</a> [[epub-3]].</p>
+				<p>This document is limited in focus to <a data-cite="epub-3#sec-reflowable"
+						>reflowable EPUB publications</a> [[epub-3]].</p>
 
-				<p>It does not provide techniques for meeting the objectives of [[[epub-a11y-12]]. Refer to
-					[[[epub-a11y-tech-12]]] for more information about how to meet specific success criteria and
-					objectives.</p>
+				<p>It does not provide techniques for meeting the objectives of [[[epub-a11y-12]].
+					Refer to [[[epub-a11y-tech-12]]] for more information about how to meet specific
+					success criteria and objectives.</p>
 
 				<p>Although, in many cases, the guidance will also prove useful for evaluating <a
-						data-cite="epub-3#sec-fixed-layouts">fixed-layout EPUB publications</a> [[epub-3]], making those
-					kinds of publications accessible presents unique challenges. Guidance on making fixed layouts more
-					accessible is instead provided in [[[epub-fxl-a11y]]] [[epub-fxl-a11y]].</p>
+						data-cite="epub-3#sec-fixed-layouts">fixed-layout EPUB publications</a>
+					[[epub-3]], making those kinds of publications accessible presents unique
+					challenges. Guidance on making fixed layouts more accessible is instead provided
+					in [[[epub-fxl-a11y]]] [[epub-fxl-a11y]].</p>
 			</section>
 		</section>
 		<section id="wcag">
@@ -156,64 +161,76 @@
 				<section id="authentication-application">
 					<h4>Application</h4>
 
-					<p>There are two [[wcag2]] accessible authentication success criteria &#8212; a <a
-							data-cite="wcag2#accessible-authentication-minimum">minimum (3.3.8)</a> and an <a
-							data-cite="wcag2#accessible-authentication-enhanced">enhanced (3.3.9)</a> version &#8212; as
-						well as a related success criterion for <a data-cite="wcag2#re-authenticating">re-authentication
-							(2.2.5)</a>. These have a combined goal of ensuring that users with certain cognitive
-						disabilities are provided an easy-to-use and accessible login method for protected web sites,
-						and that information is not lost if users have to reauthenticate themselves.</p>
+					<p>There are two [[wcag2]] accessible authentication success criteria &#8212; a
+							<a data-cite="wcag2#accessible-authentication-minimum">minimum
+							(3.3.8)</a> and an <a
+							data-cite="wcag2#accessible-authentication-enhanced">enhanced
+							(3.3.9)</a> version &#8212; as well as a related success criterion for
+							<a data-cite="wcag2#re-authenticating">re-authentication (2.2.5)</a>.
+						These have a combined goal of ensuring that users with certain cognitive
+						disabilities are provided an easy-to-use and accessible login method for
+						protected web sites, and that information is not lost if users have to
+						reauthenticate themselves.</p>
 
-					<p>Not all users are able to remember usernames and passwords, transcribe verification access codes,
-						or solve puzzles to gain entry which is why it is important that logins do not rely solely on
-						methods that require these kinds of cognitive capabilities. It is also vital to ensure that
-						users do not lose any information they have input if they are required to reauthenticate as this
-						could prevent some users from being able to complete the task (i.e., they may continue to reach
-						the time out just trying to re-enter the lost information).</p>
+					<p>Not all users are able to remember usernames and passwords, transcribe
+						verification access codes, or solve puzzles to gain entry which is why it is
+						important that logins do not rely solely on methods that require these kinds
+						of cognitive capabilities. It is also vital to ensure that users do not lose
+						any information they have input if they are required to reauthenticate as
+						this could prevent some users from being able to complete the task (i.e.,
+						they may continue to reach the time out just trying to re-enter the lost
+						information).</p>
 
-					<p>It is not common that these success criteria will apply to EPUB publications, however. When a
-						login is required, the more typical scenario is that a vendor will require users to log in to
-						their reading system to access their publications. In this case, if the login does not meet the
-						requirements of the minimum success criterion, then it is the reading system that is not
-						accessible, not the individual publications it provides access to. Similarly, if the reading
-						system loses the current state of a quiz or task at the time it forces reauthentication, there
-						is nothing the publication can do about this.</p>
+					<p>It is not common that these success criteria will apply to EPUB publications,
+						however. When a login is required, the more typical scenario is that a
+						vendor will require users to log in to their reading system to access their
+						publications. In this case, if the login does not meet the requirements of
+						the minimum success criterion, then it is the reading system that is not
+						accessible, not the individual publications it provides access to.
+						Similarly, if the reading system loses the current state of a quiz or task
+						at the time it forces reauthentication, there is nothing the publication can
+						do about this.</p>
 
-					<p>Even in the case of EPUB publications served through a learning management system (LMS), it is
-						more typical for the user to log in to the LMS. The LMS may use that information to track their
-						activity, but again it is rarely the publications within the LMS that are secured.</p>
+					<p>Even in the case of EPUB publications served through a learning management
+						system (LMS), it is more typical for the user to log in to the LMS. The LMS
+						may use that information to track their activity, but again it is rarely the
+						publications within the LMS that are secured.</p>
 
-					<p>One major reason that EPUB publications typically do not build in login requirements is because
-						scripting support is not guaranteed. The reading system is more reliably going to have a
-						connection to, or be able to connect to, the user's network. It is also more capable of being
-						able to store information for later transmission to a publisher's server when a connection is
-						not immediately available, as persistent storage is also not commonly available within EPUB
-						publications. The lack of persistent state also means that a login in one EPUB content document
-						likely will not persist into any of the others. That means a user might, for example, have to
-						log in at the end of every chapter to complete embedded quizzes.</p>
+					<p>One major reason that EPUB publications typically do not build in login
+						requirements is because scripting support is not guaranteed. The reading
+						system is more reliably going to have a connection to, or be able to connect
+						to, the user's network. It is also more capable of being able to store
+						information for later transmission to a publisher's server when a connection
+						is not immediately available, as persistent storage is also not commonly
+						available within EPUB publications. The lack of persistent state also means
+						that a login in one EPUB content document likely will not persist into any
+						of the others. That means a user might, for example, have to log in at the
+						end of every chapter to complete embedded quizzes.</p>
 				</section>
 
 				<section id="authentication-locating">
 					<h4>Locating</h4>
 
-					<p>Despite the potential drawbacks of adding authentication to EPUB publications, nothing prevents a
-						publisher from using logins. They are much rarer than on the web because a publication belongs
-						to one user and so it does not have to be blocked internally from public access and there is no
-						question if the user is human or not. Authentication typically only matters in the case where
-						the publisher has to collect information; for example, from quizzes and other interactive
-						content.</p>
+					<p>Despite the potential drawbacks of adding authentication to EPUB
+						publications, nothing prevents a publisher from using logins. They are much
+						rarer than on the web because a publication belongs to one user and so it
+						does not have to be blocked internally from public access and there is no
+						question if the user is human or not. Authentication typically only matters
+						in the case where the publisher has to collect information; for example,
+						from quizzes and other interactive content.</p>
 
-					<p>For these reasons, it is unlikely that logins will be found outside of educational material,
-						which can help narrow down when to look for them. Since a login will typically require the user
-						to have an account with the publisher, they are less likely to be found in general reading
-						material.</p>
+					<p>For these reasons, it is unlikely that logins will be found outside of
+						educational material, which can help narrow down when to look for them.
+						Since a login will typically require the user to have an account with the
+						publisher, they are less likely to be found in general reading material.</p>
 
-					<p>But, while it may be highly uncommon to find logins, their possibility cannot be ignored when
-						performing an accessibility review.</p>
+					<p>But, while it may be highly uncommon to find logins, their possibility cannot
+						be ignored when performing an accessibility review.</p>
 
-					<p>Unfortunately, there is no quick way to determine if a publication has a login attached to any of
-						its content short of manually checking. The only useful aid that an EPUB publication provides is
-						the scripting designation that has to be expressed in the package document manifest.</p>
+					<p>Unfortunately, there is no quick way to determine if a publication has a
+						login attached to any of its content short of manually checking. The only
+						useful aid that an EPUB publication provides is the scripting designation
+						that has to be expressed in the package document manifest.</p>
 
 					<aside class="example" title="Scripted content document designation">
 						<pre>&lt;package xmlns="http://www.idpf.org/2007/opf" &#8230;>
@@ -225,66 +242,77 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>Knowing which files are scripted may help reduce the amount of work involved in finding logins,
-						but that is only if scripting is used sparingly in the publication. If most or all of the EPUB
-						content documents are scripted, it might be easier to read the JavaScript files. Even without a
-						strong knowledge of scripting, the names of the various functions might provide clues to their
-						purpose. For example, a function with "login" in its name would be a major flag to look more
-						deeply into what the scripting is doing.</p>
+					<p>Knowing which files are scripted may help reduce the amount of work involved
+						in finding logins, but that is only if scripting is used sparingly in the
+						publication. If most or all of the EPUB content documents are scripted, it
+						might be easier to read the JavaScript files. Even without a strong
+						knowledge of scripting, the names of the various functions might provide
+						clues to their purpose. For example, a function with "login" in its name
+						would be a major flag to look more deeply into what the scripting is
+						doing.</p>
 
-					<p>Ultimately, direct testing of all scripted content for accessibility is always advised (i.e., not
-						trying to gauge the accessibility by looking only at the markup), so as long as an assessment is
-						thorough in this regard any logins should be found in due course.</p>
+					<p>Ultimately, direct testing of all scripted content for accessibility is
+						always advised (i.e., not trying to gauge the accessibility by looking only
+						at the markup), so as long as an assessment is thorough in this regard any
+						logins should be found in due course.</p>
 
-					<p>If a login is found, checking for a reauthentication requirement may still take some work. It
-						should never be assumed that lack of mention of a timed session means that users will not be
-						prompted to reauthenticate after a certain amount of time, or a certain amount of time without
-						activity being registered. Verifying if there is a timeout, and checking what happens after
-						reauthenticating, may require inspecting code to understand when a timeout is triggered. If the
-						evaluator is not the publisher of the content, it may be faster to check with publisher whether
-						session timeouts can occur and how best to test them.</p>
+					<p>If a login is found, checking for a reauthentication requirement may still
+						take some work. It should never be assumed that lack of mention of a timed
+						session means that users will not be prompted to reauthenticate after a
+						certain amount of time, or a certain amount of time without activity being
+						registered. Verifying if there is a timeout, and checking what happens after
+						reauthenticating, may require inspecting code to understand when a timeout
+						is triggered. If the evaluator is not the publisher of the content, it may
+						be faster to check with publisher whether session timeouts can occur and how
+						best to test them.</p>
 				</section>
 			</section>
 
 			<section id="bypass-blocks">
 				<h3>Bypass blocks</h3>
 
-				<p>Web sites are constructed very differently from EPUB publications. A typical web site wraps the
-					content of each page within a repeating template, for example. This template gives each page a
-					consistent look and feel, but users are rarely interested in the wrapper content after visiting the
-					first page. Visual readers can typically skip past the site header, navigation bars, search boxes,
-					and other helpful but seldom-used features to get right to the content.</p>
+				<p>Web sites are constructed very differently from EPUB publications. A typical web
+					site wraps the content of each page within a repeating template, for example.
+					This template gives each page a consistent look and feel, but users are rarely
+					interested in the wrapper content after visiting the first page. Visual readers
+					can typically skip past the site header, navigation bars, search boxes, and
+					other helpful but seldom-used features to get right to the content.</p>
 
-				<p>To provide the same ease of access to readers who would have to navigate sequentially through the
-					repetitive content, the [[wcag2]] <a href="https://www.w3.org/TR/WCAG/#bypass-blocks">bypass blocks
-						success criterion (2.4.1)</a> requires a means of bypassing the repeated content in a set of
-					pages. This success criterion does not apply to typical EPUB publications, however, as EPUB content
-					documents do not repeat content in the same way that web sites do.</p>
+				<p>To provide the same ease of access to readers who would have to navigate
+					sequentially through the repetitive content, the [[wcag2]] <a
+						href="https://www.w3.org/TR/WCAG/#bypass-blocks">bypass blocks success
+						criterion (2.4.1)</a> requires a means of bypassing the repeated content in
+					a set of pages. This success criterion does not apply to typical EPUB
+					publications, however, as EPUB content documents do not repeat content in the
+					same way that web sites do.</p>
 
-				<p>Each new content document might begin with similar content, such as learning objectives or key terms,
-					but this content is part of the body of the publication and not identical to what came before.
-					Consequently, it is not required to add a link to skip it. (Secondary content still needs to be
-					identified in accordance with <a href="https://www.w3.org/TR/WCAG/#info-and-relationships">success
+				<p>Each new content document might begin with similar content, such as learning
+					objectives or key terms, but this content is part of the body of the publication
+					and not identical to what came before. Consequently, it is not required to add a
+					link to skip it. (Secondary content still needs to be identified in accordance
+					with <a href="https://www.w3.org/TR/WCAG/#info-and-relationships">success
 						criterion 1.3.1</a>, however.)</p>
 
 				<div class="note">
-					<p>If an EPUB publication were to reproduce a set of web pages with their full site trappings, then
-						success criterion 2.4.1 would apply, but this practice is not common.</p>
+					<p>If an EPUB publication were to reproduce a set of web pages with their full
+						site trappings, then success criterion 2.4.1 would apply, but this practice
+						is not common.</p>
 				</div>
 			</section>
 
 			<section id="consistent-help">
 				<h3>Consistent help</h3>
 
-				<p>The goal of the [[wcag2]] <a data-cite="wcag2#consistent-help">consistent help success criterion
-						(3.2.6)</a> is to ensure that when a help mechanism is provided across a set of pages, it is
-					consistently located for discovery by users. Consistent placement ensure that, for example,
-					non-visual users and users with cognitive disabilities can easily locate the help information if
-					they are having difficulty completing a task.</p>
+				<p>The goal of the [[wcag2]] <a data-cite="wcag2#consistent-help">consistent help
+						success criterion (3.2.6)</a> is to ensure that when a help mechanism is
+					provided across a set of pages, it is consistently located for discovery by
+					users. Consistent placement ensure that, for example, non-visual users and users
+					with cognitive disabilities can easily locate the help information if they are
+					having difficulty completing a task.</p>
 
-				<p>The application of this success criterion to EPUB publications, however, is nowhere near as prevalent
-					as it is for the web. First off, the success criterion is limited to the following types of
-					help:</p>
+				<p>The application of this success criterion to EPUB publications, however, is
+					nowhere near as prevalent as it is for the web. First off, the success criterion
+					is limited to the following types of help:</p>
 
 				<ul>
 					<li>human contact details;</li>
@@ -293,37 +321,43 @@
 					<li>a fully automated contact mechanism.</li>
 				</ul>
 
-				<p>It does not apply to instructional help that might be provided for forms &#8212; for example, for
-					embedded tests, quizzes, and other interactive content. Its focus is on help mechanisms such as a
-					phone number or email address to contact a site owner, or a link out to a frequently asked questions
-					site, or an option to open a chat window, or an embedded contact form.</p>
+				<p>It does not apply to instructional help that might be provided for forms &#8212;
+					for example, for embedded tests, quizzes, and other interactive content. Its
+					focus is on help mechanisms such as a phone number or email address to contact a
+					site owner, or a link out to a frequently asked questions site, or an option to
+					open a chat window, or an embedded contact form.</p>
 
 				<div class="note">
-					<p>This success criterion does not require these kinds of help mechanisms; its focus is only on
-						their consistently placement when present.</p>
+					<p>This success criterion does not require these kinds of help mechanisms; its
+						focus is only on their consistently placement when present.</p>
 				</div>
 
-				<p>It is not that these kinds of contact features will never occur in publications, but it is rare that
-					they are repeated across documents. When publishers provide help contact information, it is usually
-					only provided once, either in a front or back matter section. In this case, since the contact
-					information is not repeated there is no consistency issue.</p>
+				<p>It is not that these kinds of contact features will never occur in publications,
+					but it is rare that they are repeated across documents. When publishers provide
+					help contact information, it is usually only provided once, either in a front or
+					back matter section. In this case, since the contact information is not repeated
+					there is no consistency issue.</p>
 
 				<div class="note">
-					<p>The success criterion does not require a publisher to be consistent in where they locate this
-						information from book to book, but it is helpful to users to place it in the same location.</p>
+					<p>The success criterion does not require a publisher to be consistent in where
+						they locate this information from book to book, but it is helpful to users
+						to place it in the same location.</p>
 				</div>
 
-				<p>But just because it is not common to repeat contact information does not mean it cannot occur. If a
-					publisher includes quizzes at the end of each chapter, they might choose to add their contact
-					information to the beginning or end of each quiz to make it easier for users to find and be able to
-					reach out to them. In this case, the placement has to be consistent. If the contact information is
-					at the start of the first quiz, it needs to be placed at the start of each subsequent quiz. It
-					cannot be at the start of some of the quizzes and at the end of others.</p>
+				<p>But just because it is not common to repeat contact information does not mean it
+					cannot occur. If a publisher includes quizzes at the end of each chapter, they
+					might choose to add their contact information to the beginning or end of each
+					quiz to make it easier for users to find and be able to reach out to them. In
+					this case, the placement has to be consistent. If the contact information is at
+					the start of the first quiz, it needs to be placed at the start of each
+					subsequent quiz. It cannot be at the start of some of the quizzes and at the end
+					of others.</p>
 
-				<p>So, although rare, care needs to be taken not to skip evaluating an EPUB publication for consistent
-					help. Educational material is the most likely to have repeated contact information due to their
-					inclusion of tests, quizzes, and games, but any time embed interactive content is found a quick
-					check should be made that there is not a repeating help mechanism that falls under this success
+				<p>So, although rare, care needs to be taken not to skip evaluating an EPUB
+					publication for consistent help. Educational material is the most likely to have
+					repeated contact information due to their inclusion of tests, quizzes, and
+					games, but any time embed interactive content is found a quick check should be
+					made that there is not a repeating help mechanism that falls under this success
 					criterion.</p>
 			</section>
 
@@ -333,78 +367,89 @@
 				<section id="consistent-navigation-application">
 					<h4>Application</h4>
 
-					<p>The [[wcag2]] <a data-cite="wcag2#consistent-navigation">consistent navigation success criterion
-							(3.2.3)</a> has a similar goal to the <a href="#consistent-help">consistent help success
-							criterion</a> but in this case the objective is to make it easier for users on the web to
-						find and use repeated navigational aids such as tables of contents, search boxes, and skip to
-						content links. Having these aids in the same location, and the links within them ordered in the
-						same way (when the links repeat), simplifies navigating a site.</p>
+					<p>The [[wcag2]] <a data-cite="wcag2#consistent-navigation">consistent
+							navigation success criterion (3.2.3)</a> has a similar goal to the <a
+							href="#consistent-help">consistent help success criterion</a> but in
+						this case the objective is to make it easier for users on the web to find
+						and use repeated navigational aids such as tables of contents, search boxes,
+						and skip to content links. Having these aids in the same location, and the
+						links within them ordered in the same way (when the links repeat),
+						simplifies navigating a site.</p>
 
-					<p>But many of these kinds of navigation aids are not included in EPUB publications, at least in a
-						way that they fall on the publisher to make accessible (i.e., being available across multiple
-						content documents). It is the user's reading system that is going to make access to the table of
-						contents, or landmarks, or page list, or a search box consistently available in its user
-						interface. Likewise, information about what (virtual) page the user is on is handled by the
-						reading system. Even the EPUB equivalent of a skip to content link &#8212; a landmark to the
-						first page of body matter &#8212; is information for the reading system to use to advance the
-						user; it is not content the user directly encounters in the publication.</p>
+					<p>But many of these kinds of navigation aids are not included in EPUB
+						publications, at least in a way that they fall on the publisher to make
+						accessible (i.e., being available across multiple content documents). It is
+						the user's reading system that is going to make access to the table of
+						contents, or landmarks, or page list, or a search box consistently available
+						in its user interface. Likewise, information about what (virtual) page the
+						user is on is handled by the reading system. Even the EPUB equivalent of a
+						skip to content link &#8212; a landmark to the first page of body matter
+						&#8212; is information for the reading system to use to advance the user; it
+						is not content the user directly encounters in the publication.</p>
 
-					<p>If the reading system were to change the order of access to these features in the middle of
-						reading a publication, that would be a failure of the reading system not the publisher.
-						Similarly, if it were to change the order of the links within a navigation element &#8212; for
-						example, change the order of the landmark links &#8212; that would also be a failure of the
-						reading system.</p>
+					<p>If the reading system were to change the order of access to these features in
+						the middle of reading a publication, that would be a failure of the reading
+						system not the publisher. Similarly, if it were to change the order of the
+						links within a navigation element &#8212; for example, change the order of
+						the landmark links &#8212; that would also be a failure of the reading
+						system.</p>
 
 					<div class="note">
-						<p>Including the EPUB navigation document in the spine does not fall under the success criterion
-							because it is a one-time placement and not available across the other spine items.</p>
+						<p>Including the EPUB navigation document in the spine does not fall under
+							the success criterion because it is a one-time placement and not
+							available across the other spine items.</p>
 					</div>
 				</section>
 
 				<section id="consistent-navigation-mini-toc">
 					<h4>Mini tables of contents</h4>
 
-					<p>The most common case where the consistent navigation success criterion applies to EPUB
-						publication is when chapters include mini tables of contents at their start. These are most
-						typically found in educational works to provide quick access to all the subsections of a major
-						topic.</p>
+					<p>The most common case where the consistent navigation success criterion
+						applies to EPUB publication is when chapters include mini tables of contents
+						at their start. These are most typically found in educational works to
+						provide quick access to all the subsections of a major topic.</p>
 
-					<p>In this case, the position of each of these mini tables of contents needs to be consistent
-						relative to any other content at the beginning of the chapter or section. If the first mini
-						table of contents occurs after the first chapter heading, for example, then the same pattern has
-						to be followed in each subsequent chapter.</p>
+					<p>In this case, the position of each of these mini tables of contents needs to
+						be consistent relative to any other content at the beginning of the chapter
+						or section. If the first mini table of contents occurs after the first
+						chapter heading, for example, then the same pattern has to be followed in
+						each subsequent chapter.</p>
 
-					<p>It is also worth noting that the pattern of placement has to be consistent, not that the same
-						elements always have to appear. For example, if some chapters have a title followed by an
-						epigraph, followed by an image to illustrate the concept being covered before the mini table of
-						contents is provided, then it is acceptable if some chapters omit the epigraph and/or image so
-						long as the order of the elements before the navigation is always consistent. It would only be a
-						failure if the mini table of contents is sometimes placed before the heading, or between the
-						epigraph and image.</p>
+					<p>It is also worth noting that the pattern of placement has to be consistent,
+						not that the same elements always have to appear. For example, if some
+						chapters have a title followed by an epigraph, followed by an image to
+						illustrate the concept being covered before the mini table of contents is
+						provided, then it is acceptable if some chapters omit the epigraph and/or
+						image so long as the order of the elements before the navigation is always
+						consistent. It would only be a failure if the mini table of contents is
+						sometimes placed before the heading, or between the epigraph and image.</p>
 
-					<p>The order of links within the mini tables of contents is not likely going to be relevant to check
-						for this success criterion. Because each chapter's content is unique, the links are never going
-						to be repeated from one chapter to the next so there is not a consistent order that has to be
+					<p>The order of links within the mini tables of contents is not likely going to
+						be relevant to check for this success criterion. Because each chapter's
+						content is unique, the links are never going to be repeated from one chapter
+						to the next so there is not a consistent order that has to be
 						maintained.</p>
 				</section>
 
 				<section id="consistent-navigation-page-numbering">
 					<h4>Page numbering</h4>
 
-					<p>Although page numbers provide a form of static navigation aid &#8212; indicating to the user
-						where they are in a publication &#8212; their consistent placement in reflowable EPUB
-						publications is out of scope for this success criterion. Page break markers in these documents
-						will occur arbitrarily at locations that typically correspond to a statically paginated
+					<p>Although page numbers provide a form of static navigation aid &#8212;
+						indicating to the user where they are in a publication &#8212; their
+						consistent placement in reflowable EPUB publications is out of scope for
+						this success criterion. Page break markers in these documents will occur
+						arbitrarily at locations that typically correspond to a statically paginated
 						equivalent, like a print copy of the book.</p>
 
-					<p>The consistent identification of page break markers in reflowable publications is more typically
-						a concern of the reading system, as it will provide the user the page number somewhere in its
-						user interface.</p>
+					<p>The consistent identification of page break markers in reflowable
+						publications is more typically a concern of the reading system, as it will
+						provide the user the page number somewhere in its user interface.</p>
 
 					<div class="note">
-						<p>Page number location can be a concern with fixed-layout publications, particularly if they
-							reproduce print-equivalent page headers and footers. Refer to [[[epub-fxl-a11y]]]
-							[[epub-fxl-a11y]] for more information.</p>
+						<p>Page number location can be a concern with fixed-layout publications,
+							particularly if they reproduce print-equivalent page headers and
+							footers. Refer to [[[epub-fxl-a11y]]] [[epub-fxl-a11y]] for more
+							information.</p>
 					</div>
 				</section>
 			</section>
@@ -412,82 +457,97 @@
 			<section id="live-media">
 				<h3>Live media</h3>
 
-				<p>The purpose of the [[wcag2]] <a data-cite="wcag2#captions-live">Captions (Live) (1.2.4)</a> and <a
-						data-cite="wcag2#audio-only-live">Audio-only (Live) (1.2.9)</a> success criteria is to ensure
-					that users who are deaf or hard of hearing can access real-time presentations over the web. Typical
-					examples of content these success criteria apply to include live podcasts, concerts, and esport
-					events.</p>
+				<p>The purpose of the [[wcag2]] <a data-cite="wcag2#captions-live">Captions (Live)
+						(1.2.4)</a> and <a data-cite="wcag2#audio-only-live">Audio-only (Live)
+						(1.2.9)</a> success criteria is to ensure that users who are deaf or hard of
+					hearing can access real-time presentations over the web. Typical examples of
+					content these success criteria apply to include live podcasts, concerts, and
+					esport events.</p>
 
-				<p>The live nature of these success criteria make their application to EPUB publications largely
-					theoretical. For one, EPUB does not support embedding live video streaming services which means the
-					only way to live stream video is to use JavaScript libraries. That immediately reduces the
-					reliability of playback since reading systems vary widely in what kind of scripting they will allow.
-					It is also not uncommon for a reading system that allows scripting to block access to the
-					network.</p>
+				<p>The live nature of these success criteria make their application to EPUB
+					publications largely theoretical. For one, EPUB does not support embedding live
+					video streaming services which means the only way to live stream video is to use
+					JavaScript libraries. That immediately reduces the reliability of playback since
+					reading systems vary widely in what kind of scripting they will allow. It is
+					also not uncommon for a reading system that allows scripting to block access to
+					the network.</p>
 
-				<p>But an even simpler reason why live streaming is not used in EPUB publications is because the event
-					is likely to expire before many users will even purchase the publication. If the publisher is going
-					to host a live-streaming event, such as a question-and-answer session with the author, they are more
-					likely to link out to the event from promotional material in the front or back matter of the
-					publication. This also allows a recording of the event to be provided after it is over.</p>
+				<p>But an even simpler reason why live streaming is not used in EPUB publications is
+					because the event is likely to expire before many users will even purchase the
+					publication. If the publisher is going to host a live-streaming event, such as a
+					question-and-answer session with the author, they are more likely to link out to
+					the event from promotional material in the front or back matter of the
+					publication. This also allows a recording of the event to be provided after it
+					is over.</p>
 
-				<p>So, this is another case of success criteria that cannot be ruled out as never applying to EPUB
-					publications but in practice are unlikely to ever be encountered.</p>
+				<p>So, this is another case of success criteria that cannot be ruled out as never
+					applying to EPUB publications but in practice are unlikely to ever be
+					encountered.</p>
 			</section>
 
 			<section id="meaningful-sequence">
 				<h3>Meaningful sequence</h3>
 
-				<p>The [[wcag2]] <a data-cite="wcag2#meaningful-sequence">meaningful sequence success criterion
-						(1.3.2)</a> specifies that each web page have a meaningful order (i.e., that the visual
-					presentation of the content match the underlying markup).</p>
+				<p>The [[wcag2]] <a data-cite="wcag2#meaningful-sequence">meaningful sequence
+						success criterion (1.3.2)</a> specifies that each web page have a meaningful
+					order (i.e., that the visual presentation of the content match the underlying
+					markup).</p>
 
-				<p>As EPUB allows two <a data-cite="epub-3/#dfn-epub-content-document">EPUB content documents</a> to be
-					rendered together in a <a data-cite="epub-3#spread">synthetic spread</a> [[epub-3]], the order of
-					content within a single document cannot always be evaluated in isolation. Content might span
-					visually from one document to the next. For example, a sidebar might span the bottom of two
-					pages.</p>
+				<p>As EPUB allows two <a data-cite="epub-3/#dfn-epub-content-document">EPUB content
+						documents</a> to be rendered together in a <a data-cite="epub-3#spread"
+						>synthetic spread</a> [[epub-3]], the order of content within a single
+					document cannot always be evaluated in isolation. Content might span visually
+					from one document to the next. For example, a sidebar might span the bottom of
+					two pages.</p>
 
 				<p>Ordering each document separately by the visual display will lead to users of <a
-						data-cite="epub-a11y#dfn-assistive-technology">assistive technologies</a> encountering gaps
-					between the start and end of the spanned text. If the markup cannot be arranged to provide a more
-					logical reading experience (e.g., the beginning of the spanned content at the end of the first page
-					followed by the conclusion at the start of the next), another means of satisfying this criteria will
-					be necessary to avoid failure (e.g., a hyperlink could be provided to allow a user to jump from the
-					break point on the first page to the continuation on the next).</p>
+						data-cite="epub-a11y#dfn-assistive-technology">assistive technologies</a>
+					encountering gaps between the start and end of the spanned text. If the markup
+					cannot be arranged to provide a more logical reading experience (e.g., the
+					beginning of the spanned content at the end of the first page followed by the
+					conclusion at the start of the next), another means of satisfying this criteria
+					will be necessary to avoid failure (e.g., a hyperlink could be provided to allow
+					a user to jump from the break point on the first page to the continuation on the
+					next).</p>
 			</section>
 
 			<section id="multiple-ways">
 				<h3>Multiple ways</h3>
 
-				<p>The [[wcag2]] <a data-cite="wcag2#multiple-ways">multiple ways success criterion</a> requires that
-					web users are able to locate content within a set of pages on a site. This ensures that there are at
-					least two ways to reach any information.</p>
+				<p>The [[wcag2]] <a data-cite="wcag2#multiple-ways">multiple ways success
+						criterion</a> requires that web users are able to locate content within a
+					set of pages on a site. This ensures that there are at least two ways to reach
+					any information.</p>
 
-				<p>This requirement is equally helpful for reading digital publications like EPUB because without
-					multiple ways to reach into a publication a user would have to manually swipe or click from page to
-					page to read. If this were the case, readers of print books would have better access, as they could
-					read page to page or flip through the pages using the page numbers to locate a passage they are
+				<p>This requirement is equally helpful for reading digital publications like EPUB
+					because without multiple ways to reach into a publication a user would have to
+					manually swipe or click from page to page to read. If this were the case,
+					readers of print books would have better access, as they could read page to page
+					or flip through the pages using the page numbers to locate a passage they are
 					looking for.</p>
 
-				<p>Fortunately, EPUB publications, unlike web site, will typically always minimally meet this success
-					criterion both because of the way they are constructed and because of common affordances offered by
-					reading systems.</p>
+				<p>Fortunately, EPUB publications, unlike web site, will typically always minimally
+					meet this success criterion both because of the way they are constructed and
+					because of common affordances offered by reading systems.</p>
 
 				<p>From an authoring perspective, the primary requirements are to list all <a
-						data-cite="epub/#sec-spine-elem">all EPUB content documents in the spine</a> and to ensure that
-					users have a secondary means of <a data-cite="epub/#sec-itemref-elem">accessing all non-linear
-						documents</a> [[epub-3]]. This ensures that users have a means of accessing all the content
-					either by paging through the publication, for linear content, or following hyperlinks to reach any
-					non-linear content a reading system might not show in the default presentation.</p>
+						data-cite="epub/#sec-spine-elem">all EPUB content documents in the
+					spine</a> and to ensure that users have a secondary means of <a
+						data-cite="epub/#sec-itemref-elem">accessing all non-linear
+					documents</a> [[epub-3]]. This ensures that users have a means of accessing all
+					the content either by paging through the publication, for linear content, or
+					following hyperlinks to reach any non-linear content a reading system might not
+					show in the default presentation.</p>
 
-				<p>EPUB's requirement for a table of contents provides the second method of access. It is possible that
-					a publication could fail this success criterion by proividing an incomplete table of contents, but
-					such occurrences are rare. (Refer to the <a href="#sec-toc-completeness">note on the completeness of
-						the table of contents</a> for further discussion.)</p>
+				<p>EPUB's requirement for a table of contents provides the second method of access.
+					It is possible that a publication could fail this success criterion by
+					proividing an incomplete table of contents, but such occurrences are rare.
+					(Refer to the <a href="#sec-toc-completeness">note on the completeness of the
+						table of contents</a> for further discussion.)</p>
 
-				<p>While these two basic requirements of EPUB satisfy the need for multiple ways to access the content
-					on their own, publications often contain additional methods of access, such as:</p>
+				<p>While these two basic requirements of EPUB satisfy the need for multiple ways to
+					access the content on their own, publications often contain additional methods
+					of access, such as:</p>
 
 				<ul>
 					<li>topical indexes;</li>
@@ -495,43 +555,48 @@
 					<li><a data-cite="epub-3/#sec-nav-pagelist">a page list</a> [[epub-3]].</li>
 				</ul>
 
-				<p>Reading systems also facilitate access into the content through text search capability and also via
-					the ability to jump to dynamically generated pages.</p>
+				<p>Reading systems also facilitate access into the content through text search
+					capability and also via the ability to jump to dynamically generated pages.</p>
 
 				<section id="sec-toc-completeness" class="notoc">
 					<h4>Note about the table of contents</h4>
 
-					<p>A common question about the EPUB table of contents is what completeness it needs to have with
-						respect to the headings of the publication. Although the obvious answer is to create a simple
-						aggregation of all the headings for all the sections, practically there are several usability
-						challenges to this approach.</p>
+					<p>A common question about the EPUB table of contents is what completeness it
+						needs to have with respect to the headings of the publication. Although the
+						obvious answer is to create a simple aggregation of all the headings for all
+						the sections, practically there are several usability challenges to this
+						approach.</p>
 
-					<p>Factors such as device screen sizes can make the table of contents for publications with a deep
-						hierarchy of headings unreadable, so headings below a certain depth get trimmed to improve the
-						readability. Further, <a data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not
-						always provide structured access to the headings in the table of contents, or provide shortcuts
-						to navigate the links. The result is that users have to listen to each link one at a time to
-						find where they want to go, a tedious and time-consuming process.</p>
+					<p>Factors such as device screen sizes can make the table of contents for
+						publications with a deep hierarchy of headings unreadable, so headings below
+						a certain depth get trimmed to improve the readability. Further, <a
+							data-cite="epub/#dfn-epub-reading-system">reading systems</a> do not
+						always provide structured access to the headings in the table of contents,
+						or provide shortcuts to navigate the links. The result is that users have to
+						listen to each link one at a time to find where they want to go, a tedious
+						and time-consuming process.</p>
 
-					<p>Although it is expected that reading systems will improve access to the table of contents as
-						accessibility support for EPUB evolves — making complete tables of contents usable by everyone —
-						there are legitimate usability reasons why they are not provided now.</p>
+					<p>Although it is expected that reading systems will improve access to the table
+						of contents as accessibility support for EPUB evolves — making complete
+						tables of contents usable by everyone — there are legitimate usability
+						reasons why they are not provided now.</p>
 
-					<p>When opting not to provide links to all the headings, it is best to optimize the links that are
-						provided to improve the overall reading experience. Some considerations on how to achieve this
-						include:</p>
+					<p>When opting not to provide links to all the headings, it is best to optimize
+						the links that are provided to improve the overall reading experience. Some
+						considerations on how to achieve this include:</p>
 
 					<ul>
 						<li>
 							<p>ensuring that there is at least one link to every <a
-									data-cite="epub/#dfn-epub-content-document">EPUB content document</a> — allowing the
-								user to reach each document simplifies navigation to the minor headings within them;
-								and</p>
+									data-cite="epub/#dfn-epub-content-document">EPUB content
+									document</a> — allowing the user to reach each document
+								simplifies navigation to the minor headings within them; and</p>
 						</li>
 						<li>
-							<p>only omitting minor headings from the table of contents — although a subjective decision,
-								there is often a level of diminishing value for navigation (e.g., fourth level and lower
-								headings often only delimit short subsections on a topic).</p>
+							<p>only omitting minor headings from the table of contents — although a
+								subjective decision, there is often a level of diminishing value for
+								navigation (e.g., fourth level and lower headings often only delimit
+								short subsections on a topic).</p>
 						</li>
 					</ul>
 				</section>
@@ -540,64 +605,74 @@
 			<section id="redundant-entry">
 				<h3>Redundant entry</h3>
 
-				<p>The goal of the [[wcag2]] <a data-cite="wcag2#redundant-entry">redundant entry success criterion
-						(3.3.7)</a> is to prevent users from having to enter the same information again when completing
-					a multi-step process on the web. This reduces memory requirements and stress for users with
-					cognitive and learning disabilities.</p>
+				<p>The goal of the [[wcag2]] <a data-cite="wcag2#redundant-entry">redundant entry
+						success criterion (3.3.7)</a> is to prevent users from having to enter the
+					same information again when completing a multi-step process on the web. This
+					reduces memory requirements and stress for users with cognitive and learning
+					disabilities.</p>
 
-				<p>A common example of when this success criterion applies to web content is when checking out at an
-					ecommerce store. Users' billing and shipping addresses are most often the same, so requiring them to
-					re-input the same information in separate steps increases the cognitive difficulty of the checkout
-					process. A checkbox to automatically use the billing address as the shipping address is now a
-					ubiquitous pattern to avoid this issue.</p>
+				<p>A common example of when this success criterion applies to web content is when
+					checking out at an ecommerce store. Users' billing and shipping addresses are
+					most often the same, so requiring them to re-input the same information in
+					separate steps increases the cognitive difficulty of the checkout process. A
+					checkbox to automatically use the billing address as the shipping address is now
+					a ubiquitous pattern to avoid this issue.</p>
 
-				<p>A multi-step process does not require a change in documents, or for the current document to fully
-					refresh, so it is common that users will encounter them in digital publications. The most common
-					example is in interactive content such as quizzes and games. All that is required is that a sequence
-					of steps are required to complete the quiz or game and at any step the user could have to input the
+				<p>A multi-step process does not require a change in documents, or for the current
+					document to fully refresh, so it is common that users will encounter them in
+					digital publications. The most common example is in interactive content such as
+					quizzes and games. All that is required is that a sequence of steps are required
+					to complete the quiz or game and at any step the user could have to input the
 					same information again to proceed.</p>
 
-				<p>A common case where this success criterion applies is when a quiz gets validated and allows users to
-					fix any errors they made and try again, or requires users to complete all the fields correctly
-					before it can be evaluated or submitted. In the case of fixing errors, the user should not have to
-					re-answer all the questions they got correct, nor should they have to guess what incorrect answer
-					they selected the first time. A quiz that allows the user to retry should only reset when it is
-					essential that the user start over again &#8212; for example, if new questions will have to be
-					solved or if the goal is to help in memorization of the information. Similarly, if information is
-					missing or invalid so the quiz cannot be evaluated, the user should not have to complete it again in
-					full just to address the invalid fields.</p>
+				<p>A common case where this success criterion applies is when a quiz gets validated
+					and allows users to fix any errors they made and try again, or requires users to
+					complete all the fields correctly before it can be evaluated or submitted. In
+					the case of fixing errors, the user should not have to re-answer all the
+					questions they got correct, nor should they have to guess what incorrect answer
+					they selected the first time. A quiz that allows the user to retry should only
+					reset when it is essential that the user start over again &#8212; for example,
+					if new questions will have to be solved or if the goal is to help in
+					memorization of the information. Similarly, if information is missing or invalid
+					so the quiz cannot be evaluated, the user should not have to complete it again
+					in full just to address the invalid fields.</p>
 
 				<div class="note">
-					<p>Identifying and fixing input errors is covered by the <a data-cite="wcag2#error-identification"
-							>error identification (3.3.1)</a>, <a data-cite="wcag2#error-suggestion">error suggestion
-							(3.3.3)</a>, and <a data-cite="wcag2#error-prevention-all">error prevention (3.3.4)</a>
+					<p>Identifying and fixing input errors is covered by the <a
+							data-cite="wcag2#error-identification">error identification (3.3.1)</a>,
+							<a data-cite="wcag2#error-suggestion">error suggestion (3.3.3)</a>, and
+							<a data-cite="wcag2#error-prevention-all">error prevention (3.3.4)</a>
 						success criteria.</p>
 				</div>
 
-				<p>Not all quizzes will provide users an opportunity to correct their answers, of course. If only a
-					score is presented after submitting, for example, or if the answers are submitted to a learning
-					management system for evaluation by a course instructor, then the user does not have to re-enter
-					their data again and the redundant entry success criterion will not apply.</p>
+				<p>Not all quizzes will provide users an opportunity to correct their answers, of
+					course. If only a score is presented after submitting, for example, or if the
+					answers are submitted to a learning management system for evaluation by a course
+					instructor, then the user does not have to re-enter their data again and the
+					redundant entry success criterion will not apply.</p>
 
-				<p>Where redundant entry is less applicable to digital publications is in requesting the same
-					information be input in a quiz (like the case of identical billing and shipping addresses). The
-					questions themselves are not likely to repeat unless the purpose of the quiz is to test memorization
-					skills, or to see if users change their perceptions based on other stimuli such as a picture. But in
-					these cases, it is essential for the user to answer the question anew each time it occurs, so such
-					tests would fall within the exceptions for the success criterion.</p>
+				<p>Where redundant entry is less applicable to digital publications is in requesting
+					the same information be input in a quiz (like the case of identical billing and
+					shipping addresses). The questions themselves are not likely to repeat unless
+					the purpose of the quiz is to test memorization skills, or to see if users
+					change their perceptions based on other stimuli such as a picture. But in these
+					cases, it is essential for the user to answer the question anew each time it
+					occurs, so such tests would fall within the exceptions for the success
+					criterion.</p>
 
-				<p>It is still important when encountering an embedded quiz to do a quick check that there are no
-					requests for the user to repeat information. Nothing can be ruled out, even if repeated entry of
-					personal information like on ecommerce sites is unlikely. A publisher could ask the user to input
-					their name or a student ID at the end of each part of a quiz to verify they are the one completing
-					the test, for example, in which case the field should be repopulated with the information the user
-					entered the first time. It is just not currently common for publications to send information out to
-					publisher systems.</p>
+				<p>It is still important when encountering an embedded quiz to do a quick check that
+					there are no requests for the user to repeat information. Nothing can be ruled
+					out, even if repeated entry of personal information like on ecommerce sites is
+					unlikely. A publisher could ask the user to input their name or a student ID at
+					the end of each part of a quiz to verify they are the one completing the test,
+					for example, in which case the field should be repopulated with the information
+					the user entered the first time. It is just not currently common for
+					publications to send information out to publisher systems.</p>
 
-				<p>In a similar way, there may be aspects of interactive games that have redundant entry aspects to
-					them, particularly for memorization games that require the user to re-enter the same information to
-					progress to higher stages. But these are also likely to fall under the essential re-entry
-					exception.</p>
+				<p>In a similar way, there may be aspects of interactive games that have redundant
+					entry aspects to them, particularly for memorization games that require the user
+					to re-enter the same information to progress to higher stages. But these are
+					also likely to fall under the essential re-entry exception.</p>
 			</section>
 
 			<section id="reflow">
@@ -606,63 +681,74 @@
 				<section id="reflow-application">
 					<h4>Application</h4>
 
-					<p>The [[wcag2]] <a data-cite="wcag2#reflow">reflow success criterion (1.4.10)</a> seeks to ensure
-						that content remains readable for users with low vision as they enlarge it. It requires that
-						there be no loss of information or readability for vertically scrolling content at a width
-						equivalent to 320 <a data-cite="wcag2#dfn-css-pixels">CSS pixels</a> [[wcag2]].</p>
+					<p>The [[wcag2]] <a data-cite="wcag2#reflow">reflow success criterion
+							(1.4.10)</a> seeks to ensure that content remains readable for users
+						with low vision as they enlarge it. It requires that there be no loss of
+						information or readability for vertically scrolling content at a width
+						equivalent to 320 <a data-cite="wcag2#dfn-css-pixels">CSS pixels</a>
+						[[wcag2]].</p>
 
 					<div class="note">
-						<p>As EPUB reading systems do not support horizontally scrolling text, and such content is
-							rarely produced even on the web generally, the requirement for horizontally scrolling
-							content at a height of 256 CSS pixels is not discussed in this section.</p>
+						<p>As EPUB reading systems do not support horizontally scrolling text, and
+							such content is rarely produced even on the web generally, the
+							requirement for horizontally scrolling content at a height of 256 CSS
+							pixels is not discussed in this section.</p>
 					</div>
 
-					<p>The first thing to note about this success criterion is that the "scrolling" aspect of the
-						definition applies to all EPUB publications whether they are read in a reading system that lays
-						out the content in a scrolling manner or whether the reading system dynamically paginates the
-						content. Dynamic pagination is just a feature of EPUB that takes a vertically scrolled document
-						and splits it up for reading in a book-like manner.</p>
+					<p>The first thing to note about this success criterion is that the "scrolling"
+						aspect of the definition applies to all EPUB publications whether they are
+						read in a reading system that lays out the content in a scrolling manner or
+						whether the reading system dynamically paginates the content. Dynamic
+						pagination is just a feature of EPUB that takes a vertically scrolled
+						document and splits it up for reading in a book-like manner.</p>
 
-					<p>The second thing to note is that the width and height sizes do not refer to the actual screen
-						resolution of the device. The emphasis of the success criterion is on equivalence up to these
-						sizes, which is why it notes that a viewport with a width of 1280 CSS pixels is equivalent to a
-						width of 320 CSS pixels when it is zoomed to 400%. The example is just a common screen
+					<p>The second thing to note is that the width and height sizes do not refer to
+						the actual screen resolution of the device. The emphasis of the success
+						criterion is on equivalence up to these sizes, which is why it notes that a
+						viewport with a width of 1280 CSS pixels is equivalent to a width of 320 CSS
+						pixels when it is zoomed to 400%. The example is just a common screen
 						resolution and exhibits easy math to the 320 CSS pixel maximum.</p>
 
-					<p>What happens when zooming a 1280 CSS pixel viewport beyond 320 CSS pixels is out of scope, as is
-						zooming any other starting resolution after it exceeds 320 CSS pixels in width. The success
-						criterion is not saying that all viewports greater in width than 320 CSS pixels are out of
-						scope.</p>
+					<p>What happens when zooming a 1280 CSS pixel viewport beyond 320 CSS pixels is
+						out of scope, as is zooming any other starting resolution after it exceeds
+						320 CSS pixels in width. The success criterion is not saying that all
+						viewports greater in width than 320 CSS pixels are out of scope.</p>
 
-					<p>The good thing about reflowable EPUB publications when it comes to meeting this success criterion
-						is that they were designed to work exactly in the manner it anticipates. A reflowable EPUB
-						publication is expected to work on many different device screens and with many different user
-						preferences applied. The content has to reflow to fit within the paginated environment that
-						reading systems provide as users rarely can scroll the content &#8212; if the content does not
-						fit in the viewport, it is typically inaccessible to all users. Publishers are typically already
-						aware of these reflow issues and how to ensure their content does not break.</p>
+					<p>The good thing about reflowable EPUB publications when it comes to meeting
+						this success criterion is that they were designed to work exactly in the
+						manner it anticipates. A reflowable EPUB publication is expected to work on
+						many different device screens and with many different user preferences
+						applied. The content has to reflow to fit within the paginated environment
+						that reading systems provide as users rarely can scroll the content &#8212;
+						if the content does not fit in the viewport, it is typically inaccessible to
+						all users. Publishers are typically already aware of these reflow issues and
+						how to ensure their content does not break.</p>
 
-					<p>It does not mean that all reflowable EPUB publications get an automatic pass on this success
-						criterion, but only that the circumstances where the content will not reflow are not common.</p>
+					<p>It does not mean that all reflowable EPUB publications get an automatic pass
+						on this success criterion, but only that the circumstances where the content
+						will not reflow are not common.</p>
 				</section>
 
 				<section id="reflow-container-widths">
 					<h4>Container widths</h4>
 
-					<p>The most likely source of failure for the reflow success criterion is going to arise with
-						container elements, such as with the [[html]] [^aside^], [^div^], [^nav^] and similar elements
-						used to group content. When these elements are assigned fixed widths, their ability to adapt to
-						changes in zoom diminish.</p>
+					<p>The most likely source of failure for the reflow success criterion is going
+						to arise with container elements, such as with the [[html]] [^aside^],
+						[^div^], [^nav^] and similar elements used to group content. When these
+						elements are assigned fixed widths, their ability to adapt to changes in
+						zoom diminish.</p>
 
-					<p>The content of an [[html]] [^aside^] element used as a sidebar, for example, will reflow by
-						default to so that its content fits the available screen space. But if a width, or a minimum
-						width, greater than 320 CSS pixels is assigned, then as the content is zoomed the dimensions of
-						the viewport may become smaller than the width of the <code>aside</code>.</p>
+					<p>The content of an [[html]] [^aside^] element used as a sidebar, for example,
+						will reflow by default to so that its content fits the available screen
+						space. But if a width, or a minimum width, greater than 320 CSS pixels is
+						assigned, then as the content is zoomed the dimensions of the viewport may
+						become smaller than the width of the <code>aside</code>.</p>
 
 					<aside class="example" title="Problematic container width settings">
-						<p>In the first CSS rule, the width declaration does not allow the sidebar to shrink below
-							500px. In the second, the minimum width declaration similarly would stop the sidebar from
-							shrinking below 480px (assuming that 1em is equal to 16px in this case).</p>
+						<p>In the first CSS rule, the width declaration does not allow the sidebar
+							to shrink below 500px. In the second, the minimum width declaration
+							similarly would stop the sidebar from shrinking below 480px (assuming
+							that 1em is equal to 16px in this case).</p>
 						<pre>aside.sidebar {
    width: 500px
 }
@@ -673,17 +759,20 @@ aside.sidebar {
 </pre>
 					</aside>
 
-					<p>When a user zooms their publication, what typically will happen with EPUB reading systems is that
-						the sidebar will extend outside the boundary of the page/viewport, causing its text to be cut
-						off and become inaccessible.</p>
+					<p>When a user zooms their publication, what typically will happen with EPUB
+						reading systems is that the sidebar will extend outside the boundary of the
+						page/viewport, causing its text to be cut off and become inaccessible.</p>
 
-					<p>But even if the sidebar is made scrollable using <a data-cite="css-overflow#overflow-properties"
-							>CSS overflow properties</a> [[css-overflow]], the result still fails this success criterion
-						because the content now requires scrolling on the x axis to reach the hidden overflow text.</p>
+					<p>But even if the sidebar is made scrollable using <a
+							data-cite="css-overflow#overflow-properties">CSS overflow properties</a>
+						[[css-overflow]], the result still fails this success criterion because the
+						content now requires scrolling on the x axis to reach the hidden overflow
+						text.</p>
 
 					<aside class="example" title="Invalid scrolling">
-						<p>The previous CSS rule is modified to allow scrolling but since the content will require
-							scrolling on the x-axis it will fail the success criterion.</p>
+						<p>The previous CSS rule is modified to allow scrolling but since the
+							content will require scrolling on the x-axis it will fail the success
+							criterion.</p>
 						<pre>aside.sidebar {
    width: 500px;
    overflow: scroll
@@ -691,86 +780,99 @@ aside.sidebar {
 </pre>
 					</aside>
 
-					<p>Any hoped-for value in assigning fixed widths to container elements in reflowable content is
-						generally going to be offset by the problems it will cause with the reflow success criterion. If
-						a size must be specified (e.g., to ensure that boxes of content always fill the width of the
-						viewport), the more accessible way is to use a unit that adapts to changes in the viewport.
-						Setting a percentage (<code>%</code>) or viewport width (<code>vw</code>) no greater than 100
-						percent of the viewport size will avoid scroll bars appearing as the content is zoomed.</p>
+					<p>Any hoped-for value in assigning fixed widths to container elements in
+						reflowable content is generally going to be offset by the problems it will
+						cause with the reflow success criterion. If a size must be specified (e.g.,
+						to ensure that boxes of content always fill the width of the viewport), the
+						more accessible way is to use a unit that adapts to changes in the viewport.
+						Setting a percentage (<code>%</code>) or viewport width (<code>vw</code>) no
+						greater than 100 percent of the viewport size will avoid scroll bars
+						appearing as the content is zoomed.</p>
 
 					<div class="note">
-						<p>Container elements can require vertical scrolling. The reflow success criterion only requires
-							that the content not require scrolling on the opposite axis.</p>
+						<p>Container elements can require vertical scrolling. The reflow success
+							criterion only requires that the content not require scrolling on the
+							opposite axis.</p>
 					</div>
 				</section>
 
 				<section id="reflow-font-size">
 					<h4>Font size</h4>
 
-					<p>When testing this success criterion, be aware that app-based reading systems typically do not
-						allow zooming of reflowable content. They are more likely to support font size increases up to
-						400% of the default, but increasing the font size is not the same as zooming the content.</p>
+					<p>When testing this success criterion, be aware that app-based reading systems
+						typically do not allow zooming of reflowable content. They are more likely
+						to support font size increases up to 400% of the default, but increasing the
+						font size is not the same as zooming the content.</p>
 
-					<p>The reflow success criterion does not, in fact, specify requirements on the font size as the
-						content is enlarged. The requirement for text to enlarge up to 200% is instead addressed by the
-						[[wcag2]] <a data-cite="wcag2#resize-text">resize text success criterion</a>.</p>
+					<p>The reflow success criterion does not, in fact, specify requirements on the
+						font size as the content is enlarged. The requirement for text to enlarge up
+						to 200% is instead addressed by the [[wcag2]] <a
+							data-cite="wcag2#resize-text">resize text success criterion</a>.</p>
 
 					<div class="note">
-						<p>For a more detailed description of the interaction between the reflow and resize text success
-							criteria, refer to the <a
-								href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#resize-text">reflow
-								understanding document explanation of the two</a>.</p>
+						<p>For a more detailed description of the interaction between the reflow and
+							resize text success criteria, refer to the <a
+								href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#resize-text"
+								>reflow understanding document explanation of the two</a>.</p>
 					</div>
 				</section>
 
 				<section id="reflow-large-text-strings">
 					<h4>Large text strings</h4>
 
-					<p>Large words, hyperlinks, code examples, and other strings of contiguous text with no break points
-						can also pose problems for reflow as the viewport reaches 320 CSS pixels, but the text is not
-						required to stay the same font size as the content is enlarged. The font size could, for
-						example, be reduced using a media query so that it stays at 200% the original size as the
-						viewport nears 320 CSS pixels.</p>
+					<p>Large words, hyperlinks, code examples, and other strings of contiguous text
+						with no break points can also pose problems for reflow as the viewport
+						reaches 320 CSS pixels, but the text is not required to stay the same font
+						size as the content is enlarged. The font size could, for example, be
+						reduced using a media query so that it stays at 200% the original size as
+						the viewport nears 320 CSS pixels.</p>
 
-					<p>Other strategies to prevent large text strings causing scrolling include using the [[html]]
-						[^wbr^] element to specify word break locations, using the CSS <code>overflow-wrap</code> and
-							<code>word-break</code> properties, or using the Unicode soft hyphen character.</p>
+					<p>Other strategies to prevent large text strings causing scrolling include
+						using the [[html]] [^wbr^] element to specify word break locations, using
+						the CSS <code>overflow-wrap</code> and <code>word-break</code> properties,
+						or using the Unicode soft hyphen character.</p>
 				</section>
 
 				<section id="reflow-exempt-content">
 					<h4>Exempt content</h4>
 
-					<p>Not all content is required to reflow as it is enlarged. The success criterion makes an exception
-						for content that would lose its meaning if it were reflowed. For reflowable publications, the
-						most common content that requires two-dimensional layout are diagrams, charts, maps and similar
+					<p>Not all content is required to reflow as it is enlarged. The success
+						criterion makes an exception for content that would lose its meaning if it
+						were reflowed. For reflowable publications, the most common content that
+						requires two-dimensional layout are diagrams, charts, maps and similar
 						images.</p>
 
-					<p>Data tables are also exempt due to their grid nature, but the individual cells within them are
-						not. This means that it would not be unreasonable for the user to have to scroll to reach all
-						the columns, but the content with a column must not require scrolling in two dimensions to
-						read.</p>
+					<p>Data tables are also exempt due to their grid nature, but the individual
+						cells within them are not. This means that it would not be unreasonable for
+						the user to have to scroll to reach all the columns, but the content with a
+						column must not require scrolling in two dimensions to read.</p>
 
-					<p>Content that can be scrolled in two dimensions needs to always be checked that it has been
-						authored so that it can indeed be scrolled this way. Reading systems will often try to compress
-						tables to fit the available space, for example, but when that cannot be done the overflow
-						outside the page boundary will not be accessible. A common practice to avoid this is to wrap the
-						two-dimensional content in a container that allows scrolling (e.g., a <code>table</code> can be
-						placed inside a <code>div</code> that provides it more space for rendering and includes
-						scrollbars to move around the columns and rows). But when using this practice, content that does
-						not depend on two dimensions for comprehension cannot be captured in the scroll. If a table has
-						a caption, for example, only the table can scroll on the x axis to meet the success criterion;
-						the text of the caption cannot require scrolling.</p>
+					<p>Content that can be scrolled in two dimensions needs to always be checked
+						that it has been authored so that it can indeed be scrolled this way.
+						Reading systems will often try to compress tables to fit the available
+						space, for example, but when that cannot be done the overflow outside the
+						page boundary will not be accessible. A common practice to avoid this is to
+						wrap the two-dimensional content in a container that allows scrolling (e.g.,
+						a <code>table</code> can be placed inside a <code>div</code> that provides
+						it more space for rendering and includes scrollbars to move around the
+						columns and rows). But when using this practice, content that does not
+						depend on two dimensions for comprehension cannot be captured in the scroll.
+						If a table has a caption, for example, only the table can scroll on the x
+						axis to meet the success criterion; the text of the caption cannot require
+						scrolling.</p>
 				</section>
 
 				<section id="reflow-fxl">
 					<h4>Fixed layouts</h4>
 
-					<p>Although the reflow success criterion does not pose a lot of problems for reflowable EPUB
-						publications, it is one of the most problematic to meet for fixed-layout EPUB publications as
-						reading systems do not reflow the content of a fixed-layout page as it is zoomed.</p>
+					<p>Although the reflow success criterion does not pose a lot of problems for
+						reflowable EPUB publications, it is one of the most problematic to meet for
+						fixed-layout EPUB publications as reading systems do not reflow the content
+						of a fixed-layout page as it is zoomed.</p>
 
-					<p>This guide does not address the problems with making fixed-layout publication accessible. For
-						more information on this topic, refer to [[[epub-fxl-a11y]]] [[epub-fxl-a11y]].</p>
+					<p>This guide does not address the problems with making fixed-layout publication
+						accessible. For more information on this topic, refer to [[[epub-fxl-a11y]]]
+						[[epub-fxl-a11y]].</p>
 				</section>
 			</section>
 		</section>
@@ -783,68 +885,80 @@ aside.sidebar {
 				<section id="page-list">
 					<h4>Page list</h4>
 
-					<p>A <a data-cite="epub-a11y#sec-page-list">page list</a> [[epub-a11y]] is a list of links to static
-						page break locations in an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a>. Its
-						purpose is to provide users with an easy means of accessing the same location across different
-						device screen sizes and user text preferences.</p>
+					<p>A <a data-cite="epub-a11y#sec-page-list">page list</a> [[epub-a11y]] is a
+						list of links to static page break locations in an <a
+							data-cite="epub-3#dfn-epub-publication">EPUB publication</a>. These
+						destinations remain the same across reading systems, device screen sizes,
+						and user text preferences.</p>
 
-					<p>A page list is essential for accessibility when digital publications are used in coordination
-						with a static alternative like a print edition. The most common scenario is when digital
-						publications are produced for use in educational settings. Students who cannot read a print
-						edition need to be able to coordinate their digital edition with their sighted peers. But any
-						social reading environment, such as a book club, will also be more inclusive when users are not
-						disadvantaged by their need to use a digital edition.</p>
+					<p>A page list is essential for accessibility when digital publications are used
+						in coordination with a static alternative like a print edition. The most
+						common scenario is when digital publications are produced for use in
+						educational settings. Students who cannot read a print edition need to be
+						able to coordinate their digital edition with their sighted peers. But any
+						social reading environment, such as a book club, will also be more inclusive
+						when users are not disadvantaged by their need to use a digital edition.</p>
 
-					<p>It is true that many <a data-cite="epub-3#dfn-epub-reading-system">reading systems</a> provide a
-						paginated reading experience and allow users to move between these pages. The key difference is
-						that this pagination is typically not static and does not match up with a statically paginated
-						source. The number of pages and what content appears on any given page changes depending on how
-						much content can fit in the device's screen. That in turn is influenced by whether the user has
-						altered the fonts and spacing to their own preferences. A publication rendered using larger font
-						sizes and greater spacing will have more dynamic pages than one using the reading system's
-						standard settings. Consequently, coordinating access across devices is impossible without a
-						static baseline.</p>
+					<p>It is true that many <a data-cite="epub-3#dfn-epub-reading-system">reading
+							systems</a> provide a paginated reading experience and allow users to
+						move between these pages. The key difference is that this pagination is
+						typically not static and does not match up with a statically paginated
+						source. The number of pages and what content appears on any given page
+						changes depending on how much content can fit in the device's screen. That
+						in turn is influenced by whether the user has altered the fonts and spacing
+						to their own preferences. A publication rendered using larger font sizes and
+						greater spacing will have more dynamic pages than one using the reading
+						system's standard settings. Consequently, coordinating access across devices
+						is impossible without a static baseline.</p>
 
-					<p>When a page list is provided, a <a data-cite="epub-3#dfn-epub-reading-system">reading system</a>
-						can generate a "go to page" interface in which users can plug in the page number that they wish
-						to move to and know that they will end up in the same place as readers of the static source.
-						This provides users the ability to find the same location in their digital edition as their
-						peers using a print edition, for example. Without a page list, page coordination with a print
-						source becomes extremely difficult as it would rely on navigating the individual <a
-							href="#page-breaks">page break markers</a> (if they are even present).</p>
+					<p>When a page list is provided, a <a data-cite="epub-3#dfn-epub-reading-system"
+							>reading system</a> can provide an interface that allows users to enter
+						the page number from the static source that they wish to move to. This
+						provides users the ability to find the same location in their digital
+						edition as their peers using a print edition, for example. Without a page
+						list, page coordination with a print source becomes extremely difficult as
+						it would rely on navigating the individual <a href="#page-breaks">page break
+							markers</a> (if they are even present).</p>
 
-					<p>The page list is not required to reproduce every page break from the static source. Digital
-						editions often omit content from their static print counterparts, for example, typically in the
-						front or back matter. Blank pages are another feature of print editions that have no equivalent
-						in digital editions. Page break markers can be included for them but the effort to add them may
-						not be worth the effort knowing that users never actively seek this locations.</p>
+					<p>The page list is not required to reproduce every page break from the static
+						source. Digital editions often omit content from their static print
+						counterparts, for example, typically in the front or back matter. Blank
+						pages are another feature of print editions that have no equivalent in
+						digital editions. Page break markers can be included for them but the effort
+						to add them may not be worth the effort knowing that users never actively
+						seek this locations.</p>
 
-					<p>What is required is that the page list include links to every page of content that is reproduced
-						from the static equivalent. Moreover, if there are page break markers in the EPUB publication,
-						the page list has to include links to all these markers. This is to ensure that the EPUB
-						publication does not contain content that cannot be reached.</p>
+					<p>What is required is that the page list include links to every page of content
+						that is reproduced from the static equivalent. Moreover, if there are page
+						break markers in the EPUB publication, the page list has to include links to
+						all these markers. This is to ensure that the EPUB publication does not
+						contain content that cannot be reached.</p>
 
 					<div class="note">
-						<p>It is not required that each link in the page list reference a <a href="#page-breaks">page
-								break marker</a>. Using page break markers is typically the simplest and most accessible
-							way to identify all the static page break locations, but the page list can link to any
-							element with an ID that is located at a page boundary.</p>
+						<p>It is not required that each link in the page list reference a <a
+								href="#page-breaks">page break marker</a>. Using page break markers
+							is typically the simplest and most accessible way to identify all the
+							static page break locations, but the page list can link to any element
+							with an ID that is located at a page boundary.</p>
 					</div>
 
-					<p id="page-breaks-application">The page list requirement is currently only mandated in a limited
-						set of scenarios because the benefit to users only accrues when there is a statically paginated
-						equivalent to sync up with. As already noted, when a publisher knows their content will be used
-						in a mixed reading environment, such as when they sell publications to schools, ensuring the
-						digital edition has a page list is essential. Likewise, if they are providing students with a
-						print and digital bundle, the need to coordinate reading can be anticipated. And finally, if a
-						digital publication is produced from the same workflow as a print publication, making it easy to
-						retain the page locations in the digital version, then publishers should opt for maximum
-						accessibility by producing the page list.</p>
+					<p id="page-breaks-application">The page list requirement is currently only
+						mandated in a limited set of scenarios because the benefit to users only
+						accrues when there is a statically paginated equivalent to sync up with. As
+						already noted, when a publisher knows their content will be used in a mixed
+						reading environment, such as when they sell publications to schools,
+						ensuring the digital edition has a page list is essential. Likewise, if they
+						are providing students with a print and digital bundle, the need to
+						coordinate reading can be anticipated. And finally, if a digital publication
+						is produced from the same workflow as a print publication, making it easy to
+						retain the page locations in the digital version, then publishers should opt
+						for maximum accessibility by producing the page list.</p>
 
-					<p>A page list is not required for EPUB publications that do not have a statically paginated source.
-						Digital-only publications can benefit from a page list for coordinated access within reading
-						groups, but the lack of a page list affects all users equally. It does not specially
-						disadvantage any one type of user over another.</p>
+					<p>A page list is not required for EPUB publications that do not have a
+						statically paginated source. Digital-only publications can benefit from a
+						page list for coordinated access within reading groups, but the lack of a
+						page list affects all users equally. It does not specially disadvantage any
+						one type of user over another.</p>
 
 					<div class="note">
 						<p>For specific techniques to meet this requirement, refer to the section <a
@@ -856,94 +970,101 @@ aside.sidebar {
 				<section id="page-breaks">
 					<h4>Page breaks</h4>
 
-					<p>The ability to identify the current page a user is on, and have that page be consistent across
-						devices and user settings, is another essential feature for users who are trying to coordinate
-						their reading in a mixed print-digital environment. The <a href="#page-list">page list</a>
-						provides quick access to the page break locations, but without <a
-							data-cite="epub-a11y#sec-page-breaks">static page break markers</a> [[epub-a11y]] in the
-						content the context of where a user is relative to the statically paginated equivalent is
-						lost.</p>
+					<p>The ability to identify the current page a user is on, and have that page be
+						consistent across devices and user settings, is another essential feature
+						for users who are trying to coordinate their reading in a mixed
+						print-digital environment. The <a href="#page-list">page list</a> provides
+						quick access to the page break locations, but without <a
+							data-cite="epub-a11y#sec-page-breaks">static page break markers</a>
+						[[epub-a11y]] in the content the context of where a user is relative to the
+						statically paginated equivalent is lost.</p>
 
-					<p><a data-cite="epub-a11y#dfn-assistive-technology">Assistive technologies</a> [[epub-a11y]] can
-						use the page break markers to announce the current page number the user is on. This makes it
-						easier for users to verify they are in the right location, for example, or to cite content on
-						the page. Page break markers also allow assistive technologies to provide shortcut keys that
-						allow the user to move forward or backward by page &#8212; a feat that is not easy to accomplish
-						with only a page list.</p>
+					<p><a data-cite="epub-a11y#dfn-assistive-technology">Assistive technologies</a>
+						[[epub-a11y]] can use the page break markers to announce the current page
+						number the user is on. This makes it easier for users to verify they are in
+						the right location, for example, or to cite content on the page. Page break
+						markers also allow assistive technologies to provide shortcut keys that
+						allow the user to move forward or backward by page &#8212; a feat that is
+						not easy to accomplish with only a page list.</p>
 
-					<p>The inclusion of page break markers also simplifies the creation of a <a href="#page-list">page
-							list</a>, as they provide easily referenced destinations for the links.</p>
+					<p>The inclusion of page break markers also simplifies the creation of a <a
+							href="#page-list">page list</a>, as they provide easily referenced
+						destinations for the links.</p>
 
-					<p>It is not required that there be page break markers for every page from the static equivalent.
-						Some content from print sources is not reproduced in digital editions, for example. There are
-						also print conventions, like inserting blank pages so new chapters always begin on a recto page,
-						that do not translate to digital editions. Page break markers can be included for these blank or
-						missing pages, but additional context needs to be provided so users are aware why there is no
-						content.</p>
+					<p>It is not required that there be page break markers for every page from the
+						static equivalent. Some content from print sources is not reproduced in
+						digital editions, for example. There are also print conventions, like
+						inserting blank pages so new chapters always begin on a recto page, that do
+						not translate to digital editions. Page break markers can be included for
+						these blank or missing pages, but additional context needs to be provided so
+						users are aware why there is no content.</p>
 
-					<p>Since some content can also be rearranged from print to digital editions, it is also not a
-						requirement that the page break markers be arranged in numerical order.</p>
+					<p>Since some content can also be rearranged from print to digital editions, it
+						is also not a requirement that the page break markers be arranged in
+						numerical order.</p>
 
-					<p>As with the page list, it is not required that every publication include page break markers to be
-						accessible. The <a href="#page-breaks-application">same conditions</a> that apply to including a
-						page list apply to include page break markers.</p>
+					<p>As with the page list, it is not required that every publication include page
+						break markers to be accessible. The <a href="#page-breaks-application">same
+							conditions</a> that apply to including a page list apply to include page
+						break markers.</p>
 
 					<div class="note">
 						<p>For specific techniques to meet this requirement, refer to the section <a
-								data-cite="epub-a11y-tech-12#page-breaks">Provide page break markers</a> in
-							[[epub-a11y-tech-12]].</p>
+								data-cite="epub-a11y-tech-12#page-breaks">Provide page break
+								markers</a> in [[epub-a11y-tech-12]].</p>
 					</div>
 
 					<section id="page-breaks-mo">
 						<h5>Page breaks in media overlays</h5>
 
-						<p>The page break marker objectives also include a requirement that if the page break numbers
-							are read out in media overlays playback, the markers also have to be identified in the SMIL
-							markup.</p>
+						<p>The page break marker objectives also include a requirement that if the
+							page break numbers are read out in media overlays playback, the markers
+							also have to be identified in the SMIL markup.</p>
 
-						<p>This requirement ensures that the same pagination information is available to reading systems
-							during playback that is available to assistive technologies. A reading system could
-							similarly offer the ability to announce the current page or provide the ability to skip
-							forward or backward by page without relying on the semantics in the XHTML content
-							document.</p>
+						<p>This requirement ensures that the same pagination information is
+							available to reading systems during playback that is available to
+							assistive technologies. A reading system could similarly offer the
+							ability to announce the current page or provide the ability to skip
+							forward or backward by page without relying on the semantics in the
+							XHTML content document.</p>
 					</section>
 				</section>
 
 				<section id="page-source">
 					<h4>Page source</h4>
 
-					<p>When seeking accessible publications for mixed print-digital reading environments, the first
-						thing an individual wants to be sure of is that the digital edition is the same as the print
-						edition. Different editions of a publication can differ not only in the content they contain but
-						in how they are paginated. Print publications, for example, will have different pagination
-						between their hard and soft cover editions. Different editions of the same book often also have
-						different pagination as new content gets added or existing content gets revised or removed.</p>
+					<p>An <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> containing
+						a <a href="#page-list">page list</a> and <a href="#page-breaks">page break
+							markers</a> cannot be considered fully accessible if users are unable to
+						identify the corresponding source edition. Pagination and content layout
+						frequently vary across different editions of the same publication; for
+						example, the pagination of a hardcover edition often differs from that of
+						the softcover edition.</p>
 
-					<p>An <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> with a page list and page
-						break markers loses its accessibility when it is not possible for users to determine what static
-						edition the pagination corresponds to. The <a data-cite="epub-a11y#sec-page-src">source of the
-							pagination</a> [[epub-a11y]] has to be specified in the metadata to allow users to determine
-						whether if they have the right digital edition.</p>
+					<p>Consequently, the <a data-cite="epub-a11y#sec-page-src">source of the
+							pagination</a> [[epub-a11y]] has to be specified in the metadata to
+						allow users to determine if they have the right digital edition.</p>
 
-					<p>The source publication is typically identified using a standardized identifier such as an ISBN or
-						ISSN. These identifiers are more accurate than text descriptions of the source. In the case of a
-						publication that does not have a standard identifier, the source can be identified by providing
-						as much information about it as possible (e.g., title, publisher, edition, publication date,
-						etc.).</p>
+					<p>The source publication is typically identified using a standardized
+						identifier such as an ISBN or ISSN. These identifiers are more accurate than
+						text descriptions of the source. In the case of a publication that does not
+						have a standard identifier, the source can be identified by providing as
+						much information about it as possible (e.g., title, publisher, edition,
+						publication date, etc.).</p>
 
-					<p>Providing the source identifier allows vendors, for example, to present the information to users
-						in their bookstore metadata. This allows users to be sure of their purchase before making
-						it.</p>
+					<p>Providing the source identifier allows vendors, for example, to present the
+						information to users in their bookstore metadata. This allows users to be
+						sure of their purchase before making it.</p>
 
-					<p>A page source identifier is only set when an EPUB publication contains one or both of a page list
-						or page break markers. Setting it when neither is not only incorrect but can mislead users into
-						thinking the features are present even though, for example, they will not be listed in bookstore
-						metadata.</p>
+					<p>A page source identifier is only set when an EPUB publication contains one or
+						both of a page list or page break markers. Setting it when neither is not
+						only incorrect but can mislead users into thinking the features are present
+						even though, for example, they will not be listed in bookstore metadata.</p>
 
 					<div class="note">
 						<p>For specific techniques to meet this requirement, refer to the section <a
-								data-cite="epub-a11y-tech-12#page-source">Identify the pagination source</a> in
-							[[epub-a11y-tech-12]].</p>
+								data-cite="epub-a11y-tech-12#page-source">Identify the pagination
+								source</a> in [[epub-a11y-tech-12]].</p>
 					</div>
 				</section>
 			</section>
@@ -954,99 +1075,112 @@ aside.sidebar {
 				<section id="sync-completeness">
 					<h4>Completeness</h4>
 
-					<p>Although it is possible for users who require a publication in audio form to use text-to-speech
-						playback, the experience is considerably poorer than when pre-recorded narration is provided.
-						Text-to-speech engines have limited built-in vocabularies, causing them to mangle and
-						mispronounce most uncommon words they encounter. As a result users have to have words repeated
-						and spelled out to make sense of the content, slowing down their reading and reducing
-						comprehension.</p>
+					<p>Although it is possible for users who require a publication in audio form to
+						use text-to-speech playback, the experience is considerably poorer than when
+						pre-recorded narration is provided. Text-to-speech engines have limited
+						built-in vocabularies, causing them to mangle and mispronounce most uncommon
+						words they encounter. As a result users have to have words repeated and
+						spelled out to make sense of the content, slowing down their reading and
+						reducing comprehension.</p>
 
-					<p>For this reason, it is important to provide narration for the full text of a publication in
-						addition to the full text. Users can then decide which reading modality they prefer &#8212;
-						text, audio, or a mix of the two.</p>
+					<p>For this reason, it is important to provide narration for the full text of a
+						publication in addition to the full text. Users can then decide which
+						reading modality they prefer &#8212; text, audio, or a mix of the two.</p>
 				</section>
 
 				<section id="sync-escapability">
 					<h4>Escapability</h4>
 
-					<p>When reading visually, users can quickly move through, and escape from, highly structured content
-						such as sidebars, lists, and figures. Visual readers can skim lists and quickly return to the
-						primary narrative once they locate the desired information, for example. The same is true for
-						reading figures and sidebars, as they are visually offset from the primary narrative so easily
-						jumped into and out of.</p>
+					<p>When reading visually, users can quickly move through, and escape from,
+						highly structured content such as sidebars, lists, and figures. Visual
+						readers can skim lists and quickly return to the primary narrative once they
+						locate the desired information, for example. The same is true for reading
+						figures and sidebars, as they are visually offset from the primary narrative
+						so easily jumped into and out of.</p>
 
 					<p>The same ease of escaping from content is only possible if <a
-							data-cite="epub-3#dfn-epub-publication">EPUB publications</a> include structural semantics
-						in the synchronized text/audio format. Users might not be able to escape from lists, sidebars,
-						figures, and other highly structured content, without the structural semantics of those elements
-						being available.</p>
+							data-cite="epub-3#dfn-epub-publication">EPUB publications</a> include
+						structural semantics in the synchronized text/audio format. Users might not
+						be able to escape from lists, sidebars, figures, and other highly structured
+						content, without the structural semantics of those elements being
+						available.</p>
 
-					<p>When the synchronized text-audio playback instructions include this information, <a
-							data-cite="epub-3#dfn-epub-reading-system">reading systems</a> can simplify playback for
-						auditory readers to enable a comparable reading experience.</p>
+					<p>When the synchronized text-audio playback instructions include this
+						information, <a data-cite="epub-3#dfn-epub-reading-system">reading
+							systems</a> can simplify playback for auditory readers to enable a
+						comparable reading experience.</p>
 				</section>
 
 				<section id="sync-nav-doc">
 					<h4>Navigation document</h4>
 
-					<p>Reading systems typically provide their own interfaces to the navigation aids in the EPUB
-						navigation document. For example, they open the table of contents as a specialized interface on
-						top of the content the user is reading.</p>
+					<p>Reading systems typically provide their own interfaces to the navigation aids
+						in the EPUB navigation document. For example, they open the table of
+						contents as a specialized interface on top of the content the user is
+						reading.</p>
 
-					<p>To access these interfaces, users typically rely on text-to-speech playback, when available, to
-						hear the entries.</p>
+					<p>To access these interfaces, users typically rely on text-to-speech playback,
+						when available, to hear the entries.</p>
 
-					<p>Providing synchronized text-audio playback for the EPUB navigation document provides reading
-						systems the ability to use auditory labels for the links, improving the experience for auditory
-						readers.</p>
+					<p>Providing synchronized text-audio playback for the EPUB navigation document
+						provides reading systems the ability to use auditory labels for the links,
+						improving the experience for auditory readers.</p>
 				</section>
 
 				<section id="sync-reading-order">
 					<h4>Reading order</h4>
 
-					<p>Every <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> has a default reading order
-						that allows users to progress through the content. The default reading order consists of two
-						parts: the order of references in the spine provides a high-level progression through the <a
-							data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a> that make up the
-						publication, while the markup within each EPUB content document provides the default progression
-						through the content elements (i.e., as represented in the document object model [[?dom]]).</p>
+					<p>Every <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> has a
+						default reading order that allows users to progress through the content. The
+						default reading order consists of two parts: the order of references in the
+						spine provides a high-level progression through the <a
+							data-cite="epub-3#dfn-epub-content-document">EPUB content documents</a>
+						that make up the publication, while the markup within each EPUB content
+						document provides the default progression through the content elements
+						(i.e., as represented in the document object model [[?dom]]).</p>
 
-					<p>For many languages, the default reading order also matches the logical reading order &#8212; the
-						way that users will naturally follow the narrative. It ensures that readers can follow the
-						primary narrative and that they encounter secondary content where the author intended it to be
-						read. The default reading order also establishes some less obvious relations, like the progress
-						within a table from cell to cell and row to row.</p>
+					<p>For many languages, the default reading order also matches the logical
+						reading order &#8212; the way that users will naturally follow the
+						narrative. It ensures that readers can follow the primary narrative and that
+						they encounter secondary content where the author intended it to be read.
+						The default reading order also establishes some less obvious relations, like
+						the progress within a table from cell to cell and row to row.</p>
 
-					<p>If the sequence of the synchronized text-audio playback does not match this progression, it can
-						cause confusion for readers, whether they are only listening to the audio or trying to also
-						follow visually.</p>
+					<p>If the sequence of the synchronized text-audio playback does not match this
+						progression, it can cause confusion for readers, whether they are only
+						listening to the audio or trying to also follow visually.</p>
 
-					<p>Ordering the playback to match the default reading order is the safest way to ensure that users
-						can follow the text. In some cases, however, strict adherence to this practice can result in a
-						suboptimal reading experience (e.g., playback of a table by column instead of row might make
-						more natural sense in some cases). These publications have a logical reading order that cannot
-						match the default order of the elements of the host format.</p>
+					<p>Ordering the playback to match the default reading order is the safest way to
+						ensure that users can follow the text. In some cases, however, strict
+						adherence to this practice can result in a suboptimal reading experience
+						(e.g., playback of a table by column instead of row might make more natural
+						sense in some cases). These publications have a logical reading order that
+						cannot match the default order of the elements of the host format.</p>
 
-					<p>The goal of this objective is not to forbid alternate presentations, but to ensure that
-						deviations are only made to better represent the logical reading order of the content.</p>
+					<p>The goal of this objective is not to forbid alternate presentations, but to
+						ensure that deviations are only made to better represent the logical reading
+						order of the content.</p>
 				</section>
 
 				<section id="sync-skippability">
 					<h4>Skippability</h4>
 
-					<p>Being able to read the primary narrative of a work without interruption is central to reading
-						comprehension. <a data-cite="epub-3#dfn-epub-publication">EPUB publications</a> are typically
-						structured to visually represent secondary information such as page break markers and footnotes
-						outside the main narrative flow (e.g., by using different background colors or placement so
-						readers can filter this information visually out while reading).</p>
+					<p>Being able to read the primary narrative of a work without interruption is
+						central to reading comprehension. <a data-cite="epub-3#dfn-epub-publication"
+							>EPUB publications</a> are typically structured to visually represent
+						secondary information such as page break markers and footnotes outside the
+						main narrative flow (e.g., by using different background colors or placement
+						so readers can filter this information visually out while reading).</p>
 
-					<p>Readers who prefer auditory playback, however, cannot skip this information with the same ease in
-						a linear audio-based reading experience. And, without structural semantics, synchronized
-						text-audio playback cannot offer skipping content either.</p>
+					<p>Readers who prefer auditory playback, however, cannot skip this information
+						with the same ease in a linear audio-based reading experience. And, without
+						structural semantics, synchronized text-audio playback cannot offer skipping
+						content either.</p>
 
-					<p>When the synchronized text-audio playback instructions include structural semantics, however, <a
-							data-cite="epub-3#dfn-epub-reading-system">reading systems</a> can create reading
-						experiences that allow users to decide which secondary content to skip by default.</p>
+					<p>When the synchronized text-audio playback instructions include structural
+						semantics, however, <a data-cite="epub-3#dfn-epub-reading-system">reading
+							systems</a> can create reading experiences that allow users to decide
+						which secondary content to skip by default.</p>
 				</section>
 			</section>
 		</section>
@@ -1059,113 +1193,128 @@ aside.sidebar {
 				<section id="eval-filter-intro">
 					<h4>Introduction</h4>
 
-					<p>There are fifty-six success criteria that fall at level A or AA in WCAG 2.2 [[wcag2]]. They are
-						organized by whether they improve the perceivability, operability, understanding, or robustness
-						of the content.</p>
+					<p>There are fifty-six success criteria that fall at level A or AA in WCAG 2.2
+						[[wcag2]]. They are organized by whether they improve the perceivability,
+						operability, understanding, or robustness of the content.</p>
 
-					<p>This organization matters because success criteria across multiple categories can apply to
-						different content types. The <a data-cite="wcag2#non-text-content">non-text content success
-							criterion</a>, for example, can apply to images, audio, video, and interactive content. It
-						requires that static images and dynamic images drawn on an [[html]] [^canvas^] element have
-						alternative text and/or descriptions. And for audio and video, it requires labels to describe
-						the nature of the content.</p>
+					<p>This organization matters because success criteria across multiple categories
+						can apply to different content types. The <a
+							data-cite="wcag2#non-text-content">non-text content success
+							criterion</a>, for example, can apply to images, audio, video, and
+						interactive content. It requires that static images and dynamic images drawn
+						on an [[html]] [^canvas^] element have alternative text and/or descriptions.
+						And for audio and video, it requires labels to describe the nature of the
+						content.</p>
 
-					<p>At the same time, there are various success criteria that only apply to a single type of content.
-						The <a data-cite="wcag2#time-based-media">time-based media success criteria</a>, for example,
-						only apply to audio and video.</p>
+					<p>At the same time, there are various success criteria that only apply to a
+						single type of content. The <a data-cite="wcag2#time-based-media">time-based
+							media success criteria</a>, for example, only apply to audio and
+						video.</p>
 
-					<p>When carrying out an accessibility evaluation, it is important to know the possible applications
-						of each success criterion. This avoids both mistakenly missing critical checks and wasting time
-						on success criteria that cannot apply the content.</p>
+					<p>When carrying out an accessibility evaluation, it is important to know the
+						possible applications of each success criterion. This avoids both mistakenly
+						missing critical checks and wasting time on success criteria that cannot
+						apply the content.</p>
 
-					<p>It is not possible for a document like this to determine exactly which success criteria can apply
-						to an EPUB publication because so much depends on the nature of the content. But it is possible
-						to help steer evaluators away from success criteria that do not apply.</p>
+					<p>It is not possible for a document like this to determine exactly which
+						success criteria can apply to an EPUB publication because so much depends on
+						the nature of the content. But it is possible to help steer evaluators away
+						from success criteria that do not apply.</p>
 
-					<p>Many publications do not contain images, audio, video, or scripted content. The <a
-							href="#eval-filter-table">filtering table</a> identifies success criteria that can be
-						skipped when they are not present in EPUB publications. </p>
+					<p>Many publications do not contain images, audio, video, or scripted content.
+						The <a href="#eval-filter-table">filtering table</a> identifies success
+						criteria that can be skipped when they are not present in EPUB publications. </p>
 
-					<p>It is possible to determine what types of content are present, or not present, in an EPUB
-						publication by using validation tools and inspecting the package document. With this
-						information, the <a href="#eval-filter-table">filtering table</a> can be used to skip any
-						success criteria that do not apply.</p>
+					<p>It is possible to determine what types of content are present, or not
+						present, in an EPUB publication by using validation tools and inspecting the
+						package document. With this information, the <a href="#eval-filter-table"
+							>filtering table</a> can be used to skip any success criteria that do
+						not apply.</p>
 				</section>
 
 				<section id="eval-filter-identify">
 					<h4>Identifying content types</h4>
 
-					<p>Before attempting to filter the success criteria it is critical to be sure what content an EPUB
-						publication contains. The traditional way to verify this is through the <a
-							data-cite="epub-3#sec-manifest-elem">package document manifest</a> [[epub-3]]. Each manifest
-						item has to list its media type in a <a data-cite="epub-3#attrdef-item-media-type"
-								><code>media-type</code> attribute</a>, so all that is required is a knowledge of which
-						media types define which type of content.</p>
+					<p>Before attempting to filter the success criteria it is critical to be sure
+						what content an EPUB publication contains. The traditional way to verify
+						this is through the <a data-cite="epub-3#sec-manifest-elem">package document
+							manifest</a> [[epub-3]]. Each manifest item has to list its media type
+						in a <a data-cite="epub-3#attrdef-item-media-type"><code>media-type</code>
+							attribute</a>, so all that is required is a knowledge of which media
+						types define which type of content.</p>
 
-					<p>The media types themselves typically aid in understanding the nature of the listed resources, as
-						the start of each usually classifies the type. Image formats, for example, begin with
-							"<code>image/</code>", while audio formats begin with "<code>audio/</code>". EPUB also
-						maintains a list of core media types which also limits the number of formats that are actually
-						used in publications.</p>
+					<p>The media types themselves typically aid in understanding the nature of the
+						listed resources, as the start of each usually classifies the type. Image
+						formats, for example, begin with "<code>image/</code>", while audio formats
+						begin with "<code>audio/</code>". EPUB also maintains a list of core media
+						types which also limits the number of formats that are actually used in
+						publications.</p>
 
 					<div class="note">
-						<p>Refer to <a data-cite="epub-3#sec-core-media-types">EPUB 3's core media types</a> [[epub-3]]
-							and <a data-cite="ops-201#Section1.3.7">EPUB 2's core media types</a> [[ops-201]] for more
-							information.</p>
+						<p>Refer to <a data-cite="epub-3#sec-core-media-types">EPUB 3's core media
+								types</a> [[epub-3]] and <a data-cite="ops-201#Section1.3.7">EPUB
+								2's core media types</a> [[ops-201]] for more information.</p>
 					</div>
 
-					<p>Unfortunately, the package document manifest is an imperfect way of assessing the content of an
-						EPUB 3 publication. It only works well for EPUB 2 publications because EPUB 2 lacks the more
-						advanced content options of EPUB 3.</p>
+					<p>Unfortunately, the package document manifest is an imperfect way of assessing
+						the content of an EPUB 3 publication. It only works well for EPUB 2
+						publications because EPUB 2 lacks the more advanced content options of EPUB
+						3.</p>
 
-					<p>Determining whether there are images in an EPUB publication is a prime example of how the
-						manifest can fail. Scripts can be used to draw images on the [[html]] [^canvas^] element or to
-						create interactive charts or games. These kinds of images will not be listed in the manifest
-						because they are created using native html functionality.</p>
+					<p>Determining whether there are images in an EPUB publication is a prime
+						example of how the manifest can fail. Scripts can be used to draw images on
+						the [[html]] [^canvas^] element or to create interactive charts or games.
+						These kinds of images will not be listed in the manifest because they are
+						created using native html functionality.</p>
 
-					<p>Similarly, <a data-cite="epub-3#sec-data-urls">data URLs</a> allow raw image data to be embedded
-						directly in html, once again bypassing a manifest entry. A search for URLs that begin with
-							"<code>data:</code>" might not even be sufficient as a script could dynamically insert an
-						image this way.</p>
+					<p>Similarly, <a data-cite="epub-3#sec-data-urls">data URLs</a> allow raw image
+						data to be embedded directly in html, once again bypassing a manifest entry.
+						A search for URLs that begin with "<code>data:</code>" might not even be
+						sufficient as a script could dynamically insert an image this way.</p>
 
-					<p>Scripting is also problematic because it limits the ability of validators to check whether
-						resources are missing from the manifest. If an [[html]] [^audio^] or [^video^] element is
-						dynamically written into an html file, for example, a validator might only report the
-						corresponding audio or video file in the EPUB package as an unused resource in a usage message.
-						Usage messages are not usually emitted by default making the issue easy to miss. Moreover, if
-						the script writes a reference to a remotely hosted resource, the validator will not report
-						anything at all.</p>
+					<p>Scripting is also problematic because it limits the ability of validators to
+						check whether resources are missing from the manifest. If an [[html]]
+						[^audio^] or [^video^] element is dynamically written into an html file, for
+						example, a validator might only report the corresponding audio or video file
+						in the EPUB package as an unused resource in a usage message. Usage messages
+						are not usually emitted by default making the issue easy to miss. Moreover,
+						if the script writes a reference to a remotely hosted resource, the
+						validator will not report anything at all.</p>
 
-					<p>Evaluators will always have to be aware of these limitations and be on the lookout for content
-						that is not listed in the manifest.</p>
+					<p>Evaluators will always have to be aware of these limitations and be on the
+						lookout for content that is not listed in the manifest.</p>
 
-					<p>In an odd twist, although scripting makes the package document manifest less reliable for
-						detecting non-text content, the package document is the best way to detect if scripting is used.
-						When scripting is used in an EPUB content document, no matter what form it takes, it has to be
-						declared in a <a data-cite="epub-3#sec-item-resource-properties"><code>properties</code>
-							attribute</a> [[epub-3]].</p>
+					<p>In an odd twist, although scripting makes the package document manifest less
+						reliable for detecting non-text content, the package document is the best
+						way to detect if scripting is used. When scripting is used in an EPUB
+						content document, no matter what form it takes, it has to be declared in a
+							<a data-cite="epub-3#sec-item-resource-properties"
+								><code>properties</code> attribute</a> [[epub-3]].</p>
 
-					<p>Scripts are not always stored in standalone JavaScript files, so it can be quite difficult to
-						determine if scripting is present without the help of a validator. Scripts embedded using
-						[[html]] [^script^] tags and scripting inlined in the markup using event handler attributes like
-						{{HTMLElement/onclick}} and {{HTMLElement/onkeypress}} are a couple of ways that scripting can
-						be present at the content level. Trying to locate these possibilities manually is prone to
-						mistakes. But so long as the EPUB publication is validated prior to carrying out an
-						accessibility evaluation, detecting scripting will be straightfoward.</p>
+					<p>Scripts are not always stored in standalone JavaScript files, so it can be
+						quite difficult to determine if scripting is present without the help of a
+						validator. Scripts embedded using [[html]] [^script^] tags and scripting
+						inlined in the markup using event handler attributes like
+						{{HTMLElement/onclick}} and {{HTMLElement/onkeypress}} are a couple of ways
+						that scripting can be present at the content level. Trying to locate these
+						possibilities manually is prone to mistakes. But so long as the EPUB
+						publication is validated prior to carrying out an accessibility evaluation,
+						detecting scripting will be straightfoward.</p>
 				</section>
 
 				<section id="eval-filter-table">
 					<h4>Filtering table</h4>
 
-					<p>The following table provides a list of success criteria that can be skipped if an EPUB
-						publication does not contain the specified type of content.</p>
+					<p>The following table provides a list of success criteria that can be skipped
+						if an EPUB publication does not contain the specified type of content.</p>
 
 					<div class="caution">
-						<p>This table does not provide a list of all the success criteria have to be checked when the
-							specified content types are present. The <a
-								href="https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize">How to
-								Meet WCAG (Quick Reference) guide</a> provides the ability to filter WCAG success
-							criteria to show all that apply to different content types as do evaluation tools.</p>
+						<p>This table does not provide a list of all the success criteria have to be
+							checked when the specified content types are present. The <a
+								href="https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize"
+								>How to Meet WCAG (Quick Reference) guide</a> provides the ability
+							to filter WCAG success criteria to show all that apply to different
+							content types as do evaluation tools.</p>
 					</div>
 
 					<table class="zebra" id="sc-filter-table">
@@ -1184,7 +1333,8 @@ aside.sidebar {
 								<th>Images</th>
 								<td>
 									<p>
-										<a data-cite="wcag2#images-of-text">images of text (1.4.5)</a>
+										<a data-cite="wcag2#images-of-text">images of text
+											(1.4.5)</a>
 									</p>
 								</td>
 							</tr>
@@ -1194,44 +1344,52 @@ aside.sidebar {
 								<td>
 									<ul>
 										<li>
-											<a data-cite="wcag2#audio-only-and-video-only-prerecorded">audio-only and
-												video-only prerecorded (1.2.1)</a>
+											<a
+												data-cite="wcag2#audio-only-and-video-only-prerecorded"
+												>audio-only and video-only prerecorded (1.2.1)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#captions-prerecorded">captions prerecorded (1.2.2)</a>
+											<a data-cite="wcag2#captions-prerecorded">captions
+												prerecorded (1.2.2)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#audio-description-or-media-alternative-prerecorded"
-												>audio description or media alternative prerecorded (1.2.3)</a>
+											<a
+												data-cite="wcag2#audio-description-or-media-alternative-prerecorded"
+												>audio description or media alternative prerecorded
+												(1.2.3)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#captions-live">captions live (1.2.4)</a>
+											<a data-cite="wcag2#captions-live">captions live
+												(1.2.4)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#audio-description-prerecorded">audio description
-												prerecorded (1.2.5)</a>
+											<a data-cite="wcag2#audio-description-prerecorded">audio
+												description prerecorded (1.2.5)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#sign-language-prerecorded">sign language prerecorded
-												(1.2.6)</a>
+											<a data-cite="wcag2#sign-language-prerecorded">sign
+												language prerecorded (1.2.6)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#extended-audio-description-prerecorded">extended audio
-												description prerecorded (1.2.7)</a>
+											<a
+												data-cite="wcag2#extended-audio-description-prerecorded"
+												>extended audio description prerecorded (1.2.7)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#media-alternative-prerecorded">media alternative
-												prerecorded (1.2.8)</a>
+											<a data-cite="wcag2#media-alternative-prerecorded">media
+												alternative prerecorded (1.2.8)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#audio-only-live">audio-only live (1.2.9)</a>
+											<a data-cite="wcag2#audio-only-live">audio-only live
+												(1.2.9)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#audio-control">audio control (1.4.2)</a>
+											<a data-cite="wcag2#audio-control">audio control
+												(1.4.2)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#low-or-no-background-audio">low or no background audio
-												(1.4.7)</a>
+											<a data-cite="wcag2#low-or-no-background-audio">low or
+												no background audio (1.4.7)</a>
 										</li>
 									</ul>
 								</td>
@@ -1242,30 +1400,36 @@ aside.sidebar {
 								<td>
 									<ul>
 										<li>
-											<a data-cite="wcag2#identify-input-purpose">identify input purpose
-												(1.3.5)</a>
+											<a data-cite="wcag2#identify-input-purpose">identify
+												input purpose (1.3.5)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#content-on-hover-or-focus">content on hover or focus
-												(1.4.13)</a>
+											<a data-cite="wcag2#content-on-hover-or-focus">content
+												on hover or focus (1.4.13)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#no-keyboard-trap">no keyboard trap (2.1.2)</a>
+											<a data-cite="wcag2#no-keyboard-trap">no keyboard trap
+												(2.1.2)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#timing-adjustable">timing adjustable (2.2.1)</a>
+											<a data-cite="wcag2#timing-adjustable">timing adjustable
+												(2.2.1)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#pointer-gestures">pointer gestures (2.5.1)</a>
+											<a data-cite="wcag2#pointer-gestures">pointer gestures
+												(2.5.1)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#pointer-cancellation">pointer cancellation (2.5.2)</a>
+											<a data-cite="wcag2#pointer-cancellation">pointer
+												cancellation (2.5.2)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#motion-actuation">motion actuation (2.5.4)</a>
+											<a data-cite="wcag2#motion-actuation">motion actuation
+												(2.5.4)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#dragging-movements">dragging movements (2.5.7)</a>
+											<a data-cite="wcag2#dragging-movements">dragging
+												movements (2.5.7)</a>
 										</li>
 										<li>
 											<a data-cite="wcag2#on-focus">on focus (3.2.1)</a>
@@ -1274,31 +1438,37 @@ aside.sidebar {
 											<a data-cite="wcag2#on-input">on input (3.2.2)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#error-identification">error identification (3.3.1)</a>
+											<a data-cite="wcag2#error-identification">error
+												identification (3.3.1)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#labels-or-instructions">labels or instructions
-												(3.3.2)</a>
+											<a data-cite="wcag2#labels-or-instructions">labels or
+												instructions (3.3.2)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#error-suggestion">error suggestion (3.3.3)</a>
+											<a data-cite="wcag2#error-suggestion">error suggestion
+												(3.3.3)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#error-prevention-legal-financial-data">error prevention
-												legal, financial, data (3.3.4)</a>
+											<a
+												data-cite="wcag2#error-prevention-legal-financial-data"
+												>error prevention legal, financial, data (3.3.4)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#redundant-entry">redundant entry (3.3.7)</a>
+											<a data-cite="wcag2#redundant-entry">redundant entry
+												(3.3.7)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#accessible-authentication-minimum">accessible
-												authentication minimum (3.3.8)</a>
+											<a data-cite="wcag2#accessible-authentication-minimum"
+												>accessible authentication minimum (3.3.8)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#name-role-value">name, role, value (4.1.2)</a>
+											<a data-cite="wcag2#name-role-value">name, role, value
+												(4.1.2)</a>
 										</li>
 										<li>
-											<a data-cite="wcag2#status-messages">status messages (4.1.3)</a>
+											<a data-cite="wcag2#status-messages">status messages
+												(4.1.3)</a>
 										</li>
 									</ul>
 								</td>
@@ -1306,8 +1476,9 @@ aside.sidebar {
 						</tbody>
 					</table>
 
-					<p>If an EPUB publication does not contain any of the above content types, and does not use CSS
-						animations, the following Level A and AA success criteria will also not apply:</p>
+					<p>If an EPUB publication does not contain any of the above content types, and
+						does not use CSS animations, the following Level A and AA success criteria
+						will also not apply:</p>
 
 					<ul>
 						<li>
@@ -1320,8 +1491,8 @@ aside.sidebar {
 							<a data-cite="wcag2#pause-stop-hide">pause, stop, hide (2.2.2)</a>
 						</li>
 						<li>
-							<a data-cite="wcag2#three-flashes-or-below-threshold">three flashes or below threshold
-								(2.3.1)</a>
+							<a data-cite="wcag2#three-flashes-or-below-threshold">three flashes or
+								below threshold (2.3.1)</a>
 						</li>
 					</ul>
 				</section>
@@ -1330,28 +1501,30 @@ aside.sidebar {
 			<section id="eval-not-applicable">
 				<h3>Reporting inapplicable success criteria</h3>
 
-				<p>[[[epub-a11y-12]]] [[epub-a11y-12]] does not define a format for evaluation reports. Evaluators have
-					the flexibility to use a format that best meets personal and/or regional reporting needs. In
-					general, though, it is expected that the report will list all the WCAG success criteria that were
-					evaluated and the result of testing for each. For any criteria that were not met, an explanation of
-					what caused the failure is typically also provided.</p>
+				<p>[[[epub-a11y-12]]] [[epub-a11y-12]] does not define a format for evaluation
+					reports. Evaluators have the flexibility to use a format that best meets
+					personal and/or regional reporting needs. In general, though, it is expected
+					that the report will list all the WCAG success criteria that were evaluated and
+					the result of testing for each. For any criteria that were not met, an
+					explanation of what caused the failure is typically also provided.</p>
 
-				<p>While this form of reporting is traditional for accessibility evaluations, confusion sometimes arises
-					around how to report success criteria that do not apply to the content. Although the content does
-					not fail these success criteria, reporting them as a 'pass' is inaccurate because they were never
-					applicable. A 'pass' result should only be awarded when a requirement has been actively evaluated
-					and met.</p>
+				<p>While this form of reporting is traditional for accessibility evaluations,
+					confusion sometimes arises around how to report success criteria that do not
+					apply to the content. Although the content does not fail these success criteria,
+					reporting them as a 'pass' is inaccurate because they were never applicable. A
+					'pass' result should only be awarded when a requirement has been actively
+					evaluated and met.</p>
 
-				<p>A basic text novel, for example, should not have an evaluation report that says that text
-					alternatives are provided for all the audio and video content. This kind of false reporting is not
-					just misleading to users but could make regulators question whether a proper evaluation was even
-					carried out.</p>
+				<p>A basic text novel, for example, should not have an evaluation report that says
+					that text alternatives are provided for all the audio and video content. This
+					kind of false reporting is not just misleading to users but could make
+					regulators question whether a proper evaluation was even carried out.</p>
 
-				<p>The best way to avoid this problem is to assign a "not applicable" result (or an equivalent
-					language-specific term) to success criteria that do not apply to an EPUB publication. If the
-					reporting template only allows pass or fail results, then the success criteria should not be
-					reported as an unqualified pass. Use the comment field to indicate which success criteria are not
-					applicable.</p>
+				<p>The best way to avoid this problem is to assign a "not applicable" result (or an
+					equivalent language-specific term) to success criteria that do not apply to an
+					EPUB publication. If the reporting template only allows pass or fail results,
+					then the success criteria should not be reported as an unqualified pass. Use the
+					comment field to indicate which success criteria are not applicable.</p>
 			</section>
 		</section>
 		<section id="index"></section>

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -789,46 +789,55 @@ aside.sidebar {
 					<p>A page list is essential for accessibility when digital publications are used in coordination
 						with a static alternative like a print edition. The most common scenario is when digital
 						publications are produced for use in educational settings. Students who cannot read a print
-						edition need to be able to coordinate their reading with their sighted peers. But any social
-						reading environment, such as a book club, will also be more inclusive when users are not
+						edition need to be able to coordinate their digital edition with their sighted peers. But any
+						social reading environment, such as a book club, will also be more inclusive when users are not
 						disadvantaged by their need to use a digital edition.</p>
 
 					<p>It is true that many <a data-cite="epub-3#dfn-epub-reading-system">reading systems</a> provide a
-						paginated reading experience and allow users to move between these pages. But they key
-						difference is that this pagination is not static. The number of pages and what content appears
-						on any given page changes depending on how much content can fit in the device's screen. That in
-						turn is influenced by whether the user has altered the fonts and spacing to their own
-						preferences. A publication rendered using arger font sizes and greater spacing will have more
-						dynamic pages than one using the reading system's standard settings. Consequently, coordinating
-						access across devices is impossible without a static baseline.</p>
+						paginated reading experience and allow users to move between these pages. The key difference is
+						that this pagination is typically not static and does not match up with a statically paginated
+						source. The number of pages and what content appears on any given page changes depending on how
+						much content can fit in the device's screen. That in turn is influenced by whether the user has
+						altered the fonts and spacing to their own preferences. A publication rendered using larger font
+						sizes and greater spacing will have more dynamic pages than one using the reading system's
+						standard settings. Consequently, coordinating access across devices is impossible without a
+						static baseline.</p>
 
 					<p>When a page list is provided, a <a data-cite="epub-3#dfn-epub-reading-system">reading system</a>
 						can generate a "go to page" interface in which users can plug in the page number that they wish
-						to move to. This provides users the ability to find the same location in their digital edition
-						as their peers using a print edition, for example. Without a page list, page navigation becomes
-						extremely difficult as it would rely on navigating the individual <a href="#page-breaks">page
-							break markers</a> (if they are even present).</p>
+						to move to and know that they will end up in the same place as readers of the static source.
+						This provides users the ability to find the same location in their digital edition as their
+						peers using a print edition, for example. Without a page list, page coordination with a print
+						source becomes extremely difficult as it would rely on navigating the individual <a
+							href="#page-breaks">page break markers</a> (if they are even present).</p>
 
-					<p>Digital editions often omit content from their static print counterparts, typically in the front
-						or back matter. Blank pages are another feature of print editions that have no equivalent in
-						digital editions. Page break markers can be included for them but the effort to add them may not
-						be worth the effort knowing that users never actively seek this locations. For this reason, the
-						page list is not required to reproduce every page break from the static source.</p>
+					<p>The page list is not required to reproduce every page break from the static source. Digital
+						editions often omit content from their static print counterparts, for example, typically in the
+						front or back matter. Blank pages are another feature of print editions that have no equivalent
+						in digital editions. Page break markers can be included for them but the effort to add them may
+						not be worth the effort knowing that users never actively seek this locations.</p>
 
 					<p>What is required is that the page list include links to every page of content that is reproduced
 						from the static equivalent. Moreover, if there are page break markers in the EPUB publication,
 						the page list has to include links to all these markers. This is to ensure that the EPUB
 						publication does not contain content that cannot be reached.</p>
 
-					<p>The page list requirement is currently only mandated in a limited set of scenarios because the
-						benefit to users only accrues when there is a statically paginated equivalent to sync up with.
-						As already noted, when a publisher knows their content will be used in a mixed reading
-						environment, such as when they sell publications to schools, ensuring the digital edition has a
-						page list is essential. Likewise, if they are providing students with a print and digital
-						bundle, the need to coordinate reading can be anticipated. And finally, if a digital publication
-						is produced from the same workflow as a print publication, making it easy to retain the page
-						locations in the digital version, then publishers should opt for maximum accessibility by
-						producing the page list.</p>
+					<div class="note">
+						<p>It is not required that each link in the page list reference a <a href="#page-breaks">page
+								break marker</a>. Using page break markers is typically the simplest and most accessible
+							way to identify all the static page break locations, but the page list can link to any
+							element with an ID that is located at a page boundary.</p>
+					</div>
+
+					<p id="page-breaks-application">The page list requirement is currently only mandated in a limited
+						set of scenarios because the benefit to users only accrues when there is a statically paginated
+						equivalent to sync up with. As already noted, when a publisher knows their content will be used
+						in a mixed reading environment, such as when they sell publications to schools, ensuring the
+						digital edition has a page list is essential. Likewise, if they are providing students with a
+						print and digital bundle, the need to coordinate reading can be anticipated. And finally, if a
+						digital publication is produced from the same workflow as a print publication, making it easy to
+						retain the page locations in the digital version, then publishers should opt for maximum
+						accessibility by producing the page list.</p>
 
 					<p>A page list is not required for EPUB publications that do not have a statically paginated source.
 						Digital-only publications can benefit from a page list for coordinated access within reading
@@ -836,7 +845,7 @@ aside.sidebar {
 						disadvantage any one type of user over another.</p>
 
 					<div class="note">
-						<p>For specific techniques to meeet this requirement, refer to the section <a
+						<p>For specific techniques to meet this requirement, refer to the section <a
 								data-cite="epub-a11y-tech-12#page-list">Provide a page list</a> in
 							[[epub-a11y-tech-12]].</p>
 					</div>
@@ -845,31 +854,57 @@ aside.sidebar {
 				<section id="page-breaks">
 					<h4>Page breaks</h4>
 
-					<p>Being able to identify the current page a user is on, and having that page be consistent across
-						devices and user settings, is essential to many reading needs. Primary among these is that it
-						allows students who require digital publications to coordinate with peers who are using print
-						editions.</p>
+					<p>The ability to identify the current page a user is on, and have that page be consistent across
+						devices and user settings, is another essential feature for users who are trying to coordinate
+						their reading in a mixed print-digital environment. The <a href="#page-list">page list</a>
+						provides quick access to the page break locations, but without <a
+							data-cite="epub-a11y#sec-page-breaks">static page break markers</a> [[epub-a11y]] in the
+						content the context of where a user is relative to the statically paginated equivalent is
+						lost.</p>
 
-					<p>The ability to locate consistent page locations in an <a data-cite="epub-3#dfn-epub-publication"
-							>EPUB publication</a> is an important means of coordinating access.</p>
+					<p><a data-cite="epub-a11y#dfn-assistive-technology">Assistive technologies</a> [[epub-a11y]] can
+						use the page break markers to announce the current page number the user is on. This makes it
+						easier for users to verify they are in the right location, for example, or to cite content on
+						the page. Page break markers also allow assistive technologies to provide shortcut keys that
+						allow the user to move forward or backward by page &#8212; a feat that is not easy to accomplish
+						with only a page list.</p>
 
-					<p>Inserting <a data-cite="epub-a11y#sec-page-breaks">static page break markers</a> [[epub-a11y]]
-						into an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> provides users with
-						context about where they are in the text. <a data-cite="epub-a11y#dfn-assistive-technology"
-							>Assistive technologies</a> [[epub-a11y]] can use this information to announce the current
-						page number the user is on, for example, if the user wants to cite something on the page.</p>
-
-					<p>The inclusion of page break markers can also allow users to move quickly forwards and backwards
-						by page without having to access the page list each time.</p>
-
-					<p>The inclusion of these markers also simplifies the creation of a <a href="#page-list">page
+					<p>The inclusion of page break markers also simplifies the creation of a <a href="#page-list">page
 							list</a>, as they provide easily referenced destinations for the links.</p>
 
+					<p>It is not required that there be page break markers for every page from the static equivalent.
+						Some content from print sources is not reproduced in digital editions, for example. There are
+						also print conventions, like inserting blank pages so new chapters always begin on a recto page,
+						that do not translate to digital editions. Page break markers can be included for these blank or
+						missing pages, but additional context needs to be provided so users are aware why there is no
+						content.</p>
+
+					<p>Since some content can also be rearranged from print to digital editions, it is also not a
+						requirement that the page break markers be arranged in numerical order.</p>
+
+					<p>As with the page list, it is not required that every publication include page break markers to be
+						accessible. The <a href="#page-breaks-application">same conditions</a> that apply to including a
+						page list apply to include page break markers.</p>
+
 					<div class="note">
-						<p>For specific techniques to meeet this requirement, refer to the section <a
+						<p>For specific techniques to meet this requirement, refer to the section <a
 								data-cite="epub-a11y-tech-12#page-breaks">Provide page break markers</a> in
 							[[epub-a11y-tech-12]].</p>
 					</div>
+
+					<section id="page-breaks-mo">
+						<h5>Page breaks in media overlays</h5>
+
+						<p>The page break marker objectives also include a requirement that if the page break numbers
+							are read out in media overlays playback, the markers also have to be identified in the SMIL
+							markup.</p>
+
+						<p>This requirement ensures that the same pagination information is available to reading systems
+							during playback that is available to assistive technologies. A reading system could
+							similarly offer the ability to announce the current page or provide the ability to skip
+							forward or backward by page without relying on the semantics in the XHTML content
+							document.</p>
+					</section>
 				</section>
 
 				<section id="page-source">
@@ -904,7 +939,7 @@ aside.sidebar {
 						metadata.</p>
 
 					<div class="note">
-						<p>For specific techniques to meeet this requirement, refer to the section <a
+						<p>For specific techniques to meet this requirement, refer to the section <a
 								data-cite="epub-a11y-tech-12#page-source">Identify the pagination source</a> in
 							[[epub-a11y-tech-12]].</p>
 					</div>

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -778,49 +778,136 @@ aside.sidebar {
 			<section id="page-nav">
 				<h3>Page navigation</h3>
 
+				<section id="page-list">
+					<h4>Page list</h4>
+
+					<p>A <a data-cite="epub-a11y#sec-page-list">page list</a> [[epub-a11y]] is a list of links to static
+						page break locations in an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a>. Its
+						purpose is to provide users with an easy means of accessing the same location across different
+						device screen sizes and user text preferences.</p>
+
+					<p>A page list is essential for accessibility when digital publications are used in coordination
+						with a static alternative like a print edition. The most common scenario is when digital
+						publications are produced for use in educational settings. Students who cannot read a print
+						edition need to be able to coordinate their reading with their sighted peers. But any social
+						reading environment, such as a book club, will also be more inclusive when users are not
+						disadvantaged by their need to use a digital edition.</p>
+
+					<p>It is true that many <a data-cite="epub-3#dfn-epub-reading-system">reading systems</a> provide a
+						paginated reading experience and allow users to move between these pages. But they key
+						difference is that this pagination is not static. The number of pages and what content appears
+						on any given page changes depending on how much content can fit in the device's screen. That in
+						turn is influenced by whether the user has altered the fonts and spacing to their own
+						preferences. A publication rendered using arger font sizes and greater spacing will have more
+						dynamic pages than one using the reading system's standard settings. Consequently, coordinating
+						access across devices is impossible without a static baseline.</p>
+
+					<p>When a page list is provided, a <a data-cite="epub-3#dfn-epub-reading-system">reading system</a>
+						can generate a "go to page" interface in which users can plug in the page number that they wish
+						to move to. This provides users the ability to find the same location in their digital edition
+						as their peers using a print edition, for example. Without a page list, page navigation becomes
+						extremely difficult as it would rely on navigating the individual <a href="#page-breaks">page
+							break markers</a> (if they are even present).</p>
+
+					<p>Digital editions often omit content from their static print counterparts, typically in the front
+						or back matter. Blank pages are another feature of print editions that have no equivalent in
+						digital editions. Page break markers can be included for them but the effort to add them may not
+						be worth the effort knowing that users never actively seek this locations. For this reason, the
+						page list is not required to reproduce every page break from the static source.</p>
+
+					<p>What is required is that the page list include links to every page of content that is reproduced
+						from the static equivalent. Moreover, if there are page break markers in the EPUB publication,
+						the page list has to include links to all these markers. This is to ensure that the EPUB
+						publication does not contain content that cannot be reached.</p>
+
+					<p>The page list requirement is currently only mandated in a limited set of scenarios because the
+						benefit to users only accrues when there is a statically paginated equivalent to sync up with.
+						As already noted, when a publisher knows their content will be used in a mixed reading
+						environment, such as when they sell publications to schools, ensuring the digital edition has a
+						page list is essential. Likewise, if they are providing students with a print and digital
+						bundle, the need to coordinate reading can be anticipated. And finally, if a digital publication
+						is produced from the same workflow as a print publication, making it easy to retain the page
+						locations in the digital version, then publishers should opt for maximum accessibility by
+						producing the page list.</p>
+
+					<p>A page list is not required for EPUB publications that do not have a statically paginated source.
+						Digital-only publications can benefit from a page list for coordinated access within reading
+						groups, but the lack of a page list affects all users equally. It does not specially
+						disadvantage any one type of user over another.</p>
+
+					<div class="note">
+						<p>For specific techniques to meeet this requirement, refer to the section <a
+								data-cite="epub-a11y-tech-12#page-list">Provide a page list</a> in
+							[[epub-a11y-tech-12]].</p>
+					</div>
+				</section>
+
 				<section id="page-breaks">
 					<h4>Page breaks</h4>
 
-					<p>Inserting <a data-cite="epub-a11y#sec-page-breaks">page break markers</a> [[epub-a11y]] into an
-							<a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> provides users with context
-						about where they are in the text. <a data-cite="epub-a11y#dfn-assistive-technology">Assistive
-							technologies</a> [[epub-a11y]] can use this information to announce the current page number
-						the user is on, for example, if the user wants to cite something on the page.</p>
+					<p>Being able to identify the current page a user is on, and having that page be consistent across
+						devices and user settings, is essential to many reading needs. Primary among these is that it
+						allows students who require digital publications to coordinate with peers who are using print
+						editions.</p>
+
+					<p>The ability to locate consistent page locations in an <a data-cite="epub-3#dfn-epub-publication"
+							>EPUB publication</a> is an important means of coordinating access.</p>
+
+					<p>Inserting <a data-cite="epub-a11y#sec-page-breaks">static page break markers</a> [[epub-a11y]]
+						into an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> provides users with
+						context about where they are in the text. <a data-cite="epub-a11y#dfn-assistive-technology"
+							>Assistive technologies</a> [[epub-a11y]] can use this information to announce the current
+						page number the user is on, for example, if the user wants to cite something on the page.</p>
 
 					<p>The inclusion of page break markers can also allow users to move quickly forwards and backwards
 						by page without having to access the page list each time.</p>
 
 					<p>The inclusion of these markers also simplifies the creation of a <a href="#page-list">page
 							list</a>, as they provide easily referenced destinations for the links.</p>
-				</section>
 
-				<section id="page-list">
-					<h4>Page list</h4>
-
-					<p>The <a data-cite="epub-a11y#sec-page-list">page list</a> [[epub-a11y]] is the primary means of
-						navigating to page break locations as it provides a list of links to each of the static page
-						break locations in the <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a>.</p>
-
-					<p><a data-cite="epub-3#dfn-epub-reading-system">Reading systems</a> typically use this list to
-						generate a "go to page" interface in which users can plug in the page number that they wish to
-						move to, but sometimes offer users the ability to access the full list and select the page
-						number to go to.</p>
-
-					<p>Without a page list, page navigation becomes extremely difficult as it would rely on navigating
-						the individual <a href="#page-breaks">page break markers</a> (if they are even present).</p>
+					<div class="note">
+						<p>For specific techniques to meeet this requirement, refer to the section <a
+								data-cite="epub-a11y-tech-12#page-breaks">Provide page break markers</a> in
+							[[epub-a11y-tech-12]].</p>
+					</div>
 				</section>
 
 				<section id="page-source">
 					<h4>Page source</h4>
 
-					<p>Users need to know the <a data-cite="epub-a11y#sec-page-src">source of the pagination</a>
-						[[epub-a11y]] in an <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> to determine
-						whether it will be useful for their needs. Print publications, for example, produced in both
-						hard and soft cover editions will have different pagination. Different editions of the same book
-						often also have different pagination.</p>
+					<p>When seeking accessible publications for mixed print-digital reading environments, the first
+						thing an individual wants to be sure of is that the digital edition is the same as the print
+						edition. Different editions of a publication can differ not only in the content they contain but
+						in how they are paginated. Print publications, for example, will have different pagination
+						between their hard and soft cover editions. Different editions of the same book often also have
+						different pagination as new content gets added or existing content gets revised or removed.</p>
 
-					<p>Including a recognizable identifier for the statically paginated source, such as its ISBN or
-						ISSN, ensures that users can determine which version the pagination corresponds to.</p>
+					<p>An <a data-cite="epub-3#dfn-epub-publication">EPUB publication</a> with a page list and page
+						break markers loses its accessibility when it is not possible for users to determine what static
+						edition the pagination corresponds to. The <a data-cite="epub-a11y#sec-page-src">source of the
+							pagination</a> [[epub-a11y]] has to be specified in the metadata to allow users to determine
+						whether if they have the right digital edition.</p>
+
+					<p>The source publication is typically identified using a standardized identifier such as an ISBN or
+						ISSN. These identifiers are more accurate than text descriptions of the source. In the case of a
+						publication that does not have a standard identifier, the source can be identified by providing
+						as much information about it as possible (e.g., title, publisher, edition, publication date,
+						etc.).</p>
+
+					<p>Providing the source identifier allows vendors, for example, to present the information to users
+						in their bookstore metadata. This allows users to be sure of their purchase before making
+						it.</p>
+
+					<p>A page source identifier is only set when an EPUB publication contains one or both of a page list
+						or page break markers. Setting it when neither is not only incorrect but can mislead users into
+						thinking the features are present even though, for example, they will not be listed in bookstore
+						metadata.</p>
+
+					<div class="note">
+						<p>For specific techniques to meeet this requirement, refer to the section <a
+								data-cite="epub-a11y-tech-12#page-source">Identify the pagination source</a> in
+							[[epub-a11y-tech-12]].</p>
+					</div>
 				</section>
 			</section>
 
@@ -1212,10 +1299,11 @@ aside.sidebar {
 					evaluated and the result of testing for each. For any criteria that were not met, an explanation of
 					what caused the failure is typically also provided.</p>
 
-				<p>While this form of reporting is traditional for accessibility evaluations, confusion sometimes arises around how to
-					report success criteria that do not apply to the content. Although the content does not fail these success criteria,
-					reporting them as a 'pass' is inaccurate because they were never applicable. A 'pass' result should only be
-					awarded when a requirement has been actively evaluated and met.</p>
+				<p>While this form of reporting is traditional for accessibility evaluations, confusion sometimes arises
+					around how to report success criteria that do not apply to the content. Although the content does
+					not fail these success criteria, reporting them as a 'pass' is inaccurate because they were never
+					applicable. A 'pass' result should only be awarded when a requirement has been actively evaluated
+					and met.</p>
 
 				<p>A basic text novel, for example, should not have an evaluation report that says that text
 					alternatives are provided for all the audio and video content. This kind of false reporting is not


### PR DESCRIPTION
The original text of these sections came from the EPUB Accessibility 1.2 specification but it was kept minimal to avoid overloading each objective with explanatory text. This pull request expands each of the sections to more fully cover the requirements. (I'm going to look at the media overlay sections next.)

This link goes to the start of the revised sections:
https://raw.githack.com/w3c/epub-specs/understanding/epub-obj/epub34/a11y-understand/index.html#page-nav

***

[Preview](https://raw.githack.com/w3c/epub-specs/understanding/epub-obj/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstanding%2Fepub-obj%2Fepub34%2Fa11y-understand%2Findex.html)
