### PR TITLE
Fix SMIL namespace URL

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8043,7 +8043,7 @@ No Entry</pre>
 				<section id="sec-overlays-def">
 					<h3>Media overlay document definition</h3>
 
-					<p>All elements [[xml]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
+					<p>All elements [[xml]] defined in this section are in the <code>http://www.w3.org/ns/SMIL</code>
 						namespace [[xml-names]] unless otherwise specified.</p>
 
 					<section id="sec-smil-smil-elem">


### PR DESCRIPTION
The SMIL 3.0 namespace URL [has `http` scheme](https://www.w3.org/TR/SMIL3/smil-scalabilityFramework.html#smilScalabilityNS-BasicDoc-RulesConformant-Docs).