### PR TITLE
Remove temporary explainer biblio entries

### DIFF
--- a/epub34/a11y-tech/index.html
+++ b/epub34/a11y-tech/index.html
@@ -68,11 +68,6 @@
 						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
-					"epub-a11y-explain-12": {
-						"title": "EPUB Accessibility 1.2 Explainer",
-						"href": "https://w3c.github.io/epub-specs/epub34/a11y-explain/",
-						"publisher": "W3C"
-					},
 					"iso24751-3": {
 						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
 						"href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",

--- a/epub34/a11y/index.html
+++ b/epub34/a11y/index.html
@@ -80,11 +80,6 @@
 						"date": "05 January 2017",
 						"publisher": "IDPF"
 					},
-					"epub-a11y-explain-12": {
-						"title": "EPUB Accessibility 1.2 Explainer",
-						"href": "https://w3c.github.io/epub-specs/epub34/a11y-explain/",
-						"publisher": "W3C"
-					},
 					"epub-3": {
 						"title": "EPUB 3",
 						"href": "https://www.w3.org/TR/epub/",


### PR DESCRIPTION
Now that a draft note has been published, we don't need the temporary biblio entries in the accessibility and techniques docs.

Specref has stopped updating so respec can't yet generate the new reference. We might want to wait on merging until it is working again. (I blame the verifiable credentials overview editor for [breaking something](https://github.com/tobie/specref/actions/runs/30826361074/job/91728904888#step:4:598), whoever that person might be... 😉)