### PR TITLE
Clarify the scope of the understanding document in the title

### DIFF
--- a/epub34/a11y-explain/index.html
+++ b/epub34/a11y-explain/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB Accessibility 1.2 – Understanding Accessible Publications</title>
+		<title>EPUB Accessibility 1.2 Explainer</title>
 		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -12,9 +12,10 @@
 				group: "pm",
 				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
-				shortName: "epub-a11y-understand-12",
+				shortName: "epub-a11y-explain-12",
+				subtitle: "A guide to understanding and evaluating accessible publications",
 				noRecTrack: true,
-				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
+				edDraftURI: "https://w3c.github.io/epub-specs/epub34/a11y-explain/",
                 copyrightStart: "2026",
 				editors:[ {
 					name: "Matt Garrish",
@@ -97,8 +98,8 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>The EPUB Accessibility 1.2 – Understanding Accessible Publications guide provides information on how to
-				evaluate the accessible content conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against
+			<p>The EPUB Accessibility 1.2 Explainer provides information on how to understand and evaluate the
+				accessible publications conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against
 				reflowable EPUB publications.</p>
 		</section>
 		<section id="sotd"></section>

--- a/epub34/a11y-understand/index.html
+++ b/epub34/a11y-understand/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>Understanding EPUB Accessibility 1.2</title>
+		<title>EPUB Accessibility 1.2 – Understanding Accessible Publications</title>
 		<meta name="color-scheme" content="light dark" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/css-inline.js" class="remove"></script>
@@ -97,9 +97,9 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>The Understanding EPUB Accessibility 1.2 guide provides information on how to evaluate the accessible
-				content conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against reflowable EPUB
-				publications.</p>
+			<p>The EPUB Accessibility 1.2 – Understanding Accessible Publications guide provides information on how to
+				evaluate the accessible content conformance requirements of [[[epub-a11y-12]]] [[epub-a11y-12]] against
+				reflowable EPUB publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="intro">
@@ -109,9 +109,10 @@
 				<h3>Overview</h3>
 
 				<p>This document together with [[[epub-a11y-tech-12]]] [[epub-a11y-tech-12]] provide informative support
-					for implementing [[[epub-a11y-12]]] [[epub-a11y-12]]. This document provides general explanations of
-					the objectives and success criteria defined in EPUB Accessibility 1.2, while the EPUB Accessibility
-					Techniques 1.2 document details specific methods for meeting those requirements.</p>
+					for implementing [[[epub-a11y-12]]] [[epub-a11y-12]]. This document provides general explanation of
+					the "<a data-cite="epub-a11y-12#sec-accessible-pubs">Accessible publications</a>" section of EPUB
+					Accessibility 1.2, while the EPUB Accessibility Techniques 1.2 document details specific methods for
+					meeting those requirements.</p>
 
 				<p>This document is divided into three parts. The <a href="#wcag">first part</a> covers WCAG [[wcag2]]
 					success criteria whose application to digital publications is ambiguous or that have been found to
@@ -1212,10 +1213,11 @@ aside.sidebar {
 					evaluated and the result of testing for each. For any criteria that were not met, an explanation of
 					what caused the failure is typically also provided.</p>
 
-				<p>While this form of reporting is traditional for accessibility evaluations, confusion sometimes arises around how to
-					report success criteria that do not apply to the content. Although the content does not fail these success criteria,
-					reporting them as a 'pass' is inaccurate because they were never applicable. A 'pass' result should only be
-					awarded when a requirement has been actively evaluated and met.</p>
+				<p>While this form of reporting is traditional for accessibility evaluations, confusion sometimes arises
+					around how to report success criteria that do not apply to the content. Although the content does
+					not fail these success criteria, reporting them as a 'pass' is inaccurate because they were never
+					applicable. A 'pass' result should only be awarded when a requirement has been actively evaluated
+					and met.</p>
 
 				<p>A basic text novel, for example, should not have an evaluation report that says that text
 					alternatives are provided for all the audio and video content. This kind of false reporting is not


### PR DESCRIPTION
After the discussion on the last call, this pull request changes the name from "Understanding EPUB Accessibility 1.2" to the more specific "EPUB Accessibility 1.2 – Understanding Accessible Publications".

"Accessible Publications" is the title of section 3 of the standard which is all this document is intended to cover.

***

[Preview](https://raw.githack.com/w3c/epub-specs/understand/title/epub34/a11y-understand/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fw3c.github.io%2Fepub-specs%2Fepub34%2Fa11y-understand%2Findex.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Funderstand%2Ftitle%2Fepub34%2Fa11y-understand%2Findex.html)
