### PR TITLE
missing plural in "signatures" element definition

### DIFF
--- a/epub34/authoring/index.html
+++ b/epub34/authoring/index.html
@@ -2797,7 +2797,7 @@
 									</dd>
 								</dl>
 
-								<p>The <code>signature</code> element contains child elements of type
+								<p>The <code>signatures</code> element contains child elements of type
 										<code>Signature</code>, as defined by [[xmldsig-core1]]. Signatures can be
 									applied to an EPUB publication as a whole or to its parts. They can also be used to
 									sign any kind of data (i.e., not just XML).</p>


### PR DESCRIPTION
Email communication from David Richards.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/3053.html" title="Last updated on Aug 3, 2026, 3:18 AM UTC (602279a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/3053/7108c37...602279a.html" title="Last updated on Aug 3, 2026, 3:18 AM UTC (602279a)">Diff</a>