### PR TITLE
CR link errors

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -68,9 +68,9 @@
 						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
-					"epub-a11y-understand": {
-						"title": "Understanding EPUB Accessibility 1.2",
-						"href": "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
+					"epub-a11y-explain-12": {
+						"title": "EPUB Accessibility 1.2 Explainer",
+						"href": "https://w3c.github.io/epub-specs/epub34/a11y-explain/",
 						"publisher": "W3C"
 					},
 					"iso24751-3": {
@@ -142,8 +142,8 @@
 
 				<div class="note">
 					<p>For general help understanding how WCAG success criteria and EPUB objectives defined in
-						[[epub-a11y-12]] apply to EPUB publications, refer to [[[epub-a11y-understand]]]
-						[[epub-a11y-understand]].</p>
+						[[epub-a11y-12]] apply to EPUB publications, refer to [[[epub-a11y-explain-12]]]
+						[[epub-a11y-explain-12]].</p>
 				</div>
 			</section>
 
@@ -340,8 +340,8 @@
 					<p>Given these differences in application, however, it is important to include EPUB landmarks and
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
 						navigation in its own way. Providing EPUB landmarks further fulfills the requirement for <!--<a
-							data-cite="epub-a11y-understand#multiple-ways">-->multiple
-						ways<!--</a> [[epub-a11y-understand]] --> to access the content.</p>
+							data-cite="epub-a11y-explain-12#multiple-ways">-->multiple
+						ways<!--</a> [[epub-a11y-explain-12]] --> to access the content.</p>
 
 					<p>The EPUB specification does not require that EPUB publications include a specific set of
 						landmarks; it only recommends to include a link to the start of the body matter as well as to

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -215,7 +215,7 @@
 					implementing this standard:</p>
 
 				<dl>
-					<dt>Understanding EPUB Accessibility</dt>
+					<dt>EPUB Accessibility Explainer</dt>
 					<dd>
 						<p>This document assumes a high level of familiarity with both EPUB 3 [[epub-3]] and WCAG 2
 							[[wcag2]]. It expects that implementers of the standard understand how to apply WCAG 2,
@@ -223,9 +223,9 @@
 								publication</a>, which is more like a packaged web site that reads as a single
 							document.</p>
 
-						<p>The [[[epub-a11y-explain-12]]] [[epub-a11y-explain-12]] document goes into more detail about
-							how to understand success criteria in the context of an EPUB publication &#8212; when they
-							apply, or not, what to look for in publications, etc. It also explains the additional <a
+						<p>The [[[epub-a11y-explain-12]]] [[epub-a11y-explain-12]] goes into more detail about how to
+							understand success criteria in the context of an EPUB publication &#8212; when they apply,
+							or not, what to look for in publications, etc. It also explains the additional <a
 								href="#sec-epub-req">EPUB objectives</a> introduced in this document.</p>
 					</dd>
 
@@ -710,7 +710,7 @@
 							<h6>Pagination source</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#page-source">Understanding pagination source</a>
+								<a data-cite="epub-a11y-explain-12#page-source">Pagination source explainer</a>
 								<a data-cite="epub-a11y-tech-12#page-source">Techniques for pagination source</a>
 							</div>
 
@@ -739,7 +739,7 @@
 							<h6>Page list</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#page-list">Understanding page list</a>
+								<a data-cite="epub-a11y-explain-12#page-list">Page list explainer</a>
 								<a data-cite="epub-a11y-tech-12#page-list">Techniques for page list</a>
 							</div>
 
@@ -768,7 +768,7 @@
 							<h6>Page breaks</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#page-breaks">Understanding page breaks</a>
+								<a data-cite="epub-a11y-explain-12#page-breaks">Page breaks explainer</a>
 								<a data-cite="epub-a11y-tech-12#page-breaks">Techniques for page breaks</a>
 							</div>
 
@@ -854,7 +854,7 @@
 							<h6>Completeness</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#sync-completeness">Understanding completeness</a>
+								<a data-cite="epub-a11y-explain-12#sync-completeness">Completeness explainer</a>
 								<a data-cite="epub-a11y-tech-12#sync-completeness">Techniques for completeness</a>
 							</div>
 
@@ -877,7 +877,7 @@
 							<h6>Reading order</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#sync-reading-order">Understanding reading order</a>
+								<a data-cite="epub-a11y-explain-12#sync-reading-order">Reading order explainer</a>
 								<a data-cite="epub-a11y-tech-12#sync-reading-order">Techniques for reading order</a>
 							</div>
 
@@ -906,7 +906,7 @@
 							<h6>Skippability</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#sync-skippability">Understanding skippability</a>
+								<a data-cite="epub-a11y-explain-12#sync-skippability">Skippability explainer</a>
 								<a data-cite="epub-a11y-tech-12#sync-skippability">Techniques for skippability</a>
 							</div>
 
@@ -928,7 +928,7 @@
 							<h6>Escapability</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#sync-escapability">Understanding escapability</a>
+								<a data-cite="epub-a11y-explain-12#sync-escapability">Escapability explainer</a>
 								<a data-cite="epub-a11y-tech-12#sync-escapability">Techniques for escapability</a>
 							</div>
 
@@ -950,7 +950,7 @@
 							<h6>Navigation document</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-explain-12#sync-nav-doc">Understanding navigation document</a>
+								<a data-cite="epub-a11y-explain-12#sync-nav-doc">Navigation document explainer</a>
 								<a data-cite="epub-a11y-tech-12#sync-nav-doc">Techniques for navigation document</a>
 							</div>
 

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -80,9 +80,9 @@
 						"date": "05 January 2017",
 						"publisher": "IDPF"
 					},
-					"epub-a11y-understand": {
-						"title": "Understanding EPUB Accessibility 1.2",
-						"href": "https://w3c.github.io/epub-specs/epub34/a11y-understand/",
+					"epub-a11y-explain-12": {
+						"title": "EPUB Accessibility 1.2 Explainer",
+						"href": "https://w3c.github.io/epub-specs/epub34/a11y-explain/",
 						"publisher": "W3C"
 					},
 					"epub-3": {
@@ -92,7 +92,7 @@
 					},
 					"marc21": {
 						"title": "MARC 21 XML",
-						"href": "https://www.loc.gov/standards/marcxml/"		
+						"href": "https://www.loc.gov/standards/marcxml/"
 					},
 					"onix": {
 						"title": "ONIX for Books 3.0",
@@ -223,7 +223,7 @@
 								publication</a>, which is more like a packaged web site that reads as a single
 							document.</p>
 
-						<p>The [[[epub-a11y-understand]]] [[epub-a11y-understand]] document goes into more detail about
+						<p>The [[[epub-a11y-explain-12]]] [[epub-a11y-explain-12]] document goes into more detail about
 							how to understand success criteria in the context of an EPUB publication &#8212; when they
 							apply, or not, what to look for in publications, etc. It also explains the additional <a
 								href="#sec-epub-req">EPUB objectives</a> introduced in this document.</p>
@@ -710,7 +710,7 @@
 							<h6>Pagination source</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#page-source">Understanding pagination source</a>
+								<a data-cite="epub-a11y-explain-12#page-source">Understanding pagination source</a>
 								<a data-cite="epub-a11y-tech-12#page-source">Techniques for pagination source</a>
 							</div>
 
@@ -739,7 +739,7 @@
 							<h6>Page list</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#page-list">Understanding page list</a>
+								<a data-cite="epub-a11y-explain-12#page-list">Understanding page list</a>
 								<a data-cite="epub-a11y-tech-12#page-list">Techniques for page list</a>
 							</div>
 
@@ -768,7 +768,7 @@
 							<h6>Page breaks</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#page-breaks">Understanding page breaks</a>
+								<a data-cite="epub-a11y-explain-12#page-breaks">Understanding page breaks</a>
 								<a data-cite="epub-a11y-tech-12#page-breaks">Techniques for page breaks</a>
 							</div>
 
@@ -854,7 +854,7 @@
 							<h6>Completeness</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#sync-completeness">Understanding completeness</a>
+								<a data-cite="epub-a11y-explain-12#sync-completeness">Understanding completeness</a>
 								<a data-cite="epub-a11y-tech-12#sync-completeness">Techniques for completeness</a>
 							</div>
 
@@ -877,7 +877,7 @@
 							<h6>Reading order</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#sync-reading-order">Understanding reading order</a>
+								<a data-cite="epub-a11y-explain-12#sync-reading-order">Understanding reading order</a>
 								<a data-cite="epub-a11y-tech-12#sync-reading-order">Techniques for reading order</a>
 							</div>
 
@@ -906,7 +906,7 @@
 							<h6>Skippability</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#sync-skippability">Understanding skippability</a>
+								<a data-cite="epub-a11y-explain-12#sync-skippability">Understanding skippability</a>
 								<a data-cite="epub-a11y-tech-12#sync-skippability">Techniques for skippability</a>
 							</div>
 
@@ -928,7 +928,7 @@
 							<h6>Escapability</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#sync-escapability">Understanding escapability</a>
+								<a data-cite="epub-a11y-explain-12#sync-escapability">Understanding escapability</a>
 								<a data-cite="epub-a11y-tech-12#sync-escapability">Techniques for escapability</a>
 							</div>
 
@@ -950,7 +950,7 @@
 							<h6>Navigation document</h6>
 
 							<div class="info">
-								<a data-cite="epub-a11y-understand#sync-nav-doc">Understanding navigation document</a>
+								<a data-cite="epub-a11y-explain-12#sync-nav-doc">Understanding navigation document</a>
 								<a data-cite="epub-a11y-tech-12#sync-nav-doc">Techniques for navigation document</a>
 							</div>
 
@@ -1062,7 +1062,7 @@
 						<pre>&lt;package …>
    &lt;metadata …>
       …
-      &lt;meta 
+      &lt;meta
           property="dcterms:conformsTo"
           id="conf">
          EPUB Accessibility 1.2 - WCAG 2.2 Level AA
@@ -1317,7 +1317,7 @@
        id="certifier">
       EPUB Accessibility Evaluator
    &lt;/meta>
-   
+
    &lt;meta
        property="dcterms:date"
        refines="#certifier">
@@ -1358,7 +1358,7 @@
        property="a11y:certifiedBy">
       EPUB Accessibility Evaluator
    &lt;/meta>
-   
+
    &lt;meta
        property="a11y:certifierCredential">
       A+ Accessibility Rating
@@ -1377,7 +1377,7 @@
        id="certifier">
       EPUB Accessibility Evaluator
    &lt;/meta>
-   
+
    &lt;meta
        property="a11y:certifierCredential"
        refines="#certifier">
@@ -1433,7 +1433,7 @@
        id="certifier">
       EPUB Accessibility Evaluator
    &lt;/meta>
-   
+
    &lt;link
        rel="a11y:certifierReport"
        refines="#certifier"
@@ -1452,7 +1452,7 @@
        id="conf">
      EPUB Accessibility 1.2 - WCAG 2.2 Level AA
    &lt;/meta>
-   
+
    &lt;meta
        property="a11y:certifiedBy"
        refines="#conf"
@@ -1784,10 +1784,10 @@
 				<pre>&lt;metadata …>
    …
    &lt;meta property="schema:accessibilitySummary">
-       This publication is optimized for braille readers. It will not be 
+       This publication is optimized for braille readers. It will not be
        usable by persons who cannot read braille. The publication is designed
        for braille reading devices capable of displaying 6-character cells and
-       40-character line lengths. The text is not contracted, and follows 
+       40-character line lengths. The text is not contracted, and follows
        Unified English Braille formatting conventions. All characters are
        encoded using the Unicode braille character set.
    &lt;/meta>
@@ -1799,7 +1799,7 @@
 				<pre>&lt;metadata …>
    …
    &lt;meta property="schema:accessibilitySummary">
-       This publication is an audio book. It will not be usable by persons who 
+       This publication is an audio book. It will not be usable by persons who
        cannot hear the audio. The publication is recorded by a professional
        narrator. There is navigation to the beginning of each chapter. The text
        of the publication is not included. Images are not included, but the

--- a/epub34/authoring/vocab/rendering.html
+++ b/epub34/authoring/vocab/rendering.html
@@ -170,7 +170,7 @@
 								<th>Application:</th>
 								<td>
 									<p>MAY be specified only for spine [^itemref^] elements.</p>
-									<p>MUST NOT paired with any other <a href="#spread-placement">prefixed</a> or <a 
+									<p>MUST NOT paired with any other <a href="#spread-placement">prefixed</a> or <a
 											href="#app-itemref-properties-vocab">unprefixed</a> spread placement
 										property.</p>
 								</td>
@@ -204,7 +204,7 @@
 									<p>MAY be specified only for spine [^itemref^] elements.</p>
 									<p>MAY be paired with the <code>page-spread-left</code> from the <a
 											href="#app-itemref-properties-vocab">spine properties vocabulary</a> but
-										MUST NOT paired with any other <a href="#spread-placement">prefixed</a> or <a 
+										MUST NOT paired with any other <a href="#spread-placement">prefixed</a> or <a
 											href="#app-itemref-properties-vocab">unprefixed</a> spread placement
 										property.</p>
 								</td>
@@ -238,7 +238,7 @@
 									<p>MAY be specified only for spine [^itemref^] elements.</p>
 									<p>MAY be paired with the <code>page-spread-right</code> from the <a
 											href="#app-itemref-properties-vocab">spine properties vocabulary</a> but
-										MUST NOT paired with any other <a href="#spread-placement">prefixed</a> or <a 
+										MUST NOT paired with any other <a href="#spread-placement">prefixed</a> or <a
 												href="#app-itemref-properties-vocab">unprefixed</a> spread placement
 										property.</p>
 								</td>
@@ -258,7 +258,7 @@
 				those reading systems.</p>
 
 			<p>The only restrictions are that such properties MUST NOT be defined with a <code>rendition:</code> prefix
-				and MUST NOT conflict behaviorally with properties in the <a href="app-rendering-vocab">package
+				and MUST NOT conflict behaviorally with properties in the <a href="#app-rendering-vocab">package
 					rendering vocabulary</a>.</p>
 
 			<p>If extensions are needed for use by multiple independent reading systems, the preferred method is to


### PR DESCRIPTION
- the recent change of the explainer's data were not settled in the a11y document
- there was a '#'-less link in the epub authoring spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/3051.html" title="Last updated on Jul 21, 2026, 2:22 PM UTC (f73cce6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/3051/2cf7481...f73cce6.html" title="Last updated on Jul 21, 2026, 2:22 PM UTC (f73cce6)">Diff</a>