### PR TITLE
(editorial) fixing url typo - removing double slash after domain name

### DIFF
--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -717,7 +717,7 @@
 				<p>The documents themselves have been restructured. The primary motivation for this restructuring, as
 					well as an extensive editorial revision, was to make the documents more readable. Also, as part of
 					the thorough testing regime developed by the <a
-						href="https://www.w3.org//publishing/groups/epub-wg/">W3C EPUB 3 Working Group</a>, this
+						href="https://www.w3.org/publishing/groups/epub-wg/">W3C EPUB 3 Working Group</a>, this
 					restructuring led to the separation of Recommendations and Working Group Notes (see also <a
 						href="#app-documents">the detailed list of documents</a> ). Features specified in the
 					Recommendations are thoroughly tested, are widely implemented in reading systems, and they can be


### PR DESCRIPTION
see title